### PR TITLE
Invalid behavior on reported volume capacity

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -477,7 +477,7 @@ func (p *csiProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 		volumeAttributes[k] = v
 	}
 	respCap := rep.GetVolume().GetCapacityBytes()
-	if respCap < volSizeBytes {
+	if respCap != 0 && respCap < volSizeBytes {
 		capErr := fmt.Errorf("created volume capacity %v less than requested capacity %v", respCap, volSizeBytes)
 		delReq := &csi.DeleteVolumeRequest{
 			VolumeId: rep.GetVolume().GetId(),


### PR DESCRIPTION
CSI spec states:
  // The capacity of the volume in bytes. This field is OPTIONAL. If not
  // set (value of 0), it indicates that the capacity of the volume is
  // unknown (e.g., NFS share).
  // The value of this field MUST NOT be negative.

A plugin that returns 0 will trigger an error while it is valid according to spec.