### PR TITLE
Fix GetDriverName timeout

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -143,7 +143,7 @@ func init() {
 	}
 
 	// Autodetect provisioner name
-	provisionerName, err := ctrl.GetDriverName(grpcClient, *connectionTimeout)
+	provisionerName, err := ctrl.GetDriverName(grpcClient, *operationTimeout)
 	if err != nil {
 		klog.Fatalf("Error getting CSI driver name: %s", err)
 	}


### PR DESCRIPTION
It should be CSI call timeout, not deprecated connection timeout.

cc @pohly 