### PR TITLE
Handle deletion of CSI migrated volumes

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -648,12 +648,29 @@ func (p *csiProvisioner) getVolumeContentSource(options controller.VolumeOptions
 }
 
 func (p *csiProvisioner) Delete(volume *v1.PersistentVolume) error {
-	if volume == nil || volume.Spec.CSI == nil {
+	if volume == nil {
 		return fmt.Errorf("invalid CSI PV")
 	}
+
+	var err error
+	if csitranslationlib.IsPVMigratable(volume) {
+		// we end up here only if CSI migration is enabled in-tree (both overall
+		// and for the specific plugin that is migratable) causing in-tree PV
+		// controller to yield deletion of PVs with in-tree source to external provisioner
+		// based on AnnDynamicallyProvisioned annotation.
+		volume, err = csitranslationlib.TranslateInTreePVToCSI(volume)
+		if err != nil {
+			return err
+		}
+	}
+
+	if volume.Spec.CSI == nil {
+		return fmt.Errorf("invalid CSI PV")
+	}
+
 	volumeId := p.volumeHandleToId(volume.Spec.CSI.VolumeHandle)
 
-	if err := p.checkDriverCapabilities(false); err != nil {
+	if err = p.checkDriverCapabilities(false); err != nil {
 		return err
 	}
 
@@ -681,7 +698,7 @@ func (p *csiProvisioner) Delete(volume *v1.PersistentVolume) error {
 	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
 	defer cancel()
 
-	_, err := p.csiClient.DeleteVolume(ctx, &req)
+	_, err = p.csiClient.DeleteVolume(ctx, &req)
 
 	return err
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Deletion of CSI migrated volumes were not getting correctly handled as the translation of the in-tree spec to CSI spec was not being done. This PR performs the translation.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes/kubernetes/issues/77102

**Special notes for your reviewer**:
Tested with GCE PD with feature flags enabled for CSIMigration and CSIMigrationGCE. 

```
# kubectl describe pv pvc-faad937e-eb54-49c0-a408-0a6a7d551945
Name:              pvc-faad937e-eb54-49c0-a408-0a6a7d551945
Labels:            failure-domain.beta.kubernetes.io/region=us-west1
                   failure-domain.beta.kubernetes.io/zone=us-west1-b
Annotations:       pv.kubernetes.io/provisioned-by: pd.csi.storage.gke.io
Finalizers:        [kubernetes.io/pv-protection]
StorageClass:      standard
Status:            Bound
Claim:             default/myclaim
Reclaim Policy:    Delete
Access Modes:      RWO
VolumeMode:        Filesystem
Capacity:          10Gi
Node Affinity:     
  Required Terms:  
    Term 0:        topology.gke.io/zone in [us-west1-b]
                   failure-domain.beta.kubernetes.io/zone in [us-west1-b]
                   failure-domain.beta.kubernetes.io/region in [us-west1]
Message:           
Source:
    Type:       GCEPersistentDisk (a Persistent Disk resource in Google Compute Engine)
    PDName:     pvc-faad937e-eb54-49c0-a408-0a6a7d551945
    FSType:     ext4
    Partition:  0
    ReadOnly:   false
Events:         <none>

# kubectl delete pvc myclaim
persistentvolumeclaim "myclaim" deleted

# kubectl get pv
No resources found.
```
Also verified in GCE console that PD is cleaned up.

**Does this PR introduce a user-facing change?**:
```release-note
Handle deletion of CSI migrated volumes
```
