### PR TITLE
Bump provisioner lib and migration library dependencies. Update migration translation to translate the entire storage class.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -753,14 +753,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4f625748474cd525730ed105e6f0d344a555881207bc7aed241a4356b63804f0"
+  digest = "1:3579cdaf49281ad05bf2679d5a2740476c1618649a3db724e7f519f25d55ba1f"
   name = "k8s.io/csi-translation-lib"
   packages = [
     ".",
     "plugins",
   ]
   pruneopts = "NUT"
-  revision = "7f5cabc6aac80cb6cdcf30c37d23947401f26a21"
+  revision = "e1b42b89656a9ff97090d1e72559aec3b33c9dee"
 
 [[projects]]
   digest = "1:c263611800c3a97991dbcf9d3bc4de390f6224aaa8ca0a7226a9d734f65a416a"
@@ -837,6 +837,7 @@
     "github.com/spf13/pflag",
     "google.golang.org/grpc",
     "k8s.io/api/core/v1",
+    "k8s.io/api/storage/v1",
     "k8s.io/api/storage/v1beta1",
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -534,8 +534,8 @@
     "pkg/util/feature/testing",
   ]
   pruneopts = "NUT"
-  revision = "8b27c41bdbb11ff103caa673315e097bf0289171"
-  version = "kubernetes-1.14.0"
+  revision = "1ec86e4da56ce0573788fc12bb3a5530600c0e5d"
+  version = "kubernetes-1.14.1"
 
 [[projects]]
   digest = "1:85f25c196bc700354adc889a397f6550105865ad2588704094276f78f6e9d9ba"
@@ -802,7 +802,7 @@
   revision = "21c4ce38f2a793ec01e925ddc31216500183b773"
 
 [[projects]]
-  digest = "1:a2147c72c6ac436c7cbd3ffaefb3a8ca26264dd60fed5aec22cf4ed6d6c42690"
+  digest = "1:1628303a766eb8b6a1185756a064843933f453851720ad75e219489356dc26fa"
   name = "sigs.k8s.io/sig-storage-lib-external-provisioner"
   packages = [
     "controller",
@@ -810,8 +810,8 @@
     "util",
   ]
   pruneopts = "NUT"
-  revision = "3eea7193b4c5c034f885913c03105178e9e23a4f"
-  version = "v3.1.0"
+  revision = "d22b74e900af4bf90174d259c3e52c3680b41ab4"
+  version = "v4.0.0"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,11 +27,11 @@
 
 [[constraint]]
   name = "github.com/kubernetes-csi/csi-test"
-  version = "2.0"
+  version = "v2.0.0"
 
 [[constraint]]
   name = "sigs.k8s.io/sig-storage-lib-external-provisioner"
-  version = "v3.1.0"
+  version = "v4.0.0"
 
 # TODO: remove when released
 [[constraint]]
@@ -45,7 +45,7 @@
 # up with something older or master.
 [[constraint]]
   name = "k8s.io/apiserver"
-  version = "kubernetes-1.14.0"
+  version = "kubernetes-1.14.1"
 
 [[constraint]]
   name = "k8s.io/component-base"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,6 +26,10 @@
   version = "1.0"
 
 [[constraint]]
+  name = "k8s.io/csi-translation-lib"
+  branch = "master"
+
+[[constraint]]
   name = "github.com/kubernetes-csi/csi-test"
   version = "v2.0.0"
 

