### PR TITLE
support pushing to custom registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE_NAME = quay.io/k8scsi/csi-provisioner
-IMAGE_VERSION = canary
+REGISTRY_NAME=quay.io/k8scsi
+IMAGE_NAME=csi-provisioner
+IMAGE_VERSION=canary
+IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_VERSION)
 
 REV=$(shell git describe --long --match='v*' --dirty)
 
@@ -33,10 +35,10 @@ clean:
 	rm -rf bin deploy/docker/csi-provisioner
 
 container: csi-provisioner
-	docker build -t $(IMAGE_NAME):$(IMAGE_VERSION) .
+	docker build -t $(IMAGE_TAG) .
 
 push: container
-	docker push $(IMAGE_NAME):$(IMAGE_VERSION)
+	docker push $(IMAGE_TAG)
 
 test:
 	go test `go list ./... | grep -v 'vendor'` $(TESTARGS)


### PR DESCRIPTION
Developers who want to try out locally modified code need to push into
their own registry. By composing the image tag from makefile
variables, that becomes possible with:

  make REGISTRY_NAME=localhost:5000 push

Related-to: kubernetes-csi/docs#23