### PR TITLE
Implement lock of leader election inside external-provisioner

### DIFF
--- a/deploy/kubernetes/statefulset.yaml
+++ b/deploy/kubernetes/statefulset.yaml
@@ -30,6 +30,12 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "update"]
 
 ---
 kind: ClusterRoleBinding
@@ -98,4 +104,3 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir:
-


### PR DESCRIPTION
* Implement lock of leader election inside `external-provisioner`
* Give access control of both `endpoints` and `configmaps`
* Use SharedInformer