### PR TITLE
Add secret support for Provision and Delete from pvc name and namespace

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -444,8 +444,12 @@ func (p *csiProvisioner) Provision(options controller.ProvisionOptions) (*v1.Per
 	rep := &csi.CreateVolumeResponse{}
 
 	// Resolve provision secret credentials.
-	// No PVC is provided when resolving provision/delete secret names, since the PVC may or may not exist at delete time.
-	provisionerSecretRef, err := getSecretReference(provisionerSecretParams, options.StorageClass.Parameters, pvName, nil)
+	provisionerSecretRef, err := getSecretReference(provisionerSecretParams, options.StorageClass.Parameters, pvName, &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      options.PVC.Name,
+			Namespace: options.PVC.Namespace,
+		},
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -684,18 +688,23 @@ func (p *csiProvisioner) Delete(volume *v1.PersistentVolume) error {
 	if len(storageClassName) != 0 {
 		if storageClass, err := p.client.StorageV1().StorageClasses().Get(storageClassName, metav1.GetOptions{}); err == nil {
 			// Resolve provision secret credentials.
-			// No PVC is provided when resolving provision/delete secret names, since the PVC may or may not exist at delete time.
-			provisionerSecretRef, err := getSecretReference(provisionerSecretParams, storageClass.Parameters, volume.Name, nil)
+			provisionerSecretRef, err := getSecretReference(provisionerSecretParams, storageClass.Parameters, volume.Name, &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      volume.Spec.ClaimRef.Name,
+					Namespace: volume.Spec.ClaimRef.Namespace,
+				},
+			})
 			if err != nil {
 				return err
 			}
+
 			credentials, err := getCredentials(p.client, provisionerSecretRef)
 			if err != nil {
-				return err
+				// Continue with deletion, as the secret may have already been deleted.
+				klog.Errorf("Failed to get credentials for volume %s: %s", volume.Name, err.Error())
 			}
 			req.Secrets = credentials
 		}
-
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
 	defer cancel()


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <ggp493@gmail.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
* This allows Provision to pass the correct PVC object so that the k8s secrets can be pulled and used during provisioning. 

**Which issue(s) this PR fixes**:
Fixes #170 
Fixes #233

**Special notes for your reviewer**:
* I'm still testing this change on my k8s cluster, which is why I've added the WIP tag.

**Does this PR introduce a user-facing change?**:
```release-note
Users can now provide a secret name and namespace during provision by passing the correct storage class parameters: "provisioner-secret-name" and "provisioner-secret-namespace"
```
