### PR TITLE
Cherrypick of #296: "Leader election: disable duplicate LE in provisioner lib; add lock namespacing"

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -60,8 +60,9 @@ var (
 	operationTimeout     = flag.Duration("timeout", 10*time.Second, "Timeout for waiting for creation or deletion of a volume")
 	_                    = deprecatedflags.Add("provisioner")
 
-	enableLeaderElection = flag.Bool("enable-leader-election", false, "Enables leader election. If leader election is enabled, additional RBAC rules are required. Please refer to the Kubernetes CSI documentation for instructions on setting up these RBAC rules.")
-	leaderElectionType   = flag.String("leader-election-type", "endpoints", "the type of leader election, options are 'endpoints' (default) or 'leases' (strongly recommended). The 'endpoints' option is deprecated in favor of 'leases'.")
+	enableLeaderElection    = flag.Bool("enable-leader-election", false, "Enables leader election. If leader election is enabled, additional RBAC rules are required. Please refer to the Kubernetes CSI documentation for instructions on setting up these RBAC rules.")
+	leaderElectionType      = flag.String("leader-election-type", "endpoints", "the type of leader election, options are 'endpoints' (default) or 'leases' (strongly recommended). The 'endpoints' option is deprecated in favor of 'leases'.")
+	leaderElectionNamespace = flag.String("leader-election-namespace", "", "Namespace where the leader election resource lives. Defaults to the pod namespace if not set.")
 
 	featureGates        map[string]bool
 	provisionController *controller.ProvisionController
@@ -70,6 +71,7 @@ var (
 
 type leaderElection interface {
 	Run() error
+	WithNamespace(namespace string)
 }
 
 func main() {
@@ -158,7 +160,7 @@ func main() {
 	identity := strconv.FormatInt(timeStamp, 10) + "-" + strconv.Itoa(rand.Intn(10000)) + "-" + provisionerName
 
 	provisionerOptions := []func(*controller.ProvisionController) error{
-		controller.LeaderElection(*enableLeaderElection),
+		controller.LeaderElection(false), // Always disable leader election in provisioner lib. Leader election should be done here in the CSI provisioner level instead.
 		controller.FailedProvisionThreshold(0),
 		controller.FailedDeleteThreshold(0),
 		controller.RateLimiter(workqueue.NewItemExponentialFailureRateLimiter(*retryIntervalStart, *retryIntervalMax)),
@@ -207,6 +209,10 @@ func main() {
 		} else {
 			klog.Error("--leader-election-type must be either 'endpoints' or 'lease'")
 			os.Exit(1)
+		}
+
+		if *leaderElectionNamespace != "" {
+			le.WithNamespace(*leaderElectionNamespace)
 		}
 
 		if err := le.Run(); err != nil {


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it: Today there are two leader election processes running - one defined in external-provisioner main, one enabled in the provisioner controller lib by default. I ran into this problem when I set leader election type to lease - the external provisioner tries to do both lease-based and endpoint-based LE.

Also adding the ability to restrict the lock resource to specific namespaces.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
A new flag --leader-election-namespace is introduced to allow the user to set where the leader election lock resource lives.
```
