### PR TITLE
Add dynamic provisioning support for CSI migration scenarios

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -678,6 +678,13 @@
     "util/workqueue"
   ]
   revision = "94c2b28f7daad3bd8a35083cc4f8cbe93f027cb3"
+  version = "kubernetes-1.14.0-beta.2"
+
+[[projects]]
+  branch = "master"
+  name = "k8s.io/cloud-provider"
+  packages = ["volume"]
+  revision = "c76aa0a348b5ae804635f81a4732e1b3b095003d"
 
 [[projects]]
   name = "k8s.io/csi-api"
@@ -691,6 +698,15 @@
   ]
   revision = "504ff913b8b7b6ee9cca269105b6c4a4c7923655"
   version = "kubernetes-1.13.0-beta.1"
+
+[[projects]]
+  branch = "master"
+  name = "k8s.io/csi-translation-lib"
+  packages = [
+    ".",
+    "plugins"
+  ]
+  revision = "7f5cabc6aac80cb6cdcf30c37d23947401f26a21"
 
 [[projects]]
   name = "k8s.io/klog"
@@ -742,6 +758,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ce2c07d02b259096f8edfa9a796c02607c08aa82466d2a511fff40850a9c0f75"
+  inputs-digest = "920dcfb3d924745b88b8a29762d4b955b72e584576d0ae1fc532c538a4b057a3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	csiclientset "k8s.io/csi-api/pkg/client/clientset/versioned"
+	csitranslationlib "k8s.io/csi-translation-lib"
 	"k8s.io/klog"
 
 	"google.golang.org/grpc"
