### PR TITLE
Lock travis.ci go version to 1.10.3 and add soft tag to revision

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 matrix:
   include:
-  - go: 1.x
+  - go: 1.10.3
 install:
   - go get -u github.com/golang/dep/cmd/dep
   - dep ensure -vendor-only

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ IMAGE_NAME=csi-provisioner
 IMAGE_VERSION=canary
 IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_VERSION)
 
-REV=$(shell git describe --long --match='v*' --dirty)
+REV=$(shell git describe --long --tags --match='v*' --dirty)
 
 ifdef V
 TESTARGS = -v -args -alsologtostderr -v 5


### PR DESCRIPTION
/assign @jsafrane @lpabon 

travis.ci needs to be locked to 1.10.3 because previously it was defaulting to a beta 1.11.x version that had `go fmt` issues