### PR TITLE
Remove dummy service from the deployment

### DIFF
--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -1,21 +1,6 @@
 # This YAML file demonstrates how to deploy the external
 # provisioner for use with the mock CSI driver. It
 # depends on the RBAC definitions from rbac.yaml.
-
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: csi-provisioner
-  labels:
-    app: csi-provisioner
-spec:
-  selector:
-    app: csi-provisioner
-  ports:
-    - name: dummy
-      port: 12345
-
 ---
 kind: Deployment
 apiVersion: apps/v1


### PR DESCRIPTION
csi-provisioner service creation was necessary to run external-provisioner
as statefulset, after moving from statefulset to deployment, we no longer need dummy service.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
