### PR TITLE
Fix rbac

### DIFF
--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -28,7 +28,7 @@ rules:
   #   verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "create", "delete"]
+    verbs: ["get", "list", "watch", "update", "create", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]


### PR DESCRIPTION
This PR is for fixing #231.
The issue also existed in other versions because pkg/controller calls  the function "deleteVolumeOperation" in "github.com/kubernetes-sigs/sig-storage-lib-external-provisioner" or "github.com/kubernetes-incubator/external-storage/lib/controller" where may update PersistentVolumes.