### PR TITLE
Ignore non-migrated in-tree PVC when provisioning

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -208,7 +208,7 @@ func main() {
 		} else if *leaderElectionType == "leases" {
 			le = leaderelection.NewLeaderElection(clientset, lockName, run)
 		} else {
-			klog.Error("--leader-election-type must be either 'endpoints' or 'lease'")
+			klog.Error("--leader-election-type must be either 'endpoints' or 'leases'")
 			os.Exit(1)
 		}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -113,6 +113,8 @@ const (
 	tokenPVNameKey       = "pv.name"
 	tokenPVCNameKey      = "pvc.name"
 	tokenPVCNameSpaceKey = "pvc.namespace"
+
+	annStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
 )
 
 var (
@@ -345,6 +347,14 @@ func (p *csiProvisioner) Provision(options controller.ProvisionOptions) (*v1.Per
 func (p *csiProvisioner) ProvisionExt(options controller.ProvisionOptions) (*v1.PersistentVolume, controller.ProvisioningState, error) {
 	if options.StorageClass == nil {
 		return nil, controller.ProvisioningFinished, errors.New("storage class was nil")
+	}
+
+	if options.PVC.Annotations[annStorageProvisioner] != p.driverName {
+		return nil, controller.ProvisioningFinished, &controller.IgnoredError{
+			Reason: fmt.Sprintf("PVC annotated with external-provisioner name %s does not match provisioner driver name %s. This could mean the PVC is not migrated",
+				options.PVC.Annotations[annStorageProvisioner],
+				p.driverName),
+		}
 	}
 
 	migratedVolume := false


### PR DESCRIPTION
Cherry-pick of: https://github.com/kubernetes-csi/external-provisioner/pull/341

/kind bug
/assign @jsafrane @msau42 
/cc @ddebroy @leakingtapan 

```release-note
Fixes issue where provisioner provisions volumes for in-tree PVC's which have not been migrated
```
