### PR TITLE
Remove the unused varible

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -153,7 +153,7 @@ func init() {
 
 	// Create the provisioner: it implements the Provisioner interface expected by
 	// the controller
-	csiProvisioner := ctrl.NewCSIProvisioner(clientset, csiAPIClient, *csiEndpoint, *operationTimeout, identity, *volumeNamePrefix, *volumeNameUUIDLength, grpcClient, snapClient, provisionerName)
+	csiProvisioner := ctrl.NewCSIProvisioner(clientset, csiAPIClient, *operationTimeout, identity, *volumeNamePrefix, *volumeNameUUIDLength, grpcClient, snapClient, provisionerName)
 	provisionController = controller.NewProvisionController(
 		clientset,
 		provisionerName,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -312,7 +312,6 @@ func getControllerCapabilities(conn *grpc.ClientConn, timeout time.Duration) ([]
 // NewCSIProvisioner creates new CSI provisioner
 func NewCSIProvisioner(client kubernetes.Interface,
 	csiAPIClient csiclientset.Interface,
-	csiEndpoint string,
 	connectionTimeout time.Duration,
 	identity string,
 	volumeNamePrefix string,

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -534,7 +534,7 @@ func TestCreateDriverReturnsInvalidCapacityDuringProvision(t *testing.T) {
 	defer mockController.Finish()
 	defer driver.Stop()
 
-	csiProvisioner := NewCSIProvisioner(nil, nil, driver.Address(), 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName)
+	csiProvisioner := NewCSIProvisioner(nil, nil, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName)
 
 	// Requested PVC with requestedBytes storage
 	opts := controller.VolumeOptions{
@@ -1379,7 +1379,7 @@ func runProvisionTest(t *testing.T, k string, tc provisioningTestcase, requested
 		clientSet = fakeclientset.NewSimpleClientset()
 	}
 
-	csiProvisioner := NewCSIProvisioner(clientSet, nil, driver.Address(), 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName)
+	csiProvisioner := NewCSIProvisioner(clientSet, nil, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName)
 
 	out := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
@@ -1734,7 +1734,7 @@ func TestProvisionFromSnapshot(t *testing.T) {
 			return true, content, nil
 		})
 
-		csiProvisioner := NewCSIProvisioner(clientSet, nil, driver.Address(), 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, client, driverName)
+		csiProvisioner := NewCSIProvisioner(clientSet, nil, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, client, driverName)
 
 		out := &csi.CreateVolumeResponse{
 			Volume: &csi.Volume{
@@ -1829,7 +1829,7 @@ func TestProvisionWithTopology(t *testing.T) {
 
 	clientSet := fakeclientset.NewSimpleClientset()
 	csiClientSet := fakecsiclientset.NewSimpleClientset()
-	csiProvisioner := NewCSIProvisioner(clientSet, csiClientSet, driver.Address(), 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName)
+	csiProvisioner := NewCSIProvisioner(clientSet, csiClientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName)
 
 	out := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
@@ -1867,7 +1867,7 @@ func TestProvisionWithMountOptions(t *testing.T) {
 
 	clientSet := fakeclientset.NewSimpleClientset()
 	csiClientSet := fakecsiclientset.NewSimpleClientset()
-	csiProvisioner := NewCSIProvisioner(clientSet, csiClientSet, driver.Address(), 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName)
+	csiProvisioner := NewCSIProvisioner(clientSet, csiClientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName)
 
 	out := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{


### PR DESCRIPTION
I found the variable `csiEndpoint` in function NewCSIProvisioner has never been used. So, I think it is better to remove it.