@@ -143,19 +144,20 @@ var (
 
 // CSIProvisioner struct
 type csiProvisioner struct {
-	client                 kubernetes.Interface
-	csiClient              csi.ControllerClient
-	csiAPIClient           csiclientset.Interface
-	grpcClient             *grpc.ClientConn
-	snapshotClient         snapclientset.Interface
-	timeout                time.Duration
-	identity               string
-	volumeNamePrefix       string
-	volumeNameUUIDLength   int
-	config                 *rest.Config
-	driverName             string
-	pluginCapabilities     connection.PluginCapabilitySet
-	controllerCapabilities connection.ControllerCapabilitySet
+	client                                kubernetes.Interface
+	csiClient                             csi.ControllerClient
+	csiAPIClient                          csiclientset.Interface
+	grpcClient                            *grpc.ClientConn
+	snapshotClient                        snapclientset.Interface
+	timeout                               time.Duration
+	identity                              string
+	volumeNamePrefix                      string
+	volumeNameUUIDLength                  int
+	config                                *rest.Config
+	driverName                            string
+	pluginCapabilities                    connection.PluginCapabilitySet
+	controllerCapabilities                connection.ControllerCapabilitySet
+	supportsMigrationFromInTreePluginName string
 }
 
 var _ controller.Provisioner = &csiProvisioner{}
@@ -211,22 +213,24 @@ func NewCSIProvisioner(client kubernetes.Interface,
 	snapshotClient snapclientset.Interface,
 	driverName string,
 	pluginCapabilities connection.PluginCapabilitySet,
-	controllerCapabilities connection.ControllerCapabilitySet) controller.Provisioner {
+	controllerCapabilities connection.ControllerCapabilitySet,
+	supportsMigrationFromInTreePluginName string) controller.Provisioner {
 
 	csiClient := csi.NewControllerClient(grpcClient)
 	provisioner := &csiProvisioner{
-		client:                 client,
-		grpcClient:             grpcClient,
-		csiClient:              csiClient,
-		csiAPIClient:           csiAPIClient,
-		snapshotClient:         snapshotClient,
-		timeout:                connectionTimeout,
-		identity:               identity,
-		volumeNamePrefix:       volumeNamePrefix,
-		volumeNameUUIDLength:   volumeNameUUIDLength,
-		driverName:             driverName,
-		pluginCapabilities:     pluginCapabilities,
-		controllerCapabilities: controllerCapabilities,
+		client:                                client,
+		grpcClient:                            grpcClient,
+		csiClient:                             csiClient,
+		csiAPIClient:                          csiAPIClient,
+		snapshotClient:                        snapshotClient,
+		timeout:                               connectionTimeout,
+		identity:                              identity,
+		volumeNamePrefix:                      volumeNamePrefix,
+		volumeNameUUIDLength:                  volumeNameUUIDLength,
+		driverName:                            driverName,
+		pluginCapabilities:                    pluginCapabilities,
+		controllerCapabilities:                controllerCapabilities,
+		supportsMigrationFromInTreePluginName: supportsMigrationFromInTreePluginName,
 	}
 	return provisioner
 }
@@ -325,6 +329,31 @@ func getVolumeCapability(
 }
 
 func (p *csiProvisioner) Provision(options controller.VolumeOptions) (*v1.PersistentVolume, error) {
+	createVolumeRequestParameters := options.Parameters
+	migratedVolume := false
+	if p.supportsMigrationFromInTreePluginName != "" {
+		storageClassName := options.PVC.Spec.StorageClassName
+		// TODO(https://github.com/kubernetes-csi/external-provisioner/issues/256): use informers
+		// NOTE: we cannot depend on PVC.Annotations[volume.beta.kubernetes.io/storage-provisioner] to get
+		// the in-tree provisioner name in case of CSI migration scenarios. The annotation will be
+		// set to the CSI provisioner name by PV controller for migration scenarios
+		// so that external provisioner can correctly pick up the PVC pointing to an in-tree plugin
+		storageClass, err := p.client.StorageV1().StorageClasses().Get(*storageClassName, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get storage class named %s: %v", *storageClassName, err)
+		}
+		if storageClass.Provisioner == p.supportsMigrationFromInTreePluginName {
+			klog.V(2).Infof("translating storage class parameters for in-tree plugin %s to CSI", storageClass.Provisioner)
+			createVolumeRequestParameters, err = csitranslationlib.TranslateInTreeStorageClassParametersToCSI(p.supportsMigrationFromInTreePluginName, options.Parameters)
+			if err != nil {
+				return nil, fmt.Errorf("failed to translate storage class parameters: %v", err)
+			}
+			migratedVolume = true
+		} else {
+			klog.V(4).Infof("skip translation of storage class parameters for plugin: %s", storageClass.Provisioner)
+		}
+	}
+
 	var needSnapshotSupport bool
 	if options.PVC.Spec.DataSource != nil {
 		// PVC.Spec.DataSource.Name is the name of the VolumeSnapshot API object
@@ -355,7 +384,7 @@ func (p *csiProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 
 	fsTypesFound := 0
 	fsType := ""
-	for k, v := range options.Parameters {
+	for k, v := range createVolumeRequestParameters {
 		if strings.ToLower(k) == "fstype" || k == prefixedFsTypeKey {
 			fsType = v
 			fsTypesFound++
@@ -383,7 +412,7 @@ func (p *csiProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 	// Create a CSI CreateVolumeRequest and Response
 	req := csi.CreateVolumeRequest{
 		Name:               pvName,
-		Parameters:         options.Parameters,
+		Parameters:         createVolumeRequestParameters,
 		VolumeCapabilities: volumeCaps,
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: int64(volSizeBytes),
@@ -418,7 +447,7 @@ func (p *csiProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 
 	// Resolve provision secret credentials.
 	// No PVC is provided when resolving provision/delete secret names, since the PVC may or may not exist at delete time.
-	provisionerSecretRef, err := getSecretReference(provisionerSecretParams, options.Parameters, pvName, nil)
+	provisionerSecretRef, err := getSecretReference(provisionerSecretParams, createVolumeRequestParameters, pvName, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -429,20 +458,20 @@ func (p *csiProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 	req.Secrets = provisionerCredentials
 
 	// Resolve controller publish, node stage, node publish secret references
-	controllerPublishSecretRef, err := getSecretReference(controllerPublishSecretParams, options.Parameters, pvName, options.PVC)
+	controllerPublishSecretRef, err := getSecretReference(controllerPublishSecretParams, createVolumeRequestParameters, pvName, options.PVC)
 	if err != nil {
 		return nil, err
 	}
-	nodeStageSecretRef, err := getSecretReference(nodeStageSecretParams, options.Parameters, pvName, options.PVC)
+	nodeStageSecretRef, err := getSecretReference(nodeStageSecretParams, createVolumeRequestParameters, pvName, options.PVC)
 	if err != nil {
 		return nil, err
 	}
-	nodePublishSecretRef, err := getSecretReference(nodePublishSecretParams, options.Parameters, pvName, options.PVC)
+	nodePublishSecretRef, err := getSecretReference(nodePublishSecretParams, createVolumeRequestParameters, pvName, options.PVC)
 	if err != nil {
 		return nil, err
 	}
 
-	req.Parameters, err = removePrefixedParameters(options.Parameters)
+	req.Parameters, err = removePrefixedParameters(createVolumeRequestParameters)
 	if err != nil {
 		return nil, fmt.Errorf("failed to strip CSI Parameters of prefixed keys: %v", err)
 	}
@@ -514,6 +543,15 @@ func (p *csiProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 	// Set FSType if PV is not Block Volume
 	if !util.CheckPersistentVolumeClaimModeBlock(options.PVC) {
 		pv.Spec.PersistentVolumeSource.CSI.FSType = fsType
+	}
+
+	if migratedVolume {
+		pv, err = csitranslationlib.TranslateCSIPVToInTree(pv)
+		if err != nil {
+			klog.Warningf("failed to translate CSI PV to in-tree due to: %v. Deleting provisioned PV", err)
+			p.Delete(pv)
+			return nil, err
+		}
 	}
 
 	klog.Infof("successfully created PV %+v", pv.Spec.PersistentVolumeSource)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -391,7 +391,7 @@ func TestCreateDriverReturnsInvalidCapacityDuringProvision(t *testing.T) {
 	defer driver.Stop()
 
 	pluginCaps, controllerCaps := provisionCapabilities()
-	csiProvisioner := NewCSIProvisioner(nil, nil, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps)
+	csiProvisioner := NewCSIProvisioner(nil, nil, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "")
 
 	// Requested PVC with requestedBytes storage
 	opts := controller.VolumeOptions{
@@ -1164,7 +1164,7 @@ func runProvisionTest(t *testing.T, k string, tc provisioningTestcase, requested
 	}
 
 	pluginCaps, controllerCaps := provisionCapabilities()
-	csiProvisioner := NewCSIProvisioner(clientSet, nil, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps)
+	csiProvisioner := NewCSIProvisioner(clientSet, nil, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "")
 
 	out := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
@@ -1514,7 +1514,7 @@ func TestProvisionFromSnapshot(t *testing.T) {
 		})
 
 		pluginCaps, controllerCaps := provisionFromSnapshotCapabilities()
-		csiProvisioner := NewCSIProvisioner(clientSet, nil, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, client, driverName, pluginCaps, controllerCaps)
+		csiProvisioner := NewCSIProvisioner(clientSet, nil, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, client, driverName, pluginCaps, controllerCaps, "")
 
 		out := &csi.CreateVolumeResponse{
 			Volume: &csi.Volume{
@@ -1607,7 +1607,7 @@ func TestProvisionWithTopology(t *testing.T) {
 	clientSet := fakeclientset.NewSimpleClientset()
 	csiClientSet := fakecsiclientset.NewSimpleClientset()
 	pluginCaps, controllerCaps := provisionWithTopologyCapabilities()
-	csiProvisioner := NewCSIProvisioner(clientSet, csiClientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps)
+	csiProvisioner := NewCSIProvisioner(clientSet, csiClientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "")
 
 	out := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
@@ -1648,7 +1648,7 @@ func TestProvisionWithMountOptions(t *testing.T) {
 	clientSet := fakeclientset.NewSimpleClientset()
 	csiClientSet := fakecsiclientset.NewSimpleClientset()
 	pluginCaps, controllerCaps := provisionCapabilities()
-	csiProvisioner := NewCSIProvisioner(clientSet, csiClientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps)
+	csiProvisioner := NewCSIProvisioner(clientSet, csiClientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "")
 
 	out := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{

--- a/vendor/k8s.io/cloud-provider/LICENSE
+++ b/vendor/k8s.io/cloud-provider/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/k8s.io/cloud-provider/volume/constants.go
+++ b/vendor/k8s.io/cloud-provider/volume/constants.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+const (
+	// ProvisionedVolumeName is the name of a volume in an external cloud
+	// that is being provisioned and thus should be ignored by rest of Kubernetes.
+	ProvisionedVolumeName = "placeholder-for-provisioning"
+
+	// LabelMultiZoneDelimiter separates zones for volumes
+	LabelMultiZoneDelimiter = "__"
+)

--- a/vendor/k8s.io/csi-translation-lib/LICENSE
+++ b/vendor/k8s.io/csi-translation-lib/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/k8s.io/csi-translation-lib/plugins/aws_ebs.go
+++ b/vendor/k8s.io/csi-translation-lib/plugins/aws_ebs.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"k8s.io/api/core/v1"
+)
+
+const (
+	// AWSEBSDriverName is the name of the CSI driver for EBS
+	AWSEBSDriverName = "ebs.csi.aws.com"
+	// AWSEBSInTreePluginName is the name of the intree plugin for EBS
+	AWSEBSInTreePluginName = "kubernetes.io/aws-ebs"
+)
+
+var _ InTreePlugin = &awsElasticBlockStoreCSITranslator{}
+
+// awsElasticBlockStoreTranslator handles translation of PV spec from In-tree EBS to CSI EBS and vice versa
+type awsElasticBlockStoreCSITranslator struct{}
+
+// NewAWSElasticBlockStoreCSITranslator returns a new instance of awsElasticBlockStoreTranslator
+func NewAWSElasticBlockStoreCSITranslator() InTreePlugin {
+	return &awsElasticBlockStoreCSITranslator{}
+}
+
+// TranslateInTreeStorageClassParametersToCSI translates InTree EBS storage class parameters to CSI storage class
+func (t *awsElasticBlockStoreCSITranslator) TranslateInTreeStorageClassParametersToCSI(scParameters map[string]string) (map[string]string, error) {
+	return scParameters, nil
+}
+
+// TranslateInTreePVToCSI takes a PV with AWSElasticBlockStore set from in-tree
+// and converts the AWSElasticBlockStore source to a CSIPersistentVolumeSource
+func (t *awsElasticBlockStoreCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	if pv == nil || pv.Spec.AWSElasticBlockStore == nil {
+		return nil, fmt.Errorf("pv is nil or AWS EBS not defined on pv")
+	}
+
+	ebsSource := pv.Spec.AWSElasticBlockStore
+
+	volumeHandle, err := KubernetesVolumeIDToEBSVolumeID(ebsSource.VolumeID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to translate Kubernetes ID to EBS Volume ID %v", err)
+	}
+
+	csiSource := &v1.CSIPersistentVolumeSource{
+		Driver:       AWSEBSDriverName,
+		VolumeHandle: volumeHandle,
+		ReadOnly:     ebsSource.ReadOnly,
+		FSType:       ebsSource.FSType,
+		VolumeAttributes: map[string]string{
+			"partition": strconv.FormatInt(int64(ebsSource.Partition), 10),
+		},
+	}
+
+	pv.Spec.AWSElasticBlockStore = nil
+	pv.Spec.CSI = csiSource
+	return pv, nil
+}
+
+// TranslateCSIPVToInTree takes a PV with CSIPersistentVolumeSource set and
+// translates the EBS CSI source to a AWSElasticBlockStore source.
+func (t *awsElasticBlockStoreCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	if pv == nil || pv.Spec.CSI == nil {
+		return nil, fmt.Errorf("pv is nil or CSI source not defined on pv")
+	}
+
+	csiSource := pv.Spec.CSI
+
+	ebsSource := &v1.AWSElasticBlockStoreVolumeSource{
+		VolumeID: csiSource.VolumeHandle,
+		FSType:   csiSource.FSType,
+		ReadOnly: csiSource.ReadOnly,
+	}
+
+	if partition, ok := csiSource.VolumeAttributes["partition"]; ok {
+		partValue, err := strconv.Atoi(partition)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to convert partition %v to integer: %v", partition, err)
+		}
+		ebsSource.Partition = int32(partValue)
+	}
+
+	pv.Spec.CSI = nil
+	pv.Spec.AWSElasticBlockStore = ebsSource
+	return pv, nil
+}
+
+// CanSupport tests whether the plugin supports a given volume
+// specification from the API.  The spec pointer should be considered
+// const.
+func (t *awsElasticBlockStoreCSITranslator) CanSupport(pv *v1.PersistentVolume) bool {
+	return pv != nil && pv.Spec.AWSElasticBlockStore != nil
+}
+
+// GetInTreePluginName returns the name of the intree plugin driver
+func (t *awsElasticBlockStoreCSITranslator) GetInTreePluginName() string {
+	return AWSEBSInTreePluginName
+}
+
+// GetCSIPluginName returns the name of the CSI plugin
+func (t *awsElasticBlockStoreCSITranslator) GetCSIPluginName() string {
+	return AWSEBSDriverName
+}
+
+// awsVolumeRegMatch represents Regex Match for AWS volume.
+var awsVolumeRegMatch = regexp.MustCompile("^vol-[^/]*$")
+
+// KubernetesVolumeIDToEBSVolumeID translates Kubernetes volume ID to EBS volume ID
+// KubernetsVolumeID forms:
+//  * aws://<zone>/<awsVolumeId>
+//  * aws:///<awsVolumeId>
+//  * <awsVolumeId>
+// EBS Volume ID form:
+//  * vol-<alphanumberic>
+// This translation shouldn't be needed and should be fixed in long run
+// See https://github.com/kubernetes/kubernetes/issues/73730
+func KubernetesVolumeIDToEBSVolumeID(kubernetesID string) (string, error) {
+	// name looks like aws://availability-zone/awsVolumeId
+
+	// The original idea of the URL-style name was to put the AZ into the
+	// host, so we could find the AZ immediately from the name without
+	// querying the API.  But it turns out we don't actually need it for
+	// multi-AZ clusters, as we put the AZ into the labels on the PV instead.
+	// However, if in future we want to support multi-AZ cluster
+	// volume-awareness without using PersistentVolumes, we likely will
+	// want the AZ in the host.
+	if !strings.HasPrefix(kubernetesID, "aws://") {
+		// Assume a bare aws volume id (vol-1234...)
+		return kubernetesID, nil
+	}
+	url, err := url.Parse(kubernetesID)
+	if err != nil {
+		// TODO: Maybe we should pass a URL into the Volume functions
+		return "", fmt.Errorf("Invalid disk name (%s): %v", kubernetesID, err)
+	}
+	if url.Scheme != "aws" {
+		return "", fmt.Errorf("Invalid scheme for AWS volume (%s)", kubernetesID)
+	}
+
+	awsID := url.Path
+	awsID = strings.Trim(awsID, "/")
+
+	// We sanity check the resulting volume; the two known formats are
+	// vol-12345678 and vol-12345678abcdef01
+	if !awsVolumeRegMatch.MatchString(awsID) {
+		return "", fmt.Errorf("Invalid format for AWS volume (%s)", kubernetesID)
+	}
+
+	return awsID, nil
+}

--- a/vendor/k8s.io/csi-translation-lib/plugins/gce_pd.go
+++ b/vendor/k8s.io/csi-translation-lib/plugins/gce_pd.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	cloudvolume "k8s.io/cloud-provider/volume"
+)
+
+const (
+	// GCEPDDriverName is the name of the CSI driver for GCE PD
+	GCEPDDriverName = "pd.csi.storage.gke.io"
+	// GCEPDInTreePluginName is the name of the intree plugin for GCE PD
+	GCEPDInTreePluginName = "kubernetes.io/gce-pd"
+
+	// Volume ID Expected Format
+	// "projects/{projectName}/zones/{zoneName}/disks/{diskName}"
+	volIDZonalFmt = "projects/%s/zones/%s/disks/%s"
+	// "projects/{projectName}/regions/{regionName}/disks/{diskName}"
+	volIDRegionalFmt   = "projects/%s/regions/%s/disks/%s"
+	volIDDiskNameValue = 5
+	volIDTotalElements = 6
+
+	// UnspecifiedValue is used for an unknown zone string
+	UnspecifiedValue = "UNSPECIFIED"
+)
+
+var _ InTreePlugin = &gcePersistentDiskCSITranslator{}
+
+// gcePersistentDiskCSITranslator handles translation of PV spec from In-tree
+// GCE PD to CSI GCE PD and vice versa
+type gcePersistentDiskCSITranslator struct{}
+
+// NewGCEPersistentDiskCSITranslator returns a new instance of gcePersistentDiskTranslator
+func NewGCEPersistentDiskCSITranslator() InTreePlugin {
+	return &gcePersistentDiskCSITranslator{}
+}
+
+// TranslateInTreeStorageClassParametersToCSI translates InTree GCE storage class parameters to CSI storage class
+func (g *gcePersistentDiskCSITranslator) TranslateInTreeStorageClassParametersToCSI(scParameters map[string]string) (map[string]string, error) {
+	return scParameters, nil
+}
+
+// TranslateInTreePVToCSI takes a PV with GCEPersistentDisk set from in-tree
+// and converts the GCEPersistentDisk source to a CSIPersistentVolumeSource
+func (g *gcePersistentDiskCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	var volID string
+
+	if pv == nil || pv.Spec.GCEPersistentDisk == nil {
+		return nil, fmt.Errorf("pv is nil or GCE Persistent Disk source not defined on pv")
+	}
+
+	zonesLabel := pv.Labels[v1.LabelZoneFailureDomain]
+	zones := strings.Split(zonesLabel, cloudvolume.LabelMultiZoneDelimiter)
+	if len(zones) == 1 && len(zones[0]) != 0 {
+		// Zonal
+		volID = fmt.Sprintf(volIDZonalFmt, UnspecifiedValue, zones[0], pv.Spec.GCEPersistentDisk.PDName)
+	} else if len(zones) > 1 {
+		// Regional
+		region, err := getRegionFromZones(zones)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get region from zones: %v", err)
+		}
+		volID = fmt.Sprintf(volIDZonalFmt, UnspecifiedValue, region, pv.Spec.GCEPersistentDisk.PDName)
+	} else {
+		// Unspecified
+		volID = fmt.Sprintf(volIDZonalFmt, UnspecifiedValue, UnspecifiedValue, pv.Spec.GCEPersistentDisk.PDName)
+	}
+
+	gceSource := pv.Spec.PersistentVolumeSource.GCEPersistentDisk
+
+	partition := ""
+	if gceSource.Partition != 0 {
+		partition = strconv.Itoa(int(gceSource.Partition))
+	}
+
+	csiSource := &v1.CSIPersistentVolumeSource{
+		Driver:       GCEPDDriverName,
+		VolumeHandle: volID,
+		ReadOnly:     gceSource.ReadOnly,
+		FSType:       gceSource.FSType,
+		VolumeAttributes: map[string]string{
+			"partition": partition,
+		},
+	}
+
+	pv.Spec.PersistentVolumeSource.GCEPersistentDisk = nil
+	pv.Spec.PersistentVolumeSource.CSI = csiSource
+
+	return pv, nil
+}
+
+// TranslateCSIPVToInTree takes a PV with CSIPersistentVolumeSource set and
+// translates the GCE PD CSI source to a GCEPersistentDisk source.
+func (g *gcePersistentDiskCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	if pv == nil || pv.Spec.CSI == nil {
+		return nil, fmt.Errorf("pv is nil or CSI source not defined on pv")
+	}
+	csiSource := pv.Spec.CSI
+
+	pdName, err := pdNameFromVolumeID(csiSource.VolumeHandle)
+	if err != nil {
+		return nil, err
+	}
+
+	gceSource := &v1.GCEPersistentDiskVolumeSource{
+		PDName:   pdName,
+		FSType:   csiSource.FSType,
+		ReadOnly: csiSource.ReadOnly,
+	}
+	if partition, ok := csiSource.VolumeAttributes["partition"]; ok && partition != "" {
+		partInt, err := strconv.Atoi(partition)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to convert partition %v to integer: %v", partition, err)
+		}
+		gceSource.Partition = int32(partInt)
+	}
+
+	// TODO: Take the zone/regional information and stick it into the label.
+
+	pv.Spec.CSI = nil
+	pv.Spec.GCEPersistentDisk = gceSource
+
+	return pv, nil
+}
+
+// CanSupport tests whether the plugin supports a given volume
+// specification from the API.  The spec pointer should be considered
+// const.
+func (g *gcePersistentDiskCSITranslator) CanSupport(pv *v1.PersistentVolume) bool {
+	return pv != nil && pv.Spec.GCEPersistentDisk != nil
+}
+
+// GetInTreePluginName returns the name of the intree plugin driver
+func (g *gcePersistentDiskCSITranslator) GetInTreePluginName() string {
+	return GCEPDInTreePluginName
+}
+
+// GetCSIPluginName returns the name of the CSI plugin
+func (g *gcePersistentDiskCSITranslator) GetCSIPluginName() string {
+	return GCEPDDriverName
+}
+
+func pdNameFromVolumeID(id string) (string, error) {
+	splitID := strings.Split(id, "/")
+	if len(splitID) != volIDTotalElements {
+		return "", fmt.Errorf("failed to get id components. Expected projects/{project}/zones/{zone}/disks/{name}. Got: %s", id)
+	}
+	return splitID[volIDDiskNameValue], nil
+}
+
+// TODO: Replace this with the imported one from GCE PD CSI Driver when
+// the driver removes all k8s/k8s dependencies
+func getRegionFromZones(zones []string) (string, error) {
+	regions := sets.String{}
+	if len(zones) < 1 {
+		return "", fmt.Errorf("no zones specified")
+	}
+	for _, zone := range zones {
+		// Zone expected format {locale}-{region}-{zone}
+		splitZone := strings.Split(zone, "-")
+		if len(splitZone) != 3 {
+			return "", fmt.Errorf("zone in unexpected format, expected: {locale}-{region}-{zone}, got: %v", zone)
+		}
+		regions.Insert(strings.Join(splitZone[0:2], "-"))
+	}
+	if regions.Len() != 1 {
+		return "", fmt.Errorf("multiple or no regions gotten from zones, got: %v", regions)
+	}
+	return regions.UnsortedList()[0], nil
+}

--- a/vendor/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
+++ b/vendor/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import "k8s.io/api/core/v1"
+
+// InTreePlugin handles translations between CSI and in-tree sources in a PV
+type InTreePlugin interface {
+
+	// TranslateInTreeStorageClassParametersToCSI takes in-tree storage class
+	// parameters and translates them to a set of parameters consumable by CSI plugin
+	TranslateInTreeStorageClassParametersToCSI(scParameters map[string]string) (map[string]string, error)
+
+	// TranslateInTreePVToCSI takes a persistent volume and will translate
+	// the in-tree source to a CSI Source. The input persistent volume can be modified
+	TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error)
+
+	// TranslateCSIPVToInTree takes a PV with a CSI PersistentVolume Source and will translate
+	// it to a in-tree Persistent Volume Source for the in-tree volume
+	// by the `Driver` field in the CSI Source. The input PV object can be modified
+	TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.PersistentVolume, error)
+
+	// CanSupport tests whether the plugin supports a given volume
+	// specification from the API.
+	CanSupport(pv *v1.PersistentVolume) bool
+
+	// GetInTreePluginName returns the in-tree plugin name this migrates
+	GetInTreePluginName() string
+
+	// GetCSIPluginName returns the name of the CSI plugin that supersedes the in-tree plugin
+	GetCSIPluginName() string
+}

--- a/vendor/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
+++ b/vendor/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"fmt"
+	"k8s.io/api/core/v1"
+)
+
+const (
+	// CinderDriverName is the name of the CSI driver for Cinder
+	CinderDriverName = "cinder.csi.openstack.org"
+	// CinderInTreePluginName is the name of the intree plugin for Cinder
+	CinderInTreePluginName = "kubernetes.io/cinder"
+)
+
+var _ InTreePlugin = (*osCinderCSITranslator)(nil)
+
+// osCinderCSITranslator handles translation of PV spec from In-tree Cinder to CSI Cinder and vice versa
+type osCinderCSITranslator struct{}
+
+// NewOpenStackCinderCSITranslator returns a new instance of osCinderCSITranslator
+func NewOpenStackCinderCSITranslator() InTreePlugin {
+	return &osCinderCSITranslator{}
+}
+
+// TranslateInTreeStorageClassParametersToCSI translates InTree Cinder storage class parameters to CSI storage class
+func (t *osCinderCSITranslator) TranslateInTreeStorageClassParametersToCSI(scParameters map[string]string) (map[string]string, error) {
+	return scParameters, nil
+}
+
+// TranslateInTreePVToCSI takes a PV with Cinder set from in-tree
+// and converts the Cinder source to a CSIPersistentVolumeSource
+func (t *osCinderCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	if pv == nil || pv.Spec.Cinder == nil {
+		return nil, fmt.Errorf("pv is nil or Cinder not defined on pv")
+	}
+
+	cinderSource := pv.Spec.Cinder
+
+	csiSource := &v1.CSIPersistentVolumeSource{
+		Driver:           CinderDriverName,
+		VolumeHandle:     cinderSource.VolumeID,
+		ReadOnly:         cinderSource.ReadOnly,
+		FSType:           cinderSource.FSType,
+		VolumeAttributes: map[string]string{},
+	}
+
+	pv.Spec.Cinder = nil
+	pv.Spec.CSI = csiSource
+	return pv, nil
+}
+
+// TranslateCSIPVToInTree takes a PV with CSIPersistentVolumeSource set and
+// translates the Cinder CSI source to a Cinder In-tree source.
+func (t *osCinderCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	if pv == nil || pv.Spec.CSI == nil {
+		return nil, fmt.Errorf("pv is nil or CSI source not defined on pv")
+	}
+
+	csiSource := pv.Spec.CSI
+
+	cinderSource := &v1.CinderPersistentVolumeSource{
+		VolumeID: csiSource.VolumeHandle,
+		FSType:   csiSource.FSType,
+		ReadOnly: csiSource.ReadOnly,
+	}
+
+	pv.Spec.CSI = nil
+	pv.Spec.Cinder = cinderSource
+	return pv, nil
+}
+
+// CanSupport tests whether the plugin supports a given volume
+// specification from the API.  The spec pointer should be considered
+// const.
+func (t *osCinderCSITranslator) CanSupport(pv *v1.PersistentVolume) bool {
+	return pv != nil && pv.Spec.Cinder != nil
+}
+
+// GetInTreePluginName returns the name of the intree plugin driver
+func (t *osCinderCSITranslator) GetInTreePluginName() string {
+	return CinderInTreePluginName
+}
+
+// GetCSIPluginName returns the name of the CSI plugin
+func (t *osCinderCSITranslator) GetCSIPluginName() string {
+	return CinderDriverName
+}

--- a/vendor/k8s.io/csi-translation-lib/translate.go
+++ b/vendor/k8s.io/csi-translation-lib/translate.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csitranslation
+
+import (
+	"errors"
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/csi-translation-lib/plugins"
+)
+
+var (
+	inTreePlugins = map[string]plugins.InTreePlugin{
+		plugins.GCEPDDriverName:  plugins.NewGCEPersistentDiskCSITranslator(),
+		plugins.AWSEBSDriverName: plugins.NewAWSElasticBlockStoreCSITranslator(),
+		plugins.CinderDriverName: plugins.NewOpenStackCinderCSITranslator(),
+	}
+)
+
+// TranslateInTreeStorageClassParametersToCSI takes in-tree storage class
+// parameters and translates them to a set of parameters consumable by CSI plugin
+func TranslateInTreeStorageClassParametersToCSI(inTreePluginName string, scParameters map[string]string) (map[string]string, error) {
+	for _, curPlugin := range inTreePlugins {
+		if inTreePluginName == curPlugin.GetInTreePluginName() {
+			return curPlugin.TranslateInTreeStorageClassParametersToCSI(scParameters)
+		}
+	}
+	return nil, fmt.Errorf("could not find in-tree storage class parameter translation logic for %#v", inTreePluginName)
+}
+
+// TranslateInTreePVToCSI takes a persistent volume and will translate
+// the in-tree source to a CSI Source if the translation logic
+// has been implemented. The input persistent volume will not
+// be modified
+func TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	if pv == nil {
+		return nil, errors.New("persistent volume was nil")
+	}
+	copiedPV := pv.DeepCopy()
+	for _, curPlugin := range inTreePlugins {
+		if curPlugin.CanSupport(copiedPV) {
+			return curPlugin.TranslateInTreePVToCSI(copiedPV)
+		}
+	}
+	return nil, fmt.Errorf("could not find in-tree plugin translation logic for %#v", copiedPV.Name)
+}
+
+// TranslateCSIPVToInTree takes a PV with a CSI PersistentVolume Source and will translate
+// it to a in-tree Persistent Volume Source for the specific in-tree volume specified
+// by the `Driver` field in the CSI Source. The input PV object will not be modified.
+func TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+	if pv == nil || pv.Spec.CSI == nil {
+		return nil, errors.New("CSI persistent volume was nil")
+	}
+	copiedPV := pv.DeepCopy()
+	for driverName, curPlugin := range inTreePlugins {
+		if copiedPV.Spec.CSI.Driver == driverName {
+			return curPlugin.TranslateCSIPVToInTree(copiedPV)
+		}
+	}
+	return nil, fmt.Errorf("could not find in-tree plugin translation logic for %s", copiedPV.Spec.CSI.Driver)
+}
+
+// IsMigratableIntreePluginByName tests whether there is migration logic for the in-tree plugin
+// whose name matches the given name
+func IsMigratableIntreePluginByName(inTreePluginName string) bool {
+	for _, curPlugin := range inTreePlugins {
+		if curPlugin.GetInTreePluginName() == inTreePluginName {
+			return true
+		}
+	}
+	return false
+}
+
+// IsMigratedCSIDriverByName tests whether there exists an in-tree plugin with logic
+// to migrate to the CSI driver with given name
+func IsMigratedCSIDriverByName(csiPluginName string) bool {
+	if _, ok := inTreePlugins[csiPluginName]; ok {
+		return true
+	}
+	return false
+}
+
+// GetInTreePluginNameFromSpec returns the plugin name
+func GetInTreePluginNameFromSpec(pv *v1.PersistentVolume, vol *v1.Volume) (string, error) {
+	if pv != nil {
+		for _, curPlugin := range inTreePlugins {
+			if curPlugin.CanSupport(pv) {
+				return curPlugin.GetInTreePluginName(), nil
+			}
+		}
+		return "", fmt.Errorf("could not find in-tree plugin name from persistent volume %v", pv)
+	} else if vol != nil {
+		// TODO(dyzz): Implement inline volume migration support
+		return "", errors.New("inline volume migration not yet supported")
+	} else {
+		return "", errors.New("both persistent volume and volume are nil")
+	}
+}
+
+// GetCSINameFromInTreeName returns the name of a CSI driver that supersedes the
+// in-tree plugin with the given name
+func GetCSINameFromInTreeName(pluginName string) (string, error) {
+	for csiDriverName, curPlugin := range inTreePlugins {
+		if curPlugin.GetInTreePluginName() == pluginName {
+			return csiDriverName, nil
+		}
+	}
+	return "", fmt.Errorf("could not find CSI Driver name for plugin %v", pluginName)
+}
+
+// GetInTreeNameFromCSIName returns the name of the in-tree plugin superseded by
+// a CSI driver with the given name
+func GetInTreeNameFromCSIName(pluginName string) (string, error) {
+	if plugin, ok := inTreePlugins[pluginName]; ok {
+		return plugin.GetInTreePluginName(), nil
+	}
+	return "", fmt.Errorf("Could not find In-Tree driver name for CSI plugin %v", pluginName)
+}
+
+// IsPVMigratable tests whether there is migration logic for the given Persistent Volume
+func IsPVMigratable(pv *v1.PersistentVolume) bool {
+	for _, curPlugin := range inTreePlugins {
+		if curPlugin.CanSupport(pv) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsInlineMigratable tests whether there is Migration logic for the given Inline Volume
+func IsInlineMigratable(vol *v1.Volume) bool {
+	return false
+}


### PR DESCRIPTION
NOTE 1: The CSI migration provisioning logic here is not directly feature gated. However, the feature flags on the in-tree side sufficiently protects the logic here. This is because the PV controller in-tree will only yield PVCs (for in-tree provisioners) to the external provisioner when the feature flags for CSI migration for a particular plugin is enabled in-tree which in turn will make a plugin advertise `IsMigratedToCSI `: https://github.com/kubernetes/kubernetes/commit/23478f104f6ea26f752f1aae71301b637d2935a5#diff-3f32ad90966ceeb297f57c2a8d726348R1404 

NOTE 2: Unit tests are skipped for now. We need to address https://github.com/kubernetes/kubernetes/issues/74594 to be able to inject unit-tests as desired into the translation framework for unit testing purposes.

Tested e2e with GCE PD CSI driver name and ensured CSI driver got invoked for provisioning but the resulting PV pointed to GCEPersistentDisk

```
I0315 03:43:50.483655       1 controller.go:476] CreateVolumeRequest {Name:pvc-8bd370e9-46d4-11e9-b867-42010a8a001f CapacityRange:required_bytes:6442450944  VolumeCapabilities:[mount:<fs_type:"ext4" > access_mode:<mode:SINGLE_NODE_WRITER > ] Parameters:map[replication-type:none type:pd-standard] Secrets:map[] VolumeContentSource:<nil> AccessibilityRequirements:<nil> XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0315 03:43:50.483838       1 connection.go:180] GRPC call: /csi.v1.Controller/CreateVolume
I0315 03:43:50.483866       1 connection.go:181] GRPC request: {"capacity_range":{"required_bytes":6442450944},"name":"pvc-8bd370e9-46d4-11e9-b867-42010a8a001f","parameters":{"replication-type":"none","type":"pd-standard"},"volume_capabilities":[{"AccessType":{"Mount":{"fs_type":"ext4"}},"access_mode":{"mode":1}}]}
I0315 03:43:54.881857       1 connection.go:183] GRPC response: {"volume":{"accessible_topology":[{"segments":{"topology.gke.io/zone":"us-west1-a"}}],"capacity_bytes":6442450944,"volume_id":"projects/docker4x/zones/us-west1-a/disks/pvc-8bd370e9-46d4-11e9-b867-42010a8a001f"}}
I0315 03:43:54.883303       1 connection.go:184] GRPC error: <nil>
I0315 03:43:54.883320       1 controller.go:520] create volume rep: {CapacityBytes:6442450944 VolumeId:projects/docker4x/zones/us-west1-a/disks/pvc-8bd370e9-46d4-11e9-b867-42010a8a001f VolumeContext:map[] ContentSource:<nil> AccessibleTopology:[segments:<key:"topology.gke.io/zone" value:"us-west1-a" > ] XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0}
I0315 03:43:54.883435       1 controller.go:588] successfully created PV {GCEPersistentDisk:&GCEPersistentDiskVolumeSource{PDName:pvc-8bd370e9-46d4-11e9-b867-42010a8a001f,FSType:ext4,Partition:0,ReadOnly:false,} AWSElasticBlockStore:nil HostPath:nil Glusterfs:nil NFS:nil RBD:nil ISCSI:nil Cinder:nil CephFS:nil FC:nil Flocker:nil FlexVolume:nil AzureFile:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil PortworxVolume:nil ScaleIO:nil Local:nil StorageOS:nil CSI:nil}
I0315 03:43:54.883573       1 controller.go:1275] provision "default/podpvc" class "slow": volume "pvc-8bd370e9-46d4-11e9-b867-42010a8a001f" provisioned
I0315 03:43:54.883594       1 controller.go:1292] provision "default/podpvc" class "slow": succeeded
```

```
> kubectl describe pv pvc-8bd370e9-46d4-11e9-b867-42010a8a001f
Name:              pvc-8bd370e9-46d4-11e9-b867-42010a8a001f
Labels:            failure-domain.beta.kubernetes.io/region=us-west1
                   failure-domain.beta.kubernetes.io/zone=us-west1-a
Annotations:       pv.kubernetes.io/provisioned-by: pd.csi.storage.gke.io
Finalizers:        [external-provisioner.volume.kubernetes.io/finalizer kubernetes.io/pv-protection]
StorageClass:      slow
Status:            Bound
Claim:             default/podpvc
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          6Gi
Node Affinity:     
  Required Terms:  
    Term 0:        failure-domain.beta.kubernetes.io/zone in [us-west1-a]
                   failure-domain.beta.kubernetes.io/region in [us-west1]
Message:           
Source:
    Type:       GCEPersistentDisk (a Persistent Disk resource in Google Compute Engine)
    PDName:     pvc-8bd370e9-46d4-11e9-b867-42010a8a001f
    FSType:     ext4
    Partition:  0
    ReadOnly:   false
Events:         <none>
```