### PR TITLE
Cherry pick handling of deletion of CSI migrated volumes

### DIFF
--- a/CHANGELOG-1.1.md
+++ b/CHANGELOG-1.1.md
@@ -1,3 +1,8 @@
+# Changelog since v1.1.0
+
+## Notable Changes
+* Handle deletion of volumes associated with in-tree plugins that are migrated to CSI ([#276](https://github.com/kubernetes-csi/external-provisioner/pull/276))
+
 # Changelog since v1.0.1
 
 ## Breaking Changes


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Cherry picks https://github.com/kubernetes-csi/external-provisioner/commit/6b31b6c565f1b78ead865e26f9ad98cc36b52951 to `Release 1.1` branch and updates changelog.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes/kubernetes/issues/77102

**Special notes for your reviewer**:
As requested in https://github.com/kubernetes-csi/external-provisioner/pull/275#pullrequestreview-235078520

**Does this PR introduce a user-facing change?**:
```release-note
Handle deletion of CSI migrated volumes
```
