### PR TITLE
Persistent name and Exponential backoff

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -42,7 +42,7 @@ var (
 	kubeconfig           = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Either this or master needs to be set if the provisioner is being run out of cluster.")
 	csiEndpoint          = flag.String("csi-address", "/run/csi/socket", "The gRPC endpoint for Target CSI Volume")
 	connectionTimeout    = flag.Duration("connection-timeout", 10*time.Second, "Timeout for waiting for CSI driver socket.")
-	volumeNamePrefix     = flag.String("volume-name-prefix", "kubernetes-dynamic-pv", "Prefix to apply to the name of a created volume")
+	volumeNamePrefix     = flag.String("volume-name-prefix", "pvc", "Prefix to apply to the name of a created volume")
 	volumeNameUUIDLength = flag.Int("volume-name-uuid-length", 16, "Length in characters for the generated uuid of a created volume")
 
 	provisionController *controller.ProvisionController


### PR DESCRIPTION
This PR addresses two issues:
1. For a specific PVC, external provisioner always generates the same PV name
2. Implements Exponential Backoff for long operations like CreateVolume

Now there are 2 timers, one short timeout which is enforced by the context, second is exponential backoff timer.
This functionality will require support from the driver. It needs to detect if the request to CreateVolume comes for already initiated volume and then check for completion periodically, once it is completed it should return CreateVolumeResponse struct. 

Fixes https://github.com/kubernetes-csi/external-provisioner/issues/63