### PR TITLE
Make the provisioner name optional

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -40,7 +40,7 @@ import (
 )
 
 var (
-	provisioner          = flag.String("provisioner", "", "Name of the provisioner. The provisioner will only provision volumes for claims that request a StorageClass with a provisioner field set equal to this name.")
+	provisioner          = flag.String("provisioner", "", "Name of the provisioner. The provisioner will only provision volumes for claims that request a StorageClass with a provisioner field set equal to this name. If omitted, CSI driver name is used.")
 	master               = flag.String("master", "", "Master URL to build a client config from. Either this or kubeconfig needs to be set if the provisioner is being run out of cluster.")
 	kubeconfig           = flag.String("kubeconfig", "", "Absolute path to the kubeconfig file. Either this or master needs to be set if the provisioner is being run out of cluster.")
 	csiEndpoint          = flag.String("csi-address", "/run/csi/socket", "The gRPC endpoint for Target CSI Volume")
@@ -121,6 +121,16 @@ func init() {
 		}
 		time.Sleep(10 * time.Second)
 	}
+
+	// Autodetect provisioner name if necessary
+	if *provisioner == "" {
+		*provisioner, err = ctrl.GetDriverName(grpcClient, *connectionTimeout)
+		if err != nil {
+			glog.Fatalf("Error getting CSI driver name: %s", err)
+		}
+		glog.V(2).Infof("Detected CSI driver %q", *provisioner)
+	}
+
 	// Create the provisioner: it implements the Provisioner interface expected by
 	// the controller
 	csiProvisioner := ctrl.NewCSIProvisioner(clientset, csiAPIClient, *csiEndpoint, *connectionTimeout, identity, *volumeNamePrefix, *volumeNameUUIDLength, grpcClient, snapClient)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -158,7 +158,7 @@ func Connect(address string, timeout time.Duration) (*grpc.ClientConn, error) {
 	}
 }
 
-func getDriverName(conn *grpc.ClientConn, timeout time.Duration) (string, error) {
+func GetDriverName(conn *grpc.ClientConn, timeout time.Duration) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -304,7 +304,7 @@ func checkDriverState(grpcClient *grpc.ClientConn, timeout time.Duration, needSn
 		}
 	}
 
-	driverName, err := getDriverName(grpcClient, timeout)
+	driverName, err := GetDriverName(grpcClient, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get driver info: %v", err)
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -122,7 +122,7 @@ func TestGetPluginName(t *testing.T) {
 	out := test.output[0]
 
 	identityServer.EXPECT().GetPluginInfo(gomock.Any(), in).Return(out, nil).Times(1)
-	oldName, err := getDriverName(csiConn.conn, timeout)
+	oldName, err := GetDriverName(csiConn.conn, timeout)
 	if err != nil {
 		t.Errorf("test %q: Failed to get driver's name", test.name)
 	}
@@ -132,7 +132,7 @@ func TestGetPluginName(t *testing.T) {
 
 	out = test.output[1]
 	identityServer.EXPECT().GetPluginInfo(gomock.Any(), in).Return(out, nil).Times(1)
-	newName, err := getDriverName(csiConn.conn, timeout)
+	newName, err := GetDriverName(csiConn.conn, timeout)
 	if err != nil {
 		t.Errorf("test %s: Failed to get driver's name", test.name)
 	}
@@ -360,7 +360,7 @@ func TestGetDriverName(t *testing.T) {
 		// Setup expectation
 		identityServer.EXPECT().GetPluginInfo(gomock.Any(), in).Return(out, injectedErr).Times(1)
 
-		name, err := getDriverName(csiConn.conn, timeout)
+		name, err := GetDriverName(csiConn.conn, timeout)
 		if test.expectError && err == nil {
 			t.Errorf("test %q: Expected error, got none", test.name)
 		}


### PR DESCRIPTION
Driver name is used as provisioner when no provisioner is specified by the
user.

Fixes: #108

@davidz627 