### PR TITLE
Use leader election library from csi-lib-utils 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -133,16 +133,17 @@
   version = "v1.1.6"
 
 [[projects]]
-  digest = "1:bee5467f0581e0bbc0c776908cfe02a7dc114bfefa895f59244d32f95be25401"
+  digest = "1:c74719aeb472ab2bd9ad14069f1a3ce97e54542de4143c4fc4c6c04dfd0dcf3c"
   name = "github.com/kubernetes-csi/csi-lib-utils"
   packages = [
     "connection",
     "deprecatedflags",
+    "leaderelection",
     "protosanitizer",
   ]
   pruneopts = "NUT"
-  revision = "2d2f98bf7ee876e6fe9bf23dc3bd71dbdd21b44b"
-  version = "0.5.0"
+  revision = "b8b7a89535d80e12f2c0f4c53cfb981add8aaca2"
+  version = "v0.6.1"
 
 [[projects]]
   digest = "1:189ada87769e6bd22de67cf8d5ac2f348070e7bcc4cdc5be3aaa5b19758e8fc2"
@@ -168,7 +169,7 @@
     "pkg/client/clientset/versioned/typed/volumesnapshot/v1alpha1/fake",
   ]
   pruneopts = "NUT"
-  revision = "84cca9386429a43aeed490f077e61e5004a7700c"
+  revision = "54a21f108e31331ab64c3c6b9fb199ee3070bc75"
 
 [[projects]]
   digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
@@ -248,7 +249,7 @@
   name = "github.com/prometheus/procfs"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "af7bedc223fba51343f25a6fa7aba84355d0357a"
+  revision = "ea9eea63887261e4d8ed8315f4078e88d540c725"
 
 [[projects]]
   digest = "1:9d8420bbf131d1618bde6530af37c3799340d3762cc47210c1d9532a4c3a2779"
@@ -290,7 +291,7 @@
     "trace",
   ]
   pruneopts = "NUT"
-  revision = "74de082e2cca95839e88aa0aeee5aadf6ce7710f"
+  revision = "b630fd6fe46bcfc98f989005d8b8ec1400e60a6e"
 
 [[projects]]
   branch = "master"
@@ -301,18 +302,18 @@
     "internal",
   ]
   pruneopts = "NUT"
-  revision = "c85d3e98c914e3a33234ad863dcbff5dbc425bb8"
+  revision = "9f3314589c9a9136388751d9adae6b0ed400978a"
 
 [[projects]]
   branch = "master"
-  digest = "1:af393301820919efc2288c08608a9aab90a3b293aa64e65a06739b7edbb7082f"
+  digest = "1:992976af3618fd8fb06e5e4c4fa177800a1e0880cbbbc91df3f952520808806c"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "NUT"
-  revision = "9eb1bfa1ce65ae8a6ff3114b0aaf9a41a6cf3560"
+  revision = "81d4e9dc473e5e8c933f2aaeba2a3d81efb9aed2"
 
 [[projects]]
   digest = "1:e7071ed636b5422cc51c0e3a6cebc229d6c9fffc528814b519a980641422d619"
@@ -828,6 +829,7 @@
     "github.com/golang/mock/gomock",
     "github.com/kubernetes-csi/csi-lib-utils/connection",
     "github.com/kubernetes-csi/csi-lib-utils/deprecatedflags",
+    "github.com/kubernetes-csi/csi-lib-utils/leaderelection",
     "github.com/kubernetes-csi/csi-test/driver",
     "github.com/kubernetes-csi/external-snapshotter/pkg/apis/volumesnapshot/v1alpha1",
     "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,11 +34,6 @@
   name = "sigs.k8s.io/sig-storage-lib-external-provisioner"
   version = ">=v3.0.0-beta"
 
-# TODO: remove when official 0.4.0 tagged
-[[constraint]]
-  name = "github.com/kubernetes-csi/csi-lib-utils"
-  version = ">=0.4.0-rc1"
-
 # TODO: remove when released
 [[constraint]]
   name = "github.com/kubernetes-csi/external-snapshotter"
