### PR TITLE
Change default volume name behavior to non-truncating

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -44,7 +44,7 @@ var (
 	csiEndpoint          = flag.String("csi-address", "/run/csi/socket", "The gRPC endpoint for Target CSI Volume")
 	connectionTimeout    = flag.Duration("connection-timeout", 10*time.Second, "Timeout for waiting for CSI driver socket.")
 	volumeNamePrefix     = flag.String("volume-name-prefix", "pvc", "Prefix to apply to the name of a created volume")
-	volumeNameUUIDLength = flag.Int("volume-name-uuid-length", 16, "Length in characters for the generated uuid of a created volume")
+	volumeNameUUIDLength = flag.Int("volume-name-uuid-length", -1, "Truncates generated UUID of a created volume to this length. Defaults behavior is to NOT truncate.")
 	showVersion          = flag.Bool("version", false, "Show version.")
 
 	provisionController *controller.ProvisionController

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -274,7 +274,14 @@ func makeVolumeName(prefix, pvcUID string, volumeNameUUIDLength int) (string, er
 	if len(pvcUID) == 0 {
 		return "", fmt.Errorf("corrupted PVC object, it is missing UID")
 	}
-	return fmt.Sprintf("%s-%s", prefix, strings.Replace(string(pvcUID), "-", "", -1)[0:volumeNameUUIDLength]), nil
+	if volumeNameUUIDLength == -1 {
+		// Default behavior is to not truncate or remove dashes
+		return fmt.Sprintf("%s-%s", prefix, pvcUID), nil
+	} else {
+		// Else we remove all dashes from UUID and truncate to volumeNameUUIDLength
+		return fmt.Sprintf("%s-%s", prefix, strings.Replace(string(pvcUID), "-", "", -1)[0:volumeNameUUIDLength]), nil
+	}
+
 }
 
 func (p *csiProvisioner) Provision(options controller.VolumeOptions) (*v1.PersistentVolume, error) {


### PR DESCRIPTION
Fixes: #115

Changes default behavior of volume name to non-truncating. If the flag is set we will remove all dashes and truncate volume name.

/assign @cduchesne @saad-ali 

I believe this should also be cherry-picked to v0.3.0 container as we don't want default behavior of naming to jitter between versions.