### PR TITLE
Rename deprecatedSecretParamsMap

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -57,7 +57,8 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
-type deprecatedSecretParamsMap struct {
+// secretParamsMap provides a mapping of current as well as deprecated secret keys
+type secretParamsMap struct {
 	name                         string
 	deprecatedSecretNameKey      string
 	deprecatedSecretNamespaceKey string
@@ -116,7 +117,7 @@ const (
 )
 
 var (
-	provisionerSecretParams = deprecatedSecretParamsMap{
+	provisionerSecretParams = secretParamsMap{
 		name:                         "Provisioner",
 		deprecatedSecretNameKey:      provisionerSecretNameKey,
 		deprecatedSecretNamespaceKey: provisionerSecretNamespaceKey,
@@ -124,7 +125,7 @@ var (
 		secretNamespaceKey:           prefixedProvisionerSecretNamespaceKey,
 	}
 
-	nodePublishSecretParams = deprecatedSecretParamsMap{
+	nodePublishSecretParams = secretParamsMap{
 		name:                         "NodePublish",
 		deprecatedSecretNameKey:      nodePublishSecretNameKey,
 		deprecatedSecretNamespaceKey: nodePublishSecretNamespaceKey,
@@ -132,7 +133,7 @@ var (
 		secretNamespaceKey:           prefixedNodePublishSecretNamespaceKey,
 	}
 
-	controllerPublishSecretParams = deprecatedSecretParamsMap{
+	controllerPublishSecretParams = secretParamsMap{
 		name:                         "ControllerPublish",
 		deprecatedSecretNameKey:      controllerPublishSecretNameKey,
 		deprecatedSecretNamespaceKey: controllerPublishSecretNamespaceKey,
@@ -140,7 +141,7 @@ var (
 		secretNamespaceKey:           prefixedControllerPublishSecretNamespaceKey,
 	}
 
-	nodeStageSecretParams = deprecatedSecretParamsMap{
+	nodeStageSecretParams = secretParamsMap{
 		name:                         "NodeStage",
 		deprecatedSecretNameKey:      nodeStageSecretNameKey,
 		deprecatedSecretNamespaceKey: nodeStageSecretNamespaceKey,
@@ -876,7 +877,7 @@ func (p *csiProvisioner) volumeHandleToId(handle string) string {
 
 // verifyAndGetSecretNameAndNamespaceTemplate gets the values (templates) associated
 // with the parameters specified in "secret" and verifies that they are specified correctly.
-func verifyAndGetSecretNameAndNamespaceTemplate(secret deprecatedSecretParamsMap, storageClassParams map[string]string) (nameTemplate, namespaceTemplate string, err error) {
+func verifyAndGetSecretNameAndNamespaceTemplate(secret secretParamsMap, storageClassParams map[string]string) (nameTemplate, namespaceTemplate string, err error) {
 	numName := 0
 	numNamespace := 0
 
@@ -938,7 +939,7 @@ func verifyAndGetSecretNameAndNamespaceTemplate(secret deprecatedSecretParamsMap
 // - the nameTemplate or namespaceTemplate contains a token that cannot be resolved
 // - the resolved name is not a valid secret name
 // - the resolved namespace is not a valid namespace name
-func getSecretReference(secretParams deprecatedSecretParamsMap, storageClassParams map[string]string, pvName string, pvc *v1.PersistentVolumeClaim) (*v1.SecretReference, error) {
+func getSecretReference(secretParams secretParamsMap, storageClassParams map[string]string, pvName string, pvc *v1.PersistentVolumeClaim) (*v1.SecretReference, error) {
 	nameTemplate, namespaceTemplate, err := verifyAndGetSecretNameAndNamespaceTemplate(secretParams, storageClassParams)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get name and namespace template from params: %v", err)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -720,7 +720,7 @@ func createFakePVCWithVolumeMode(requestBytes int64, volumeMode v1.PersistentVol
 
 func TestGetSecretReference(t *testing.T) {
 	testcases := map[string]struct {
-		secretParams deprecatedSecretParamsMap
+		secretParams secretParamsMap
 		params       map[string]string
 		pvName       string
 		pvc          *v1.PersistentVolumeClaim


### PR DESCRIPTION
The struct name deprecatedSecretParamsMap is misleading, it includes the
"deprecated" prefix hinting that the struct it deprecated, however it's
not.  It also isn't made up of strictly deprecated secret keys (which
are in fact labeled with the "deprecated" prefix).

Given this a private struct, it's simple to just rename it, this change
renames it to simply "secretParamsMap" and adds a comment to the struct
to give at least a hint as to the intent.

resolves #224
