### PR TITLE
Share topology keys

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -416,9 +416,10 @@ func (p *csiProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 
 	if driverState.capabilities.Has(PluginCapability_ACCESSIBILITY_CONSTRAINTS) &&
 		utilfeature.DefaultFeatureGate.Enabled(features.Topology) {
+		topologyKeys := lookupTopologyKeys(p.client, p.csiAPIClient, driverState.driverName, options.SelectedNode)
 		requirements, err := GenerateAccessibilityRequirements(
+			topologyKeys,
 			p.client,
-			p.csiAPIClient,
 			driverState.driverName,
 			options.AllowedTopologies,
 			options.SelectedNode)


### PR DESCRIPTION
restructures how topology keys are provided to GenerateAccessibilityRequirements so they only get looked up once when a selected node is provided, and so we can unit test how GenerateAccessibilityRequirements behaves with different sets of topology keys

if we end up with topologyKeys living in the CSIDriver object, this top-level lookup will get even simpler, and we'll have one spot to swap it out