@@ -56,6 +51,14 @@
 [[constraint]]
   name = "k8s.io/component-base"
   version = "kubernetes-1.14.0"
+
+[[constraint]]
+  name = "k8s.io/client-go"
+  version = "kubernetes-1.14.0"
+
+[[constraint]]
+  name = "github.com/kubernetes-csi/csi-lib-utils"
+  version = ">=0.6.1"
 
 [prune]
   non-go = true

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Note that the external-provisioner does not scale with more replicas. Only one e
 
 * `--enable-leader-election`: Enables leader election. This is mandatory when there are multiple replicas of the same external-provisioner running for one CSI driver. Only one of them may be active (=leader). A new leader will be re-elected when current leader dies or becomes unresponsive for ~15 seconds.
 
+* `--leader-election-type`: The resource type to use for leader election, options are 'endpoints' (default) or 'leases' (recommended)
+
 * `--timeout <duration>`: Timeout of all calls to CSI driver. It should be set to value that accommodates majority of `ControllerCreateVolume` and `ControllerDeleteVolume` calls. See [CSI error and timeout handling](#csi-error-and-timeout-handling) for details. 15 seconds is used by default.
 
 * `--retry-interval-start <duration>` - Initial retry interval of failed provisioning or deletion. It doubles with each failure, up to `--retry-interval-max` and then it stops increasing. Default value is 1 second. See [CSI error and timeout handling](#csi-error-and-timeout-handling) for details.

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -76,8 +76,13 @@ metadata:
   namespace: default
   name: external-provisioner-cfg
 rules:
+# Only one of the following rules for endpoints or leases is required based on
+# what is set for `--leader-election-type`. Endpoints are deprecated in favor of Leases.
 - apiGroups: [""]
   resources: ["endpoints"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
   verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---

--- a/vendor/github.com/kubernetes-csi/csi-lib-utils/leaderelection/leader_election.go
+++ b/vendor/github.com/kubernetes-csi/csi-lib-utils/leaderelection/leader_election.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+)
+
+const (
+	defaultLeaseDuration = 15 * time.Second
+	defaultRenewDeadline = 10 * time.Second
+	defaultRetryPeriod   = 5 * time.Second
+)
+
+// leaderElection is a convenience wrapper around client-go's leader election library.
+type leaderElection struct {
+	runFunc func(ctx context.Context)
+
+	// the lockName identifies the leader election config and should be shared across all members
+	lockName string
+	// the identity is the unique identity of the currently running member
+	identity string
+	// the namespace to store the lock resource
+	namespace string
+	// resourceLock defines the type of leaderelection that should be used
+	// valid options are resourcelock.LeasesResourceLock, resourcelock.EndpointsResourceLock,
+	// and resourcelock.ConfigMapsResourceLock
+	resourceLock string
+
+	leaseDuration time.Duration
+	renewDeadline time.Duration
+	retryPeriod   time.Duration
+
+	clientset kubernetes.Interface
+}
+
+// NewLeaderElection returns the default & preferred leader election type
+func NewLeaderElection(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
+	return NewLeaderElectionWithLeases(clientset, lockName, runFunc)
+}
+
+// NewLeaderElectionWithLeases returns an implementation of leader election using Leases
+func NewLeaderElectionWithLeases(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
+	return &leaderElection{
+		runFunc:       runFunc,
+		lockName:      lockName,
+		resourceLock:  resourcelock.LeasesResourceLock,
+		leaseDuration: defaultLeaseDuration,
+		renewDeadline: defaultRenewDeadline,
+		retryPeriod:   defaultRetryPeriod,
+		clientset:     clientset,
+	}
+}
+
+// NewLeaderElectionWithEndpoints returns an implementation of leader election using Endpoints
+func NewLeaderElectionWithEndpoints(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
+	return &leaderElection{
+		runFunc:       runFunc,
+		lockName:      lockName,
+		resourceLock:  resourcelock.EndpointsResourceLock,
+		leaseDuration: defaultLeaseDuration,
+		renewDeadline: defaultRenewDeadline,
+		retryPeriod:   defaultRetryPeriod,
+		clientset:     clientset,
+	}
+}
+
+// NewLeaderElectionWithConfigMaps returns an implementation of leader election using ConfigMaps
+func NewLeaderElectionWithConfigMaps(clientset kubernetes.Interface, lockName string, runFunc func(ctx context.Context)) *leaderElection {
+	return &leaderElection{
+		runFunc:       runFunc,
+		lockName:      lockName,
+		resourceLock:  resourcelock.ConfigMapsResourceLock,
+		leaseDuration: defaultLeaseDuration,
+		renewDeadline: defaultRenewDeadline,
+		retryPeriod:   defaultRetryPeriod,
+		clientset:     clientset,
+	}
+}
+
+func (l *leaderElection) WithIdentity(identity string) {
+	l.identity = identity
+}
+
+func (l *leaderElection) WithNamespace(namespace string) {
+	l.namespace = namespace
+}
+
+func (l *leaderElection) WithLeaseDuration(leaseDuration time.Duration) {
+	l.leaseDuration = leaseDuration
+}
+
+func (l *leaderElection) WithRenewDeadline(renewDeadline time.Duration) {
+	l.renewDeadline = renewDeadline
+}
+
+func (l *leaderElection) WithRetryPeriod(retryPeriod time.Duration) {
+	l.retryPeriod = retryPeriod
+}
+
+func (l *leaderElection) Run() error {
+	if l.identity == "" {
+		id, err := defaultLeaderElectionIdentity()
+		if err != nil {
+			return fmt.Errorf("error getting the default leader identity: %v", err)
+		}
+
+		l.identity = id
+	}
+
+	if l.namespace == "" {
+		l.namespace = inClusterNamespace()
+	}
+
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: l.clientset.CoreV1().Events(l.namespace)})
+	eventRecorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: fmt.Sprintf("%s/%s", l.lockName, string(l.identity))})
+
+	rlConfig := resourcelock.ResourceLockConfig{
+		Identity:      sanitizeName(l.identity),
+		EventRecorder: eventRecorder,
+	}
+
+	lock, err := resourcelock.New(l.resourceLock, l.namespace, sanitizeName(l.lockName), l.clientset.CoreV1(), l.clientset.CoordinationV1(), rlConfig)
+	if err != nil {
+		return err
+	}
+
+	leaderConfig := leaderelection.LeaderElectionConfig{
+		Lock:          lock,
+		LeaseDuration: l.leaseDuration,
+		RenewDeadline: l.renewDeadline,
+		RetryPeriod:   l.retryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				klog.V(2).Info("became leader, starting")
+				l.runFunc(ctx)
+			},
+			OnStoppedLeading: func() {
+				klog.Fatal("stopped leading")
+			},
+			OnNewLeader: func(identity string) {
+				klog.V(3).Infof("new leader detected, current leader: %s", identity)
+			},
+		},
+	}
+
+	leaderelection.RunOrDie(context.TODO(), leaderConfig)
+	return nil // should never reach here
+}
+
+func defaultLeaderElectionIdentity() (string, error) {
+	return os.Hostname()
+}
+
+// sanitizeName sanitizes the provided string so it can be consumed by leader election library
+func sanitizeName(name string) string {
+	re := regexp.MustCompile("[^a-zA-Z0-9-]")
+	name = re.ReplaceAllString(name, "-")
+	if name[len(name)-1] == '-' {
+		// name must not end with '-'
+		name = name + "X"
+	}
+	return name
+}
+
+// inClusterNamespace returns the namespace in which the pod is running in by checking
+// the env var POD_NAMESPACE, then the file /var/run/secrets/kubernetes.io/serviceaccount/namespace.
+// if neither returns a valid namespace, the "default" namespace is returned
+func inClusterNamespace() string {
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
+
+	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
+			return ns
+		}
+	}
+
+	return "default"
+}

