### PR TITLE
Updating StatefulSet to support clusters using RBAC

### DIFF
--- a/deploy/kubernetes/statefulset.yaml
+++ b/deploy/kubernetes/statefulset.yaml
@@ -19,9 +19,18 @@ metadata:
   name: external-provisioner-runner
 rules:
   - apiGroups: [""]
-    resources: ["persistentvolumesclaims"]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]
-    
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -86,7 +95,6 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
-
       volumes:
         - name: socket-dir
           emptyDir:


### PR DESCRIPTION
This patch modifies the statefulset example to include proper roles. It is also required to run the components in the kube-system namespace.