### PR TITLE
rbac: fix kubectl validation error

### DIFF
--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -87,3 +87,4 @@ subjects:
 roleRef:
   kind: Role
   name: external-provisioner-cfg
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
The files worked fine in automated testing, but kubectl complains
about the missing apiGroup.