### PR TITLE
Ignore non-migrated in-tree PVC when provisioning

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -208,7 +208,7 @@ func main() {
 		} else if *leaderElectionType == "leases" {
 			le = leaderelection.NewLeaderElection(clientset, lockName, run)
 		} else {
-			klog.Error("--leader-election-type must be either 'endpoints' or 'lease'")
+			klog.Error("--leader-election-type must be either 'endpoints' or 'leases'")
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
Cherry-pick of: https://github.com/kubernetes-csi/external-provisioner/pull/341/

/kind bug
/assign @jsafrane @msau42 
/cc @ddebroy @leakingtapan 

```release-note
Fixes issue where provisioner provisions volumes for in-tree PVC's which have not been migrated
```
