### PR TITLE
Add -version argument to show version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@
 IMAGE_NAME = quay.io/k8scsi/csi-provisioner
 IMAGE_VERSION = canary
 
+REV=$(shell git describe --long --match='v*' --dirty)
+
 ifdef V
 TESTARGS = -v -args -alsologtostderr -v 5
 else
@@ -25,7 +27,7 @@ all: csi-provisioner
 
 csi-provisioner:
 	mkdir -p bin
-	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o ./bin/csi-provisioner ./cmd/csi-provisioner
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/csi-provisioner ./cmd/csi-provisioner
 
 clean:
 	rm -rf bin deploy/docker/csi-provisioner

--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"math/rand"
 	"os"
 	"strconv"
@@ -44,8 +45,10 @@ var (
 	connectionTimeout    = flag.Duration("connection-timeout", 10*time.Second, "Timeout for waiting for CSI driver socket.")
 	volumeNamePrefix     = flag.String("volume-name-prefix", "pvc", "Prefix to apply to the name of a created volume")
 	volumeNameUUIDLength = flag.Int("volume-name-uuid-length", 16, "Length in characters for the generated uuid of a created volume")
+	showVersion          = flag.Bool("version", false, "Show version.")
 
 	provisionController *controller.ProvisionController
+	version             = "unknown"
 )
 
 func init() {
@@ -54,6 +57,12 @@ func init() {
 
 	flag.Parse()
 	flag.Set("logtostderr", "true")
+
+	if *showVersion {
+		fmt.Println(os.Args[0], version)
+		os.Exit(0)
+	}
+	glog.Infof("Version: %s", version)
 
 	// get the KUBECONFIG from env if specified (useful for local/debug cluster)
 	kubeconfigEnv := os.Getenv("KUBECONFIG")


### PR DESCRIPTION
+ log the version on startup.

It follows https://github.com/kubernetes-csi/external-attacher/pull/47

Fixes: #80