### PR TITLE
Fixed  nil pointer dereference for Migration case

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -617,6 +617,8 @@ func (p *csiProvisioner) ProvisionExt(options controller.ProvisionOptions) (*v1.
 		pv.Spec.PersistentVolumeSource.CSI.FSType = fsType
 	}
 
+	klog.V(2).Infof("successfully created PV %v for PVC %v and csi volume name %v", pv.Name, options.PVC.Name, pv.Spec.CSI.VolumeHandle)
+
 	if migratedVolume {
 		pv, err = csitranslationlib.TranslateCSIPVToInTree(pv)
 		if err != nil {
@@ -631,7 +633,6 @@ func (p *csiProvisioner) ProvisionExt(options controller.ProvisionOptions) (*v1.
 		}
 	}
 
-	klog.V(2).Infof("successfully created PV %v for PVC %v and csi volume name %v", pv.Name, options.PVC.Name, pv.Spec.CSI.VolumeHandle)
 	klog.V(5).Infof("successfully created PV %+v", pv.Spec.PersistentVolumeSource)
 	return pv, controller.ProvisioningFinished, nil
 }


### PR DESCRIPTION
/kind bug

Should be cherry-picked to any version with this new log message.

This call prints out `pv.Spec.CSI.VolumeHandle` which has a nil pointer derefence when migrated since we translate the PV to an in-tree PV

/assign @msau42 @ddebroy @jsafrane 
/cc @leakingtapan @Madhu-1 

```release-note
Fixes nil pointer derefence in log when migration turned on
```
