### PR TITLE
filter resizer related params from storageclass before passing them to the driver

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -76,6 +76,9 @@ const (
 	prefixedNodePublishSecretNameKey      = csiParameterPrefix + "node-publish-secret-name"
 	prefixedNodePublishSecretNamespaceKey = csiParameterPrefix + "node-publish-secret-namespace"
 
+	prefixedResizerSecretNameKey      = csiParameterPrefix + "resizer-secret-name"
+	prefixedResizerSecretNamespaceKey = csiParameterPrefix + "resizer-secret-namespace"
+
 	// [Deprecated] CSI Parameters that are put into fields but
 	// NOT stripped from the parameters passed to CreateVolume
 	provisionerSecretNameKey      = "csiProvisionerSecretName"
@@ -571,6 +574,8 @@ func removePrefixedParameters(param map[string]string) (map[string]string, error
 			case prefixedNodeStageSecretNamespaceKey:
 			case prefixedNodePublishSecretNameKey:
 			case prefixedNodePublishSecretNamespaceKey:
+			case prefixedResizerSecretNameKey:
+			case prefixedResizerSecretNamespaceKey:
 			default:
 				return map[string]string{}, fmt.Errorf("found unknown parameter key \"%s\" with reserved namespace %s", k, csiParameterPrefix)
 			}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -203,6 +203,8 @@ func TestStripPrefixedCSIParams(t *testing.T) {
 				prefixedNodeStageSecretNamespaceKey:         "csiBar",
 				prefixedNodePublishSecretNameKey:            "csiBar",
 				prefixedNodePublishSecretNamespaceKey:       "csiBar",
+				prefixedResizerSecretNameKey:                "csiBar",
+				prefixedResizerSecretNamespaceKey:           "csiBar",
 			},
 			expectedParams: map[string]string{},
 		},


### PR DESCRIPTION
The external resizer introduces two StorageClass parameters used by resizing secret: https://github.com/kubernetes-csi/external-resizer/blob/25e836c8513f0d31df3604981f1312f0db376e45/pkg/resizer/csi_resizer.go#L45

The external provisioner should remove these parameters before passing to the driver.
