### PR TITLE
Evenly spread volumes of a StatefuleSet across nodes based on topology

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -416,6 +416,7 @@ func (p *csiProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 			p.client,
 			p.csiAPIClient,
 			driverState.driverName,
+			options.PVC.Name,
 			options.AllowedTopologies,
 			options.SelectedNode)
 		if err != nil {


### PR DESCRIPTION
If immediate volume binding mode is set and the PVC follows StatefulSet naming format, then the provisioner will choose, as the first segment in preferred topology, a segment from requisite topology based on the relevant parts of the PVC name that ensures an even spread of topology across the StatefulSet's volumes.

The logic around determining the StatefulSet naming format and obtaining a hash and index is identical to the logic in pkg/volume/util/util.go Kubernetes main tree.

Fixes: https://github.com/kubernetes-csi/external-provisioner/issues/143

cc @msau42 @verult 