### PR TITLE
Fix hostpathplugin path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Run a local kubernetes cluster built from latest master code
 Go to drivers and run:
 
 ```bash
-_output/hostpath --drivername mydriver  --endpoint unix://tmp/csi.sock --nodeid foobar -v=5
+_output/hostpathplugin --drivername mydriver  --endpoint unix://tmp/csi.sock --nodeid foobar -v=5
 ```
 
 ### Start external provisioner


### PR DESCRIPTION
This patch changes "_output/hostpath" to "_output/hostpathplugin"
in the README on how to run hostpath driver.