### PR TITLE
Topology support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ flycheck_*.el
 
 .idea/
 /.project
+*.iml
 
 # ignore build directory
 _output/

--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -29,6 +29,7 @@ import (
 	ctrl "github.com/kubernetes-csi/external-provisioner/pkg/controller"
 	snapclientset "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	csiclientset "k8s.io/csi-api/pkg/client/clientset/versioned"
 
 	"google.golang.org/grpc"
 
@@ -92,6 +93,10 @@ func init() {
 	if err != nil {
 		glog.Fatalf("Failed to create snapshot client: %v", err)
 	}
+	csiAPIClient, err := csiclientset.NewForConfig(config)
+	if err != nil {
+		glog.Fatalf("Failed to create CSI API client: %v", err)
+	}
 
 	// The controller needs to know what the server version is because out-of-tree
 	// provisioners aren't officially supported until 1.5
@@ -118,7 +123,7 @@ func init() {
 	}
 	// Create the provisioner: it implements the Provisioner interface expected by
 	// the controller
-	csiProvisioner := ctrl.NewCSIProvisioner(clientset, *csiEndpoint, *connectionTimeout, identity, *volumeNamePrefix, *volumeNameUUIDLength, grpcClient, snapClient)
+	csiProvisioner := ctrl.NewCSIProvisioner(clientset, csiAPIClient, *csiEndpoint, *connectionTimeout, identity, *volumeNamePrefix, *volumeNameUUIDLength, grpcClient, snapClient)
 	provisionController = controller.NewProvisionController(
 		clientset,
 		*provisioner,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -408,6 +408,14 @@ func (p *csiProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 		req.VolumeContentSource = volumeContentSource
 	}
 
+	if driverState.capabilities.Has(PluginCapability_ACCESSIBILITY_CONSTRAINTS) {
+		requirements, err := GenerateAccessibilityRequirements(options.AllowedTopologies)
+		if err != nil {
+			return nil, fmt.Errorf("error generating accessibility requirements: %v", err)
+		}
+		req.AccessibilityRequirements = requirements
+	}
+
 	glog.V(5).Infof("CreateVolumeRequest %+v", req)
 
 	rep := &csi.CreateVolumeResponse{}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -416,7 +416,9 @@ func (p *csiProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 		requirements, err := GenerateAccessibilityRequirements(
 			p.client,
 			p.csiAPIClient,
-			options.AllowedTopologies)
+			driverState.driverName,
+			options.AllowedTopologies,
+			options.SelectedNode)
 		if err != nil {
 			return nil, fmt.Errorf("error generating accessibility requirements: %v", err)
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -296,7 +296,7 @@ func checkDriverState(grpcClient *grpc.ClientConn, timeout time.Duration, needSn
 		// Check whether plugin supports create snapshot
 		// If not, create volume from snapshot cannot proceed
 		if !capabilities.Has(ControllerCapability_CREATE_DELETE_SNAPSHOT) {
-			return nil, fmt.Errorf("no create/delete snapshot support detected. Cannot create volume from shapshot")
+			return nil, fmt.Errorf("no create/delete snapshot support detected. Cannot create volume from snapshot")
 		}
 	}
 
@@ -496,6 +496,7 @@ func (p *csiProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 	if len(fsType) == 0 {
 		fsType = defaultFSType
 	}
+
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: pvName,
@@ -519,6 +520,10 @@ func (p *csiProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 				},
 			},
 		},
+	}
+
+	if driverState.capabilities.Has(PluginCapability_ACCESSIBILITY_CONSTRAINTS) {
+		pv.Spec.NodeAffinity = GenerateVolumeNodeAffinity(rep.Volume.AccessibleTopology)
 	}
 
 	glog.Infof("successfully created PV %+v", pv.Spec.PersistentVolumeSource)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	fakecsiclientset "k8s.io/csi-api/pkg/client/clientset/versioned/fake"
 )
 
 const (
@@ -425,7 +426,7 @@ func TestCreateDriverReturnsInvalidCapacityDuringProvision(t *testing.T) {
 	defer mockController.Finish()
 	defer driver.Stop()
 
-	csiProvisioner := NewCSIProvisioner(nil, driver.Address(), 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil)
+	csiProvisioner := NewCSIProvisioner(nil, nil, driver.Address(), 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil)
 
 	// Requested PVC with requestedBytes storage
 	opts := controller.VolumeOptions{
@@ -1068,7 +1069,7 @@ func TestProvision(t *testing.T) {
 			clientSet = fakeclientset.NewSimpleClientset()
 		}
 
-		csiProvisioner := NewCSIProvisioner(clientSet, driver.Address(), 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil)
+		csiProvisioner := NewCSIProvisioner(clientSet, nil, driver.Address(), 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil)
 
 		out := &csi.CreateVolumeResponse{
 			Volume: &csi.Volume{
@@ -1445,7 +1446,7 @@ func TestProvisionFromSnapshot(t *testing.T) {
 			return true, content, nil
 		})
 
-		csiProvisioner := NewCSIProvisioner(clientSet, driver.Address(), 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, client)
+		csiProvisioner := NewCSIProvisioner(clientSet, nil, driver.Address(), 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, client)
 
 		out := &csi.CreateVolumeResponse{
 			Volume: &csi.Volume{
@@ -1537,7 +1538,8 @@ func TestProvisionWithTopology(t *testing.T) {
 	defer driver.Stop()
 
 	clientSet := fakeclientset.NewSimpleClientset()
-	csiProvisioner := NewCSIProvisioner(clientSet, driver.Address(), 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil)
+	csiClientSet := fakecsiclientset.NewSimpleClientset()
+	csiProvisioner := NewCSIProvisioner(clientSet, csiClientSet, driver.Address(), 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil)
 
 	out := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{

--- a/pkg/controller/topology.go
+++ b/pkg/controller/topology.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"k8s.io/api/core/v1"
+)
+
+func GenerateVolumeNodeAffinity(accessibleTopology []*csi.Topology) *v1.VolumeNodeAffinity {
+	if len(accessibleTopology) == 0 {
+		return nil
+	}
+
+	var terms []v1.NodeSelectorTerm
+	for _, topology := range accessibleTopology {
+		if len(topology.Segments) == 0 {
+			continue
+		}
+
+		var expressions []v1.NodeSelectorRequirement
+		for k, v := range topology.Segments {
+			expressions = append(expressions, v1.NodeSelectorRequirement{
+				Key:      k,
+				Operator: v1.NodeSelectorOpIn,
+				Values:   []string{v},
+			})
+		}
+		terms = append(terms, v1.NodeSelectorTerm{
+			MatchExpressions: expressions,
+		})
+	}
+
+	return &v1.VolumeNodeAffinity{
+		Required: &v1.NodeSelector{
+			NodeSelectorTerms: terms,
+		},
+	}
+}

--- a/pkg/controller/topology.go
+++ b/pkg/controller/topology.go
@@ -17,9 +17,15 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"github.com/container-storage-interface/spec/lib/go/csi/v0"
 	"k8s.io/api/core/v1"
+	"sort"
+	"strings"
 )
+
+// topologyTerm represents a single term where its topology key value pairs are AND'd together.
+type topologyTerm map[string]string
 
 func GenerateVolumeNodeAffinity(accessibleTopology []*csi.Topology) *v1.VolumeNodeAffinity {
 	if len(accessibleTopology) == 0 {
@@ -50,4 +56,123 @@ func GenerateVolumeNodeAffinity(accessibleTopology []*csi.Topology) *v1.VolumeNo
 			NodeSelectorTerms: terms,
 		},
 	}
+}
+
+func GenerateAccessibilityRequirements(allowedTopologies []v1.TopologySelectorTerm) (*csi.TopologyRequirement, error) {
+	if len(allowedTopologies) == 0 {
+		return nil, fmt.Errorf("topology aggregation not implemented")
+	} else {
+		topologyTerms := flatten(allowedTopologies)
+		topologyTerms = deduplicate(topologyTerms)
+		// TODO (verult) reduce subset duplicate terms (advanced reduction)
+
+		var requisite []*csi.Topology
+		for _, term := range topologyTerms {
+			requisite = append(requisite, &csi.Topology{Segments: term})
+		}
+		return &csi.TopologyRequirement{Requisite: requisite}, nil
+	}
+}
+
+// AllowedTopologies is an OR of TopologySelectorTerms.
+// A TopologySelectorTerm contains an AND of TopologySelectorLabelRequirements.
+// A TopologySelectorLabelRequirement contains a single key and an OR of topology values.
+//
+// The Requisite field contains an OR of Segments.
+// A segment contains an AND of topology key value pairs.
+//
+// In order to convert AllowedTopologies to CSI Requisite, one of its OR layers must be eliminated.
+// This function eliminates the OR of topology values by distributing the OR over the AND a level
+// higher.
+// For example, given a TopologySelectorTerm of this form:
+//    {
+//      "zone": { "zone1", "zone2" },
+//      "rack": { "rackA", "rackB" },
+//    }
+// Abstractly it could be viewed as:
+//    (zone1 OR zone2) AND (rackA OR rackB)
+// Distributing the OR over the AND, we get:
+//    (zone1 AND rackA) OR (zone2 AND rackA) OR (zone1 AND rackB) OR (zone2 AND rackB)
+// which in the intermediate representation returned by this function becomes:
+//    [
+//      { "zone": "zone1", "rack": "rackA" },
+//      { "zone": "zone2", "rack": "rackA" },
+//      { "zone": "zone1", "rack": "rackB" },
+//      { "zone": "zone2", "rack": "rackB" },
+//    ]
+//
+// This flattening is then applied to all TopologySelectorTerms in AllowedTopologies, and
+// the resulting terms are OR'd together.
+func flatten(allowedTopologies []v1.TopologySelectorTerm) []topologyTerm {
+	var finalTerms []topologyTerm
+	for _, selectorTerm := range allowedTopologies { // OR
+
+		var oldTerms []topologyTerm
+		for _, selectorExpression := range selectorTerm.MatchLabelExpressions { // AND
+
+			var newTerms []topologyTerm
+			for _, v := range selectorExpression.Values { // OR
+				// Distribute the OR over AND.
+
+				if len(oldTerms) == 0 {
+					// No previous terms to distribute over. Simply append the new term.
+					newTerms = append(newTerms, topologyTerm{selectorExpression.Key: v})
+				} else {
+					for _, oldTerm := range oldTerms {
+						// "Distribute" by adding an entry to the term
+						newTerm := oldTerm.clone()
+						newTerm[selectorExpression.Key] = v
+						newTerms = append(newTerms, newTerm)
+					}
+				}
+			}
+
+			oldTerms = newTerms
+		}
+
+		// Concatenate all OR'd terms.
+		finalTerms = append(finalTerms, oldTerms...)
+	}
+
+	return finalTerms
+}
+
+func deduplicate(terms []topologyTerm) []topologyTerm {
+	termMap := make(map[string]topologyTerm)
+	for _, term := range terms {
+		termMap[term.hash()] = term
+	}
+
+	var dedupedTerms []topologyTerm
+	for _, term := range termMap {
+		dedupedTerms = append(dedupedTerms, term)
+	}
+	return dedupedTerms
+}
+
+func (t topologyTerm) clone() topologyTerm {
+	ret := make(topologyTerm)
+	for k, v := range t {
+		ret[k] = v
+	}
+	return ret
+}
+
+// "<k1>#<v1>,<k2>#<v2>,..."
+// Hash properties:
+// - Two equivalent topologyTerms have the same hash
+// - Ordering of hashes correspond to a natural ordering of their topologyTerms. For example:
+//   - com.example.csi/zone#zone1 < com.example.csi/zone#zone2
+//   - com.example.csi/rack#zz    < com.example.csi/zone#zone1
+//   - com.example.csi/z#z1       < com.example.csi/zone#zone1
+//   - com.example.csi/rack#rackA,com.example.csi/zone#zone2  <  com.example.csi/rackB,com.example.csi/zone#zone1
+//   Note that both '#' and ',' are less than '/', '-', '_', '.', [A-Z0-9a-z]
+func (t topologyTerm) hash() string {
+	var segments []string
+	for k, v := range t {
+		segments = append(segments, k+"#"+v)
+	}
+
+	sort.Strings(segments)
+	return strings.Join(segments, ",")
 }

--- a/pkg/controller/topology.go
+++ b/pkg/controller/topology.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"github.com/container-storage-interface/spec/lib/go/csi/v0"
 	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	csiclientset "k8s.io/csi-api/pkg/client/clientset/versioned"
 	"sort"
 	"strings"
 )
@@ -58,7 +60,10 @@ func GenerateVolumeNodeAffinity(accessibleTopology []*csi.Topology) *v1.VolumeNo
 	}
 }
 
-func GenerateAccessibilityRequirements(allowedTopologies []v1.TopologySelectorTerm) (*csi.TopologyRequirement, error) {
+func GenerateAccessibilityRequirements(
+	kubeClient kubernetes.Interface,
+	csiAPIClient csiclientset.Interface,
+	allowedTopologies []v1.TopologySelectorTerm) (*csi.TopologyRequirement, error) {
 	if len(allowedTopologies) == 0 {
 		return nil, fmt.Errorf("topology aggregation not implemented")
 	} else {

--- a/pkg/controller/topology_test.go
+++ b/pkg/controller/topology_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/container-storage-interface/spec/lib/go/csi/v0"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"testing"
+)
+
+func TestGenerateVolumeNodeAffinity(t *testing.T) {
+	// TODO (verult) more test cases
+	testcases := map[string]struct {
+		accessibleTopology   []*csi.Topology
+		expectedNodeAffinity *v1.VolumeNodeAffinity
+	}{
+		"nil topology": {
+			accessibleTopology:   nil,
+			expectedNodeAffinity: nil,
+		},
+		"non-nil topology but nil segment": {
+			accessibleTopology:   []*csi.Topology{},
+			expectedNodeAffinity: nil,
+		},
+		"single segment": {
+			accessibleTopology: []*csi.Topology{
+				{
+					Segments: map[string]string{"com.example.csi/zone": "zone1"},
+				},
+			},
+			expectedNodeAffinity: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{
+						{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      "com.example.csi/zone",
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{"zone1"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"multiple segments": {
+			accessibleTopology: []*csi.Topology{
+				{
+					Segments: map[string]string{
+						"com.example.csi/zone": "zone1",
+						"com.example.csi/rack": "rack2",
+					},
+				},
+			},
+			expectedNodeAffinity: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{
+						{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      "com.example.csi/zone",
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{"zone1"},
+								},
+								{
+									Key:      "com.example.csi/rack",
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{"rack2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"multiple topologies": {
+			accessibleTopology: []*csi.Topology{
+				{
+					Segments: map[string]string{
+						"com.example.csi/zone": "zone1",
+					},
+				},
+				{
+					Segments: map[string]string{
+						"com.example.csi/zone": "zone2",
+					},
+				},
+			},
+			expectedNodeAffinity: &v1.VolumeNodeAffinity{
+				Required: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{
+						{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      "com.example.csi/zone",
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{"zone1"},
+								},
+							},
+						},
+						{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      "com.example.csi/zone",
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{"zone2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Logf("test: %s", name)
+		nodeAffinity := GenerateVolumeNodeAffinity(tc.accessibleTopology)
+		if !volumeNodeAffinitiesEqual(nodeAffinity, tc.expectedNodeAffinity) {
+			t.Errorf("test %q: expected node affinity %v; got: %v", name, tc.expectedNodeAffinity, nodeAffinity)
+		}
+	}
+}
+
+func nodeSelectorRequirementsEqual(r1, r2 v1.NodeSelectorRequirement) bool {
+	if r1.Key != r2.Key {
+		return false
+	}
+	if r1.Operator != r2.Operator {
+		return false
+	}
+	vals1 := sets.NewString(r1.Values...)
+	vals2 := sets.NewString(r2.Values...)
+	if vals1.Equal(vals2) {
+		return true
+	}
+	return false
+}
+
+func nodeSelectorTermsEqual(t1, t2 v1.NodeSelectorTerm) bool {
+	exprs1 := t1.MatchExpressions
+	exprs2 := t2.MatchExpressions
+	fields1 := t1.MatchFields
+	fields2 := t2.MatchFields
+	if len(exprs1) != len(exprs2) {
+		return false
+	}
+	if len(fields1) != len(fields2) {
+		return false
+	}
+	match := func(reqs1, reqs2 []v1.NodeSelectorRequirement) bool {
+		for _, req1 := range reqs1 {
+			reqMatched := false
+			for _, req2 := range reqs2 {
+				if nodeSelectorRequirementsEqual(req1, req2) {
+					reqMatched = true
+					break
+				}
+			}
+			if !reqMatched {
+				return false
+			}
+		}
+		return true
+	}
+	return match(exprs1, exprs2) && match(exprs2, exprs1) && match(fields1, fields2) && match(fields2, fields1)
+}
+
+// volumeNodeAffinitiesEqual performs a highly semantic comparison of two VolumeNodeAffinity data structures
+// It ignores ordering of instances of NodeSelectorRequirements in a VolumeNodeAffinity's NodeSelectorTerms as well as
+// orderding of strings in Values of NodeSelectorRequirements when matching two VolumeNodeAffinity structures.
+// Note that in most equality functions, Go considers two slices to be not equal if the order of elements in a slice do not
+// match - so reflect.DeepEqual as well as Semantic.DeepEqual do not work for comparing VolumeNodeAffinity semantically.
+// e.g. these two NodeSelectorTerms are considered semantically equal by volumeNodeAffinitiesEqual
+// &VolumeNodeAffinity{Required:&NodeSelector{NodeSelectorTerms:[{[{a In [1]} {b In [2 3]}] []}],},}
+// &VolumeNodeAffinity{Required:&NodeSelector{NodeSelectorTerms:[{[{b In [3 2]} {a In [1]}] []}],},}
+// TODO: move to external controller lib utils so other can use it too
+func volumeNodeAffinitiesEqual(n1, n2 *v1.VolumeNodeAffinity) bool {
+	if (n1 == nil) != (n2 == nil) {
+		return false
+	}
+	if n1 == nil || n2 == nil {
+		return true
+	}
+	ns1 := n1.Required
+	ns2 := n2.Required
+	if (ns1 == nil) != (ns2 == nil) {
+		return false
+	}
+	if (ns1 == nil) && (ns2 == nil) {
+		return true
+	}
+	if len(ns1.NodeSelectorTerms) != len(ns1.NodeSelectorTerms) {
+		return false
+	}
+	match := func(terms1, terms2 []v1.NodeSelectorTerm) bool {
+		for _, term1 := range terms1 {
+			termMatched := false
+			for _, term2 := range terms2 {
+				if nodeSelectorTermsEqual(term1, term2) {
+					termMatched = true
+					break
+				}
+			}
+			if !termMatched {
+				return false
+			}
+		}
+		return true
+	}
+	return match(ns1.NodeSelectorTerms, ns2.NodeSelectorTerms) && match(ns2.NodeSelectorTerms, ns1.NodeSelectorTerms)
+}

--- a/pkg/controller/topology_test.go
+++ b/pkg/controller/topology_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 )
 
+const testDriverName = "com.example.csi/test-driver"
+
 func TestGenerateVolumeNodeAffinity(t *testing.T) {
 	// TODO (verult) more test cases
 	testcases := map[string]struct {
@@ -530,7 +532,6 @@ func TestTopologyAggregation(t *testing.T) {
 	//       specified in the test case.
 
 	// TODO (verult) more test cases
-	const driverName = "com.example.csi/test-driver"
 	testcases := map[string]struct {
 		nodeLabels        []map[string]string
 		topologyKeys      []map[string][]string
@@ -545,9 +546,9 @@ func TestTopologyAggregation(t *testing.T) {
 				{"com.example.csi/zone": "zone1"},
 			},
 			topologyKeys: []map[string][]string{
-				{driverName: []string{"com.example.csi/zone"}},
-				{driverName: []string{"com.example.csi/zone"}},
-				{driverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
 			},
 			expectedRequisite: []*csi.Topology{
 				{Segments: map[string]string{"com.example.csi/zone": "zone1"}},
@@ -561,9 +562,9 @@ func TestTopologyAggregation(t *testing.T) {
 				{"com.example.csi/zone": "zone1"},
 			},
 			topologyKeys: []map[string][]string{
-				{driverName: []string{"com.example.csi/zone"}},
-				{driverName: []string{"com.example.csi/zone"}},
-				{driverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
 			},
 			expectedRequisite: []*csi.Topology{
 				{Segments: map[string]string{"com.example.csi/zone": "zone1"}},
@@ -576,9 +577,9 @@ func TestTopologyAggregation(t *testing.T) {
 				{"com.example.csi/zone": "zone2"},
 			},
 			topologyKeys: []map[string][]string{
-				{driverName: []string{"com.example.csi/zone"}},
-				{driverName: []string{"com.example.csi/zone"}},
-				{driverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
 			},
 			expectedRequisite: []*csi.Topology{
 				{Segments: map[string]string{"com.example.csi/zone": "zone1"}},
@@ -593,9 +594,9 @@ func TestTopologyAggregation(t *testing.T) {
 				{"com.example.csi/zone": "zone2"},
 			},
 			topologyKeys: []map[string][]string{
-				{driverName: []string{"com.example.csi/zone"}},
-				{driverName: []string{"com.example.csi/zone"}},
-				{driverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
 			},
 			expectedRequisite: []*csi.Topology{
 				{Segments: map[string]string{"com.example.csi/zone": "zone1"}},
@@ -609,9 +610,9 @@ func TestTopologyAggregation(t *testing.T) {
 		//		{ "com.example.csi/zone": "zone1", "com.example.csi/rack": "rackA" },
 		//	},
 		//	topologyKeys: []map[string][]string{
-		//		{ driverName: []string{ "com.example.csi/zone" } },
-		//		{ driverName: []string{ "com.example.csi/zone", "com.example.csi/rack" } },
-		//		{ driverName: []string{ "com.example.csi/zone", "com.example.csi/rack" } },
+		//		{ testDriverName: []string{ "com.example.csi/zone" } },
+		//		{ testDriverName: []string{ "com.example.csi/zone", "com.example.csi/rack" } },
+		//		{ testDriverName: []string{ "com.example.csi/zone", "com.example.csi/rack" } },
 		//	},
 		//	expectedRequisite: &csi.TopologyRequirement{
 		//		Requisite: []*csi.Topology{
@@ -628,9 +629,9 @@ func TestTopologyAggregation(t *testing.T) {
 				{"com.example.csi/zone": "zone1", "com.example.csi/rack": "rackA"},
 			},
 			topologyKeys: []map[string][]string{
-				{driverName: []string{"com.example.csi/zone"}},
-				{driverName: []string{"com.example.csi/zone", "com.example.csi/rack"}},
-				{driverName: []string{"com.example.csi/zone", "com.example.csi/rack"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone", "com.example.csi/rack"}},
+				{testDriverName: []string{"com.example.csi/zone", "com.example.csi/rack"}},
 			},
 			expectedRequisite: []*csi.Topology{
 				{Segments: map[string]string{"com.example.csi/zone": "zone1"}},
@@ -650,9 +651,9 @@ func TestTopologyAggregation(t *testing.T) {
 		"random node: missing keys": {
 			nodeLabels: []map[string]string{{}, {}, {}},
 			topologyKeys: []map[string][]string{
-				{driverName: nil},
-				{driverName: nil},
-				{driverName: nil},
+				{testDriverName: nil},
+				{testDriverName: nil},
+				{testDriverName: nil},
 			},
 			expectedRequisite: nil,
 		},
@@ -660,9 +661,9 @@ func TestTopologyAggregation(t *testing.T) {
 			hasSelectedNode: true,
 			nodeLabels:      []map[string]string{{}, {}, {}},
 			topologyKeys: []map[string][]string{
-				{driverName: nil},
-				{driverName: nil},
-				{driverName: nil},
+				{testDriverName: nil},
+				{testDriverName: nil},
+				{testDriverName: nil},
 			},
 			expectedRequisite: nil,
 		},
@@ -683,7 +684,7 @@ func TestTopologyAggregation(t *testing.T) {
 		requirements, err := GenerateAccessibilityRequirements(
 			kubeClient,
 			csiClient,
-			driverName,
+			testDriverName,
 			nil, /* allowedTopologies */
 			selectedNode,
 		)
@@ -710,6 +711,174 @@ func TestTopologyAggregation(t *testing.T) {
 		}
 		if !requisiteEqual(requirements.Requisite, tc.expectedRequisite) {
 			t.Errorf("expected requisite %v; got: %v", tc.expectedRequisite, requirements.Requisite)
+		}
+	}
+}
+
+func TestPreferredTopologies(t *testing.T) {
+	// TODO (verult) more test cases
+	testcases := map[string]struct {
+		allowedTopologies []v1.TopologySelectorTerm
+		nodeLabels        []map[string]string   // first node is selected node
+		topologyKeys      []map[string][]string // first entry is from the selected node
+		expectedPreferred []*csi.Topology
+		expectError       bool
+	}{
+		"allowedTopologies specified": {
+			allowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{
+							Key:    "com.example.csi/zone",
+							Values: []string{"zone1", "zone2"},
+						},
+						{
+							Key:    "com.example.csi/rack",
+							Values: []string{"rackA", "rackB"},
+						},
+					},
+				},
+			},
+			nodeLabels: []map[string]string{
+				{"com.example.csi/zone": "zone2", "com.example.csi/rack": "rackA"},
+				{"com.example.csi/zone": "zone1", "com.example.csi/rack": "rackA"},
+				{"com.example.csi/zone": "zone1", "com.example.csi/rack": "rackB"},
+			},
+			topologyKeys: []map[string][]string{
+				{testDriverName: []string{"com.example.csi/zone", "com.example.csi/rack"}},
+				{testDriverName: []string{"com.example.csi/zone", "com.example.csi/rack"}},
+				{testDriverName: []string{"com.example.csi/zone", "com.example.csi/rack"}},
+			},
+			expectedPreferred: []*csi.Topology{
+				{
+					Segments: map[string]string{
+						"com.example.csi/rack": "rackA",
+						"com.example.csi/zone": "zone2",
+					},
+				},
+				{
+					Segments: map[string]string{
+						"com.example.csi/rack": "rackB",
+						"com.example.csi/zone": "zone1",
+					},
+				},
+				{
+					Segments: map[string]string{
+						"com.example.csi/rack": "rackB",
+						"com.example.csi/zone": "zone2",
+					},
+				},
+				{
+					Segments: map[string]string{
+						"com.example.csi/rack": "rackA",
+						"com.example.csi/zone": "zone1",
+					},
+				},
+			},
+		},
+		"topology aggregation": {
+			nodeLabels: []map[string]string{
+				{"com.example.csi/zone": "zone2", "com.example.csi/rack": "rackA"},
+				{"com.example.csi/zone": "zone1", "com.example.csi/rack": "rackA"},
+				{"com.example.csi/zone": "zone1", "com.example.csi/rack": "rackB"},
+			},
+			topologyKeys: []map[string][]string{
+				{testDriverName: []string{"com.example.csi/zone", "com.example.csi/rack"}},
+				{testDriverName: []string{"com.example.csi/zone", "com.example.csi/rack"}},
+				{testDriverName: []string{"com.example.csi/zone", "com.example.csi/rack"}},
+			},
+			expectedPreferred: []*csi.Topology{
+				{
+					Segments: map[string]string{
+						"com.example.csi/rack": "rackA",
+						"com.example.csi/zone": "zone2",
+					},
+				},
+				{
+					Segments: map[string]string{
+						"com.example.csi/rack": "rackB",
+						"com.example.csi/zone": "zone1",
+					},
+				},
+				{
+					Segments: map[string]string{
+						"com.example.csi/rack": "rackA",
+						"com.example.csi/zone": "zone1",
+					},
+				},
+			},
+		},
+		"topology aggregation with no topology info": {
+			nodeLabels:        []map[string]string{{}, {}, {}},
+			topologyKeys:      []map[string][]string{{}, {}, {}},
+			expectedPreferred: nil,
+		},
+		// This case is never triggered in reality due to scheduler behavior
+		"topology from selected node is not in allowedTopologies": {
+			allowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{
+							Key:    "com.example.csi/zone",
+							Values: []string{"zone1"},
+						},
+					},
+				},
+			},
+			nodeLabels: []map[string]string{
+				{"com.example.csi/zone": "zone2"},
+				{"com.example.csi/zone": "zone1"},
+				{"com.example.csi/zone": "zone1"},
+			},
+			topologyKeys: []map[string][]string{
+				{testDriverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
+				{testDriverName: []string{"com.example.csi/zone"}},
+			},
+			expectError: true,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Logf("test: %s", name)
+
+		nodes := buildNodes(tc.nodeLabels)
+		nodeInfos := buildNodeInfos(tc.topologyKeys)
+
+		kubeClient := fakeclientset.NewSimpleClientset(nodes)
+		csiClient := fakecsiclientset.NewSimpleClientset(nodeInfos)
+		selectedNode := &nodes.Items[0]
+
+		requirements, err := GenerateAccessibilityRequirements(
+			kubeClient,
+			csiClient,
+			testDriverName,
+			tc.allowedTopologies,
+			selectedNode,
+		)
+
+		if tc.expectError {
+			if err == nil {
+				t.Error("expected error but got none")
+			}
+			continue
+		}
+		if !tc.expectError && err != nil {
+			t.Errorf("expected no error but got: %v", err)
+			continue
+		}
+		if requirements == nil {
+			if tc.expectedPreferred != nil {
+				t.Errorf("expected preferred to be %v but requirements is nil", tc.expectedPreferred)
+			}
+			continue
+		}
+		if requirements != nil && tc.expectedPreferred == nil {
+			t.Errorf("expected requirements to be nil but got preferred: %v", requirements.Preferred)
+			continue
+		}
+		if !helper.Semantic.DeepEqual(requirements.Preferred, tc.expectedPreferred) {
+			t.Errorf("expected requisite %v; got: %v", tc.expectedPreferred, requirements.Preferred)
 		}
 	}
 }

--- a/pkg/controller/topology_test.go
+++ b/pkg/controller/topology_test.go
@@ -505,7 +505,10 @@ func TestGenerateAccessibilityRequirements(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Logf("test: %s", name)
-		requirements, err := GenerateAccessibilityRequirements(tc.allowedTopologies)
+		requirements, err := GenerateAccessibilityRequirements(
+			nil, /* kubeClient */
+			nil, /* csiAPIClient */
+			tc.allowedTopologies)
 
 		if tc.expectError {
 			if err == nil {


### PR DESCRIPTION
Creating a PR for early review.

I have a local working prototype. The hope is each of these PRs introduce a feature whose implementation is as close to the final form as possible.

@jsafrane @msau42 @saad-ali @ddebroy

Features (some of these need more refinement but core logic is there):
- [x] Generating PV Node Affinity
- [x] Generating CSI requisite topology: Parsing AllowedTopologies
- [x] Generating CSI requisite topology: Topology aggregation across the cluster, when AllowedTopologies is missing
- [x] Generating CSI preferred topology
- [ ] Evenly spreading topology preference for PVs in StatefulSets.