### PR TITLE
Remove dep from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ services:
 matrix:
   include:
   - go: 1.10.3
-install:
-  - go get -u github.com/golang/dep/cmd/dep
-  - dep ensure -vendor-only
 script:
 - go fmt $(go list ./... | grep -v vendor) | wc -l | grep 0
 - go vet $(go list ./... | grep -v vendor)


### PR DESCRIPTION
Since the repo has a vendor dir, it no longer needs to pull down the libraries using dep