--- a/vendor/golang.org/x/sys/unix/mksyscall.go
+++ b/vendor/golang.org/x/sys/unix/mksyscall.go
@@ -153,6 +153,11 @@ func main() {
 			}
 			funct, inps, outps, sysname := f[2], f[3], f[4], f[5]
 
+			// ClockGettime doesn't have a syscall number on Darwin, only generate libc wrappers.
+			if goos == "darwin" && !libc && funct == "ClockGettime" {
+				continue
+			}
+
 			// Split argument lists on comma.
 			in := parseParamList(inps)
 			out := parseParamList(outps)

--- a/vendor/golang.org/x/sys/unix/syscall_darwin.go
+++ b/vendor/golang.org/x/sys/unix/syscall_darwin.go
@@ -144,6 +144,23 @@ func getAttrList(path string, attrList attrList, attrBuf []byte, options uint) (
 
 //sys getattrlist(path *byte, list unsafe.Pointer, buf unsafe.Pointer, size uintptr, options int) (err error)
 
+func SysctlClockinfo(name string) (*Clockinfo, error) {
+	mib, err := sysctlmib(name)
+	if err != nil {
+		return nil, err
+	}
+
+	n := uintptr(SizeofClockinfo)
+	var ci Clockinfo
+	if err := sysctl(mib, (*byte)(unsafe.Pointer(&ci)), &n, nil, 0); err != nil {
+		return nil, err
+	}
+	if n != SizeofClockinfo {
+		return nil, EIO
+	}
+	return &ci, nil
+}
+
 //sysnb pipe() (r int, w int, err error)
 
 func Pipe(p []int) (err error) {

--- a/vendor/golang.org/x/sys/unix/types_darwin.go
+++ b/vendor/golang.org/x/sys/unix/types_darwin.go
@@ -275,3 +275,9 @@ const (
 // uname
 
 type Utsname C.struct_utsname
+
+// Clockinfo
+
+const SizeofClockinfo = C.sizeof_struct_clockinfo
+
+type Clockinfo C.struct_clockinfo

--- a/vendor/golang.org/x/sys/unix/ztypes_darwin_386.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_darwin_386.go
@@ -487,3 +487,13 @@ type Utsname struct {
 	Version  [256]byte
 	Machine  [256]byte
 }
+
+const SizeofClockinfo = 0x14
+
+type Clockinfo struct {
+	Hz      int32
+	Tick    int32
+	Tickadj int32
+	Stathz  int32
+	Profhz  int32
+}

--- a/vendor/golang.org/x/sys/unix/ztypes_darwin_amd64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_darwin_amd64.go
@@ -497,3 +497,13 @@ type Utsname struct {
 	Version  [256]byte
 	Machine  [256]byte
 }
+
+const SizeofClockinfo = 0x14
+
+type Clockinfo struct {
+	Hz      int32
+	Tick    int32
+	Tickadj int32
+	Stathz  int32
+	Profhz  int32
+}

--- a/vendor/golang.org/x/sys/unix/ztypes_darwin_arm.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_darwin_arm.go
@@ -488,3 +488,13 @@ type Utsname struct {
 	Version  [256]byte
 	Machine  [256]byte
 }
+
+const SizeofClockinfo = 0x14
+
+type Clockinfo struct {
+	Hz      int32
+	Tick    int32
+	Tickadj int32
+	Stathz  int32
+	Profhz  int32
+}

--- a/vendor/golang.org/x/sys/unix/ztypes_darwin_arm64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_darwin_arm64.go
@@ -497,3 +497,13 @@ type Utsname struct {
 	Version  [256]byte
 	Machine  [256]byte
 }
+
+const SizeofClockinfo = 0x14
+
+type Clockinfo struct {
+	Hz      int32
+	Tick    int32
+	Tickadj int32
+	Stathz  int32
+	Profhz  int32
+}


### PR DESCRIPTION
Also adds support for lease based leader election which is highly recommended over endpoints base. Endpoints based will be supported for a few releases for backwards compatibility. 

/assign @msau42 @jsafrane  @xing-yang