### PR TITLE
solve misleading struct deprecatedSecretParamsMap

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -47,7 +47,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-type deprecatedSecretParamsMap struct {
+//secretParamsMap provides a mapping of current as well as deprecated secret keys
+type secretParamsMap struct {
 	name                         string
 	deprecatedSecretNameKey      string
 	deprecatedSecretNamespaceKey string
@@ -111,7 +112,7 @@ const (
 )
 
 var (
-	provisionerSecretParams = deprecatedSecretParamsMap{
+	provisionerSecretParams = secretParamsMap{
 		name:                         "Provisioner",
 		deprecatedSecretNameKey:      provisionerSecretNameKey,
 		deprecatedSecretNamespaceKey: provisionerSecretNamespaceKey,
@@ -119,7 +120,7 @@ var (
 		secretNamespaceKey:           prefixedProvisionerSecretNamespaceKey,
 	}
 
-	nodePublishSecretParams = deprecatedSecretParamsMap{
+	nodePublishSecretParams = secretParamsMap{
 		name:                         "NodePublish",
 		deprecatedSecretNameKey:      nodePublishSecretNameKey,
 		deprecatedSecretNamespaceKey: nodePublishSecretNamespaceKey,
@@ -127,7 +128,7 @@ var (
 		secretNamespaceKey:           prefixedNodePublishSecretNamespaceKey,
 	}
 
-	controllerPublishSecretParams = deprecatedSecretParamsMap{
+	controllerPublishSecretParams = secretParamsMap{
 		name:                         "ControllerPublish",
 		deprecatedSecretNameKey:      controllerPublishSecretNameKey,
 		deprecatedSecretNamespaceKey: controllerPublishSecretNamespaceKey,
@@ -135,7 +136,7 @@ var (
 		secretNamespaceKey:           prefixedControllerPublishSecretNamespaceKey,
 	}
 
-	nodeStageSecretParams = deprecatedSecretParamsMap{
+	nodeStageSecretParams = secretParamsMap{
 		name:                         "NodeStage",
 		deprecatedSecretNameKey:      nodeStageSecretNameKey,
 		deprecatedSecretNamespaceKey: nodeStageSecretNamespaceKey,
@@ -704,7 +705,7 @@ func (p *csiProvisioner) volumeHandleToId(handle string) string {
 
 // verifyAndGetSecretNameAndNamespaceTemplate gets the values (templates) associated
 // with the parameters specified in "secret" and verifies that they are specified correctly.
-func verifyAndGetSecretNameAndNamespaceTemplate(secret deprecatedSecretParamsMap, storageClassParams map[string]string) (nameTemplate, namespaceTemplate string, err error) {
+func verifyAndGetSecretNameAndNamespaceTemplate(secret secretParamsMap, storageClassParams map[string]string) (nameTemplate, namespaceTemplate string, err error) {
 	numName := 0
 	numNamespace := 0
 
@@ -766,7 +767,7 @@ func verifyAndGetSecretNameAndNamespaceTemplate(secret deprecatedSecretParamsMap
 // - the nameTemplate or namespaceTemplate contains a token that cannot be resolved
 // - the resolved name is not a valid secret name
 // - the resolved namespace is not a valid namespace name
-func getSecretReference(secretParams deprecatedSecretParamsMap, storageClassParams map[string]string, pvName string, pvc *v1.PersistentVolumeClaim) (*v1.SecretReference, error) {
+func getSecretReference(secretParams secretParamsMap, storageClassParams map[string]string, pvName string, pvc *v1.PersistentVolumeClaim) (*v1.SecretReference, error) {
 	nameTemplate, namespaceTemplate, err := verifyAndGetSecretNameAndNamespaceTemplate(secretParams, storageClassParams)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get name and namespace template from params: %v", err)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -478,7 +478,7 @@ func createFakePVCWithVolumeMode(requestBytes int64, volumeMode v1.PersistentVol
 
 func TestGetSecretReference(t *testing.T) {
 	testcases := map[string]struct {
-		secretParams deprecatedSecretParamsMap
+		secretParams secretParamsMap
 		params       map[string]string
 		pvName       string
 		pvc          *v1.PersistentVolumeClaim


### PR DESCRIPTION
since the struct contains "deprecated" prefix hinting but some of the key is not really deprecated.
so it may confuse us. This is a private struct, it's simple to just rename in Controller and
test file.

224

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
solve misleading struct deprecatedSecretParamsMap 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #224 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
