### PR TITLE
fix pvc and source PVC storageclass name comparison for pvc datasource

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -661,9 +661,18 @@ func (p *csiProvisioner) getPVCSource(options controller.ProvisionOptions) (*csi
 	if sourcePVC.ObjectMeta.DeletionTimestamp != nil {
 		return nil, fmt.Errorf("the PVC DataSource %s is currently being deleted", options.PVC.Spec.DataSource.Name)
 	}
-	if sourcePVC.Spec.StorageClassName != options.PVC.Spec.StorageClassName {
+
+	if sourcePVC.Spec.StorageClassName == nil {
+		return nil, fmt.Errorf("the source PVC (%s) storageclass cannot be empty", sourcePVC.Name)
+	}
+
+	if options.PVC.Spec.StorageClassName == nil {
+		return nil, fmt.Errorf("the requested PVC (%s) storageclass cannot be empty", options.PVC.Name)
+	}
+
+	if *sourcePVC.Spec.StorageClassName != *options.PVC.Spec.StorageClassName {
 		return nil, fmt.Errorf("the source PVC and destination PVCs must be in the same storage class for cloning.  Source is in %v, but new PVC is in %v",
-			sourcePVC.Spec.StorageClassName, options.PVC.Spec.StorageClassName)
+			*sourcePVC.Spec.StorageClassName, *options.PVC.Spec.StorageClassName)
 	}
 	capacity := options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	requestedSize := capacity.Value()

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -2144,8 +2145,10 @@ func runDeleteTest(t *testing.T, k string, tc deleteTestcase) {
 // TestProvisionFromPVC tests create volume clone
 func TestProvisionFromPVC(t *testing.T) {
 	var requestedBytes int64 = 1000
-	invalidSCName := "invalid-sc"
+	fakeSc1 := "fake-sc-1"
+	fakeSc2 := "fake-sc-2"
 	srcName := "fake-pvc"
+	invalidPVC := "invalid-pv"
 	pvName := "test-testi"
 	deletePolicy := v1.PersistentVolumeReclaimDelete
 
@@ -2160,6 +2163,7 @@ func TestProvisionFromPVC(t *testing.T) {
 	testcases := map[string]struct {
 		volOpts              controller.ProvisionOptions
 		restoredVolSizeSmall bool
+		restoredVolSizeBig   bool
 		wrongDataSource      bool
 		pvcStatusReady       bool
 		expectedPVSpec       *pvSpec
@@ -2178,7 +2182,8 @@ func TestProvisionFromPVC(t *testing.T) {
 						UID: "testid",
 					},
 					Spec: v1.PersistentVolumeClaimSpec{
-						Selector: nil,
+						StorageClassName: &fakeSc1,
+						Selector:         nil,
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								v1.ResourceName(v1.ResourceStorage): resource.MustParse(strconv.FormatInt(requestedBytes, 10)),
@@ -2223,7 +2228,8 @@ func TestProvisionFromPVC(t *testing.T) {
 						UID: "testid",
 					},
 					Spec: v1.PersistentVolumeClaimSpec{
-						Selector: nil,
+						StorageClassName: &fakeSc1,
+						Selector:         nil,
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								v1.ResourceName(v1.ResourceStorage): resource.MustParse(strconv.FormatInt(requestedBytes, 10)),
@@ -2254,7 +2260,7 @@ func TestProvisionFromPVC(t *testing.T) {
 						UID: "testid",
 					},
 					Spec: v1.PersistentVolumeClaimSpec{
-						StorageClassName: &invalidSCName,
+						StorageClassName: &fakeSc2,
 						Selector:         nil,
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -2286,11 +2292,11 @@ func TestProvisionFromPVC(t *testing.T) {
 						UID: "testid",
 					},
 					Spec: v1.PersistentVolumeClaimSpec{
-						StorageClassName: &invalidSCName,
+						StorageClassName: &fakeSc1,
 						Selector:         nil,
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
-								v1.ResourceName(v1.ResourceStorage): resource.MustParse(strconv.FormatInt(requestedBytes-1, 10)),
+								v1.ResourceName(v1.ResourceStorage): resource.MustParse(strconv.FormatInt(requestedBytes+1, 10)),
 							},
 						},
 						AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
@@ -2301,10 +2307,44 @@ func TestProvisionFromPVC(t *testing.T) {
 					},
 				},
 			},
-			pvcStatusReady: true,
-			expectedPVSpec: nil,
-			cloneSupport:   true,
-			expectErr:      true,
+			pvcStatusReady:       true,
+			restoredVolSizeSmall: true,
+			expectedPVSpec:       nil,
+			cloneSupport:         true,
+			expectErr:            true,
+		},
+		"provision with pvc data source destination too large": {
+			volOpts: controller.ProvisionOptions{
+				StorageClass: &storagev1.StorageClass{
+					ReclaimPolicy: &deletePolicy,
+					Parameters:    map[string]string{},
+				},
+				PVName: pvName,
+				PVC: &v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "testid",
+					},
+					Spec: v1.PersistentVolumeClaimSpec{
+						StorageClassName: &fakeSc1,
+						Selector:         nil,
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceName(v1.ResourceStorage): resource.MustParse(strconv.FormatInt(requestedBytes+1, 10)),
+							},
+						},
+						AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+						DataSource: &v1.TypedLocalObjectReference{
+							Name: srcName,
+							Kind: "PersistentVolumeClaim",
+						},
+					},
+				},
+			},
+			pvcStatusReady:     true,
+			restoredVolSizeBig: true,
+			expectedPVSpec:     nil,
+			cloneSupport:       true,
+			expectErr:          true,
 		},
 		"provision with pvc data source not found": {
 			volOpts: controller.ProvisionOptions{
@@ -2318,7 +2358,7 @@ func TestProvisionFromPVC(t *testing.T) {
 						UID: "testid",
 					},
 					Spec: v1.PersistentVolumeClaimSpec{
-						StorageClassName: &invalidSCName,
+						StorageClassName: &fakeSc1,
 						Selector:         nil,
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -2338,7 +2378,7 @@ func TestProvisionFromPVC(t *testing.T) {
 			cloneSupport:   true,
 			expectErr:      true,
 		},
-		"provision with pvc data source destination too large": {
+		"provision with source pvc storageclass nil": {
 			volOpts: controller.ProvisionOptions{
 				StorageClass: &storagev1.StorageClass{
 					ReclaimPolicy: &deletePolicy,
@@ -2350,11 +2390,42 @@ func TestProvisionFromPVC(t *testing.T) {
 						UID: "testid",
 					},
 					Spec: v1.PersistentVolumeClaimSpec{
-						StorageClassName: &invalidSCName,
 						Selector:         nil,
+						StorageClassName: &fakeSc1,
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
-								v1.ResourceName(v1.ResourceStorage): resource.MustParse(strconv.FormatInt(requestedBytes+1, 10)),
+								v1.ResourceName(v1.ResourceStorage): resource.MustParse(strconv.FormatInt(requestedBytes-1, 10)),
+							},
+						},
+						AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+						DataSource: &v1.TypedLocalObjectReference{
+							Name: "pvc-sc-nil",
+							Kind: "PersistentVolumeClaim",
+						},
+					},
+				},
+			},
+			pvcStatusReady: true,
+			expectedPVSpec: nil,
+			cloneSupport:   true,
+			expectErr:      true,
+		},
+		"provision with requested pvc storageclass nil": {
+			volOpts: controller.ProvisionOptions{
+				StorageClass: &storagev1.StorageClass{
+					ReclaimPolicy: &deletePolicy,
+					Parameters:    map[string]string{},
+				},
+				PVName: pvName,
+				PVC: &v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: "testid",
+					},
+					Spec: v1.PersistentVolumeClaimSpec{
+						Selector: nil,
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceName(v1.ResourceStorage): resource.MustParse(strconv.FormatInt(requestedBytes-1, 10)),
 							},
 						},
 						AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
@@ -2382,7 +2453,7 @@ func TestProvisionFromPVC(t *testing.T) {
 						UID: "testid",
 					},
 					Spec: v1.PersistentVolumeClaimSpec{
-						StorageClassName: &invalidSCName,
+						StorageClassName: &fakeSc1,
 						Selector:         nil,
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
@@ -2391,7 +2462,7 @@ func TestProvisionFromPVC(t *testing.T) {
 						},
 						AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 						DataSource: &v1.TypedLocalObjectReference{
-							Name: srcName,
+							Name: invalidPVC,
 							Kind: "PersistentVolumeClaim",
 						},
 					},
@@ -2426,9 +2497,6 @@ func TestProvisionFromPVC(t *testing.T) {
 
 		clientSet = fakeclientset.NewSimpleClientset()
 
-		// Create a fake claim as our PVC DataSource
-		claim := fakeClaim(srcName, "fake-claim-uid", "1Gi", pvName, v1.ClaimBound, nil)
-
 		pv := &v1.PersistentVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: pvName,
@@ -2436,7 +2504,7 @@ func TestProvisionFromPVC(t *testing.T) {
 			Spec: v1.PersistentVolumeSpec{
 				PersistentVolumeSource: v1.PersistentVolumeSource{
 					CSI: &v1.CSIPersistentVolumeSource{
-						Driver:       "test-driver",
+						Driver:       driverName,
 						VolumeHandle: "test-volume-id",
 						FSType:       "ext3",
 						VolumeAttributes: map[string]string{
@@ -2446,7 +2514,14 @@ func TestProvisionFromPVC(t *testing.T) {
 				},
 			},
 		}
-		clientSet = fakeclientset.NewSimpleClientset(claim, pv)
+
+		// Create a fake claim as our PVC DataSource
+		claim := fakeClaim(srcName, "fake-claim-uid", "1Gi", pvName, v1.ClaimBound, &fakeSc1)
+		// Create a fake claim with invalid PV
+		invalidClaim := fakeClaim(invalidPVC, "fake-claim-uid", "1Gi", "pv-not-present", v1.ClaimBound, &fakeSc1)
+		/// Create a fake claim as source PVC storageclass nil
+		scNilClaim := fakeClaim("pvc-sc-nil", "fake-claim-uid", "1Gi", pvName, v1.ClaimBound, nil)
+		clientSet = fakeclientset.NewSimpleClientset(claim, scNilClaim, pv, invalidClaim)
 
 		pluginCaps, controllerCaps := provisionFromPVCCapabilities()
 		if !tc.cloneSupport {
@@ -2457,6 +2532,19 @@ func TestProvisionFromPVC(t *testing.T) {
 			controllerServer.EXPECT().CreateVolume(gomock.Any(), gomock.Any()).Return(out, nil).Times(1)
 
 		}
+		if tc.restoredVolSizeSmall {
+			controllerServer.EXPECT().CreateVolume(gomock.Any(), gomock.Any()).Return(out, nil).Times(1)
+			// if the volume created is less than the requested size,
+			// deletevolume will be called
+			controllerServer.EXPECT().DeleteVolume(gomock.Any(), &csi.DeleteVolumeRequest{
+				VolumeId: "test-volume-id",
+			}).Return(&csi.DeleteVolumeResponse{}, nil).Times(1)
+		}
+
+		if tc.restoredVolSizeBig {
+			controllerServer.EXPECT().CreateVolume(gomock.Any(), gomock.Any()).Return(nil, errors.New("source volume size is bigger than requested volume size")).Times(1)
+		}
+
 		csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false)
 
 		pv, err := csiProvisioner.Provision(tc.volOpts)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

This fixes  the  issue in storageclass name comparison for PVC  creation with datasource=PersistanceVolumeClaim
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #308

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
