### PR TITLE
Ignore provisioning for in-tree volumes that have not been migrated

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -116,6 +116,8 @@ const (
 	tokenPVCNameSpaceKey = "pvc.namespace"
 
 	deleteVolumeRetryCount = 5
+
+	annStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
 )
 
 var (
@@ -367,6 +369,14 @@ func (p *csiProvisioner) Provision(options controller.ProvisionOptions) (*v1.Per
 func (p *csiProvisioner) ProvisionExt(options controller.ProvisionOptions) (*v1.PersistentVolume, controller.ProvisioningState, error) {
 	if options.StorageClass == nil {
 		return nil, controller.ProvisioningFinished, errors.New("storage class was nil")
+	}
+
+	if options.PVC.Annotations[annStorageProvisioner] != p.driverName {
+		return nil, controller.ProvisioningFinished, &controller.IgnoredError{
+			Reason: fmt.Sprintf("PVC annotated with external-provisioner name %s does not match provisioner driver name %s. This could mean the PVC is not migrated",
+				options.PVC.Annotations[annStorageProvisioner],
+				p.driverName),
+		}
 	}
 
 	migratedVolume := false


### PR DESCRIPTION
/kind bug

The provisioner just picks up any in-tree PVC that is related to the CSI Driver and treats it as a "migrated" PVC and continues to provision it. In reality it should use the annotation as a signal on whether the in-tree pv-controller has stood down or not (migrated or not).

/assign @jsafrane @msau42 @ddebroy 
/cc @leakingtapan

Fixes #340

```release-note
Fixes issue where provisioner provisions volumes for in-tree PVC's which have not been migrated
```
