### PR TITLE
Fixes needed to start the provisioner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@
 
 FROM centos:7
 MAINTAINER sig-storage, bchilds@redhat.com
-RUN yum update -y
 
 # Provisioner build deps
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE = k8scsi/csi-provision
+IMAGE = k8scsi/csi-provisioner
 
 VERSION :=
 TAG := $(shell git describe --abbrev=0 --tags HEAD 2>/dev/null)

--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -35,10 +35,10 @@ import (
 )
 
 var (
-	provisioner       = flag.String("provisioner", "k8s.io/flex", "Name of the provisioner. The provisioner will only provision volumes for claims that request a StorageClass with a provisioner field set equal to this name.")
+	provisioner       = flag.String("provisioner", "", "Name of the provisioner. The provisioner will only provision volumes for claims that request a StorageClass with a provisioner field set equal to this name.")
 	master            = flag.String("master", "", "Master URL to build a client config from. Either this or kubeconfig needs to be set if the provisioner is being run out of cluster.")
-	kubeconfig        = flag.String("kubeconfig", "/var/run/kubernetes/admin.kubeconfig", "Absolute path to the kubeconfig file. Either this or master needs to be set if the provisioner is being run out of cluster.")
-	csiEndpoint       = flag.String("csi-address", "/tmp/csi.sock", "The gRPC endpoint for Target CSI Volume")
+	kubeconfig        = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Either this or master needs to be set if the provisioner is being run out of cluster.")
+	csiEndpoint       = flag.String("csi-address", "", "The gRPC endpoint for Target CSI Volume")
 	connectionTimeout = flag.Duration("connection-timeout", 10*time.Second, "Timeout for waiting for CSI driver socket.")
 
 	provisionController *controller.ProvisionController

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine
+LABEL maintainers="Kubernetes Authors"
+LABEL description="CSI Provisioner"
+
+COPY csi-provisioner /csi-provisioner
+ENTRYPOINT ["/csi-provisioner"]

--- a/extras/docker/Dockerfile.builder
+++ b/extras/docker/Dockerfile.builder
@@ -1,0 +1,6 @@
+FROM golang:alpine
+LABEL maintainers="Kubernetes Authors"
+LABEL description="CSI Provisioner"
+
+RUN apk add --no-cache git
+RUN go get github.com/kubernetes-csi/external-provisioner/cmd/csi-provisioner

--- a/extras/docker/make.sh
+++ b/extras/docker/make.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+docker build -f Dockerfile.builder -t provisioner:builder .
+docker run --privileged -v $PWD:/host provisioner:builder cp /go/bin/csi-provisioner /host/csi-provisioner
+sudo chown $USER csi-provisioner
+docker build -t docker.io/k8scsi/csi-provisioner .
+rm -f csi-provisioner


### PR DESCRIPTION
* kubeconfig was always being set from the default flags, and so
  it was not noticing to use the incluster flags.
* Name of the image is now csi-provisioner not csi-provision
* Added alpine based Dockerfile building to reduce image from 300MB
  to 40MB

Signed-off-by: Luis Pabón <luis@portworx.com>