--- a/vendor/k8s.io/csi-translation-lib/plugins/aws_ebs.go
+++ b/vendor/k8s.io/csi-translation-lib/plugins/aws_ebs.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
 )
 
 const (
@@ -44,8 +45,8 @@ func NewAWSElasticBlockStoreCSITranslator() InTreePlugin {
 }
 
 // TranslateInTreeStorageClassParametersToCSI translates InTree EBS storage class parameters to CSI storage class
-func (t *awsElasticBlockStoreCSITranslator) TranslateInTreeStorageClassParametersToCSI(scParameters map[string]string) (map[string]string, error) {
-	return scParameters, nil
+func (t *awsElasticBlockStoreCSITranslator) TranslateInTreeStorageClassToCSI(sc *storage.StorageClass) (*storage.StorageClass, error) {
+	return sc, nil
 }
 
 // TranslateInTreePVToCSI takes a PV with AWSElasticBlockStore set from in-tree

--- a/vendor/k8s.io/csi-translation-lib/plugins/gce_pd.go
+++ b/vendor/k8s.io/csi-translation-lib/plugins/gce_pd.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudvolume "k8s.io/cloud-provider/volume"
 )
@@ -31,6 +32,9 @@ const (
 	GCEPDDriverName = "pd.csi.storage.gke.io"
 	// GCEPDInTreePluginName is the name of the intree plugin for GCE PD
 	GCEPDInTreePluginName = "kubernetes.io/gce-pd"
+
+	// GCEPDTopologyKey is the zonal topology key for GCE PD CSI Driver
+	GCEPDTopologyKey = "topology.gke.io/zone"
 
 	// Volume ID Expected Format
 	// "projects/{projectName}/zones/{zoneName}/disks/{diskName}"
@@ -55,9 +59,102 @@ func NewGCEPersistentDiskCSITranslator() InTreePlugin {
 	return &gcePersistentDiskCSITranslator{}
 }
 
+func translateAllowedTopologies(terms []v1.TopologySelectorTerm) ([]v1.TopologySelectorTerm, error) {
+	if terms == nil {
+		return nil, nil
+	}
+
+	newTopologies := []v1.TopologySelectorTerm{}
+	for _, term := range terms {
+		newTerm := v1.TopologySelectorTerm{}
+		for _, exp := range term.MatchLabelExpressions {
+			var newExp v1.TopologySelectorLabelRequirement
+			if exp.Key == v1.LabelZoneFailureDomain {
+				newExp = v1.TopologySelectorLabelRequirement{
+					Key:    GCEPDTopologyKey,
+					Values: exp.Values,
+				}
+			} else if exp.Key == GCEPDTopologyKey {
+				newExp = exp
+			} else {
+				return nil, fmt.Errorf("unknown topology key: %v", exp.Key)
+			}
+			newTerm.MatchLabelExpressions = append(newTerm.MatchLabelExpressions, newExp)
+		}
+		newTopologies = append(newTopologies, newTerm)
+	}
+	return newTopologies, nil
+}
+
+func generateToplogySelectors(key string, values []string) []v1.TopologySelectorTerm {
+	return []v1.TopologySelectorTerm{
+		{
+			MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+				{
+					Key:    key,
+					Values: values,
+				},
+			},
+		},
+	}
+}
+
 // TranslateInTreeStorageClassParametersToCSI translates InTree GCE storage class parameters to CSI storage class
-func (g *gcePersistentDiskCSITranslator) TranslateInTreeStorageClassParametersToCSI(scParameters map[string]string) (map[string]string, error) {
-	return scParameters, nil
+func (g *gcePersistentDiskCSITranslator) TranslateInTreeStorageClassToCSI(sc *storage.StorageClass) (*storage.StorageClass, error) {
+	var generatedTopologies []v1.TopologySelectorTerm
+
+	np := map[string]string{}
+	for k, v := range sc.Parameters {
+		switch strings.ToLower(k) {
+		case "fstype":
+			// prefixed fstype parameter is stripped out by external provisioner
+			np["csi.storage.k8s.io/fstype"] = v
+		// Strip out zone and zones parameters and translate them into topologies instead
+		case "zone":
+			generatedTopologies = generateToplogySelectors(GCEPDTopologyKey, []string{v})
+		case "zones":
+			generatedTopologies = generateToplogySelectors(GCEPDTopologyKey, strings.Split(v, ","))
+		default:
+			np[k] = v
+		}
+	}
+
+	if len(generatedTopologies) > 0 && len(sc.AllowedTopologies) > 0 {
+		return nil, fmt.Errorf("cannot simultaneously set allowed topologies and zone/zones parameters")
+	} else if len(generatedTopologies) > 0 {
+		sc.AllowedTopologies = generatedTopologies
+	} else if len(sc.AllowedTopologies) > 0 {
+		newTopologies, err := translateAllowedTopologies(sc.AllowedTopologies)
+		if err != nil {
+			return nil, fmt.Errorf("failed translating allowed topologies: %v", err)
+		}
+		sc.AllowedTopologies = newTopologies
+	}
+
+	sc.Parameters = np
+
+	return sc, nil
+}
+
+// backwardCompatibleAccessModes translates all instances of ReadWriteMany
+// access mode from the in-tree plugin to ReadWriteOnce. This is because in-tree
+// plugin never supported ReadWriteMany but also did not validate or enforce
+// this access mode for pre-provisioned volumes. The GCE PD CSI Driver validates
+// and enforces (fails) ReadWriteMany. Therefore we treat all in-tree
+// ReadWriteMany as ReadWriteOnce volumes to not break legacy volumes.
+func backwardCompatibleAccessModes(ams []v1.PersistentVolumeAccessMode) []v1.PersistentVolumeAccessMode {
+	if ams == nil {
+		return nil
+	}
+	newAM := []v1.PersistentVolumeAccessMode{}
+	for _, am := range ams {
+		if am == v1.ReadWriteMany {
+			newAM = append(newAM, v1.ReadWriteOnce)
+		} else {
+			newAM = append(newAM, am)
+		}
+	}
+	return newAM
 }
 
 // TranslateInTreePVToCSI takes a PV with GCEPersistentDisk set from in-tree
@@ -105,6 +202,7 @@ func (g *gcePersistentDiskCSITranslator) TranslateInTreePVToCSI(pv *v1.Persisten
 
 	pv.Spec.PersistentVolumeSource.GCEPersistentDisk = nil
 	pv.Spec.PersistentVolumeSource.CSI = csiSource
+	pv.Spec.AccessModes = backwardCompatibleAccessModes(pv.Spec.AccessModes)
 
 	return pv, nil
 }

--- a/vendor/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
+++ b/vendor/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
@@ -16,14 +16,17 @@ limitations under the License.
 
 package plugins
 
-import "k8s.io/api/core/v1"
+import (
+	"k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
+)
 
 // InTreePlugin handles translations between CSI and in-tree sources in a PV
 type InTreePlugin interface {
 
-	// TranslateInTreeStorageClassParametersToCSI takes in-tree storage class
-	// parameters and translates them to a set of parameters consumable by CSI plugin
-	TranslateInTreeStorageClassParametersToCSI(scParameters map[string]string) (map[string]string, error)
+	// TranslateInTreeStorageClassToCSI takes in-tree volume options
+	// and translates them to a volume options consumable by CSI plugin
+	TranslateInTreeStorageClassToCSI(sc *storage.StorageClass) (*storage.StorageClass, error)
 
 	// TranslateInTreePVToCSI takes a persistent volume and will translate
 	// the in-tree source to a CSI Source. The input persistent volume can be modified

--- a/vendor/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
+++ b/vendor/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
@@ -18,7 +18,9 @@ package plugins
 
 import (
 	"fmt"
+
 	"k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
 )
 
 const (
@@ -39,8 +41,8 @@ func NewOpenStackCinderCSITranslator() InTreePlugin {
 }
 
 // TranslateInTreeStorageClassParametersToCSI translates InTree Cinder storage class parameters to CSI storage class
-func (t *osCinderCSITranslator) TranslateInTreeStorageClassParametersToCSI(scParameters map[string]string) (map[string]string, error) {
-	return scParameters, nil
+func (t *osCinderCSITranslator) TranslateInTreeStorageClassToCSI(sc *storage.StorageClass) (*storage.StorageClass, error) {
+	return sc, nil
 }
 
 // TranslateInTreePVToCSI takes a PV with Cinder set from in-tree

--- a/vendor/k8s.io/csi-translation-lib/translate.go
+++ b/vendor/k8s.io/csi-translation-lib/translate.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
 	"k8s.io/csi-translation-lib/plugins"
 )
 
@@ -32,12 +33,13 @@ var (
 	}
 )
 
-// TranslateInTreeStorageClassParametersToCSI takes in-tree storage class
-// parameters and translates them to a set of parameters consumable by CSI plugin
-func TranslateInTreeStorageClassParametersToCSI(inTreePluginName string, scParameters map[string]string) (map[string]string, error) {
+// TranslateInTreeStorageClassToCSI takes in-tree Storage Class
+// and translates it to a set of parameters consumable by CSI plugin
+func TranslateInTreeStorageClassToCSI(inTreePluginName string, sc *storage.StorageClass) (*storage.StorageClass, error) {
+	newSC := sc.DeepCopy()
 	for _, curPlugin := range inTreePlugins {
 		if inTreePluginName == curPlugin.GetInTreePluginName() {
-			return curPlugin.TranslateInTreeStorageClassParametersToCSI(scParameters)
+			return curPlugin.TranslateInTreeStorageClassToCSI(newSC)
 		}
 	}
 	return nil, fmt.Errorf("could not find in-tree storage class parameter translation logic for %#v", inTreePluginName)

--- a/vendor/sigs.k8s.io/sig-storage-lib-external-provisioner/controller/controller.go
+++ b/vendor/sigs.k8s.io/sig-storage-lib-external-provisioner/controller/controller.go
@@ -1083,12 +1083,12 @@ func (ctrl *ProvisionController) shouldProvision(claim *v1.PersistentVolumeClaim
 	} else {
 		// Kubernetes 1.4 provisioning, evaluating class.Provisioner
 		claimClass := util.GetPersistentVolumeClaimClass(claim)
-		provisioner, _, err := ctrl.getStorageClassFields(claimClass)
+		class, err := ctrl.getStorageClass(claimClass)
 		if err != nil {
 			glog.Errorf("Error getting claim %q's StorageClass's fields: %v", claimToClaimKey(claim), err)
 			return false, err
 		}
-		if provisioner != ctrl.provisionerName {
+		if class.Provisioner != ctrl.provisionerName {
 			return false, nil
 		}
 
@@ -1223,34 +1223,20 @@ func (ctrl *ProvisionController) provisionClaimOperation(claim *v1.PersistentVol
 
 	// For any issues getting fields from StorageClass (including reclaimPolicy & mountOptions),
 	// retry the claim because the storageClass can be fixed/(re)created independently of the claim
-	provisioner, parameters, err := ctrl.getStorageClassFields(claimClass)
+	class, err := ctrl.getStorageClass(claimClass)
 	if err != nil {
 		glog.Error(logOperation(operation, "error getting claim's StorageClass's fields: %v", err))
 		return ProvisioningFinished, err
 	}
-	if !ctrl.knownProvisioner(provisioner) {
+	if !ctrl.knownProvisioner(class.Provisioner) {
 		// class.Provisioner has either changed since shouldProvision() or
 		// annDynamicallyProvisioned contains different provisioner than
 		// class.Provisioner.
-		glog.Error(logOperation(operation, "unknown provisioner %q requested in claim's StorageClass", provisioner))
+		glog.Error(logOperation(operation, "unknown provisioner %q requested in claim's StorageClass", class.Provisioner))
 		return ProvisioningFinished, nil
 	}
 
-	reclaimPolicy := v1.PersistentVolumeReclaimDelete
-	if ctrl.kubeVersion.AtLeast(utilversion.MustParseSemantic("v1.8.0")) {
-		reclaimPolicy, err = ctrl.fetchReclaimPolicy(claimClass)
-		if err != nil {
-			return ProvisioningFinished, err
-		}
-	}
-
-	mountOptions, err := ctrl.fetchMountOptions(claimClass)
-	if err != nil {
-		return ProvisioningFinished, err
-	}
-
 	var selectedNode *v1.Node
-	var allowedTopologies []v1.TopologySelectorTerm
 	if ctrl.kubeVersion.AtLeast(utilversion.MustParseSemantic("v1.11.0")) {
 		// Get SelectedNode
 		if nodeName, ok := claim.Annotations[annSelectedNode]; ok {
@@ -1261,24 +1247,13 @@ func (ctrl *ProvisionController) provisionClaimOperation(claim *v1.PersistentVol
 				return ProvisioningNoChange, err
 			}
 		}
-
-		// Get AllowedTopologies
-		allowedTopologies, err = ctrl.fetchAllowedTopologies(claimClass)
-		if err != nil {
-			err = fmt.Errorf("failed to get AllowedTopologies from StorageClass: %v", err)
-			ctrl.eventRecorder.Event(claim, v1.EventTypeWarning, "ProvisioningFailed", err.Error())
-			return ProvisioningNoChange, err
-		}
 	}
 
-	options := VolumeOptions{
-		PersistentVolumeReclaimPolicy: reclaimPolicy,
-		PVName:                        pvName,
-		PVC:                           claim,
-		MountOptions:                  mountOptions,
-		Parameters:                    parameters,
-		SelectedNode:                  selectedNode,
-		AllowedTopologies:             allowedTopologies,
+	options := ProvisionOptions{
+		StorageClass: class,
+		PVName:       pvName,
+		PVC:          claim,
+		SelectedNode: selectedNode,
 	}
 
 	ctrl.eventRecorder.Event(claim, v1.EventTypeNormal, "Provisioning", fmt.Sprintf("External provisioner is provisioning volume for claim %q", claimToClaimKey(claim)))
@@ -1436,86 +1411,36 @@ func (ctrl *ProvisionController) getProvisionedVolumeNameForClaim(claim *v1.Pers
 	return "pvc-" + string(claim.UID)
 }
 
-func (ctrl *ProvisionController) getStorageClassFields(name string) (string, map[string]string, error) {
+// getStorageClass retrives storage class object by name.
+func (ctrl *ProvisionController) getStorageClass(name string) (*storage.StorageClass, error) {
 	classObj, found, err := ctrl.classes.GetByKey(name)
 	if err != nil {
-		return "", nil, err
+		return nil, err
 	}
 	if !found {
-		return "", nil, fmt.Errorf("storageClass %q not found", name)
-		// 3. It tries to find a StorageClass instance referenced by annotation
-		//    `claim.Annotations["volume.beta.kubernetes.io/storage-class"]`. If not
-		//    found, it SHOULD report an error (by sending an event to the claim) and it
-		//    SHOULD retry periodically with step i.
+		return nil, fmt.Errorf("storageClass %q not found", name)
 	}
 	switch class := classObj.(type) {
 	case *storage.StorageClass:
-		return class.Provisioner, class.Parameters, nil
+		return class, nil
 	case *storagebeta.StorageClass:
-		return class.Provisioner, class.Parameters, nil
+		// convert storagebeta.StorageClass to storage.StorageClass
+		return &storage.StorageClass{
+			ObjectMeta:           class.ObjectMeta,
+			Provisioner:          class.Provisioner,
+			Parameters:           class.Parameters,
+			ReclaimPolicy:        class.ReclaimPolicy,
+			MountOptions:         class.MountOptions,
+			AllowVolumeExpansion: class.AllowVolumeExpansion,
+			VolumeBindingMode:    (*storage.VolumeBindingMode)(class.VolumeBindingMode),
+			AllowedTopologies:    class.AllowedTopologies,
+		}, nil
 	}
-	return "", nil, fmt.Errorf("cannot convert object to StorageClass: %+v", classObj)
+	return nil, fmt.Errorf("cannot convert object to StorageClass: %+v", classObj)
 }
 
 func claimToClaimKey(claim *v1.PersistentVolumeClaim) string {
 	return fmt.Sprintf("%s/%s", claim.Namespace, claim.Name)
-}
-
-func (ctrl *ProvisionController) fetchReclaimPolicy(storageClassName string) (v1.PersistentVolumeReclaimPolicy, error) {
-	classObj, found, err := ctrl.classes.GetByKey(storageClassName)
-	if err != nil {
-		return "", err
-	}
-	if !found {
-		return "", fmt.Errorf("storageClass %q not found", storageClassName)
-	}
-
-	switch class := classObj.(type) {
-	case *storage.StorageClass:
-		return *class.ReclaimPolicy, nil
-	case *storagebeta.StorageClass:
-		return *class.ReclaimPolicy, nil
-	}
-
-	return v1.PersistentVolumeReclaimDelete, fmt.Errorf("cannot convert object to StorageClass: %+v", classObj)
-}
-
-func (ctrl *ProvisionController) fetchMountOptions(storageClassName string) ([]string, error) {
-	classObj, found, err := ctrl.classes.GetByKey(storageClassName)
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		return nil, fmt.Errorf("storageClass %q not found", storageClassName)
-	}
-
-	switch class := classObj.(type) {
-	case *storage.StorageClass:
-		return class.MountOptions, nil
-	case *storagebeta.StorageClass:
-		return class.MountOptions, nil
-	}
-
-	return nil, fmt.Errorf("cannot convert object to StorageClass: %+v", classObj)
-}
-
-func (ctrl *ProvisionController) fetchAllowedTopologies(storageClassName string) ([]v1.TopologySelectorTerm, error) {
-	classObj, found, err := ctrl.classes.GetByKey(storageClassName)
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		return nil, fmt.Errorf("storageClass %q not found", storageClassName)
-	}
-
-	switch class := classObj.(type) {
-	case *storage.StorageClass:
-		return class.AllowedTopologies, nil
-	case *storagebeta.StorageClass:
-		return class.AllowedTopologies, nil
-	}
-
-	return nil, fmt.Errorf("cannot convert object to StorageClass: %+v", classObj)
 }
 
 // supportsBlock returns whether a provisioner supports block volume.


### PR DESCRIPTION
This PR updates the controller to translate the entire storage class when the migration path is hit. This allows us to modify things such as topology, parameters, mount options etc.

/kind feature
/sig storage


Fixes: https://github.com/kubernetes/kubernetes/issues/77235

```release-note
Fixes migration scenarios for Topology, fstype, and accessmodes for the kubernetes.io/gce-pd in-tree plugin
```
