### PR TITLE
Bump csi-translation-lib to HEAD

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -764,14 +764,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:026d302ec8c8f568cb6805891133e749e2f8b6b94068cd7375a3bbba232c9f38"
+  digest = "1:43e7fcc63bba450c9dd05e6418ad85af74e60a19e9219095e9313625933b0ce6"
   name = "k8s.io/csi-translation-lib"
   packages = [
     ".",
     "plugins",
   ]
   pruneopts = "NUT"
-  revision = "9ff632302e7ee3b0b6118cd21569ce8b51f7f0f2"
+  revision = "636def22add93345a10eeb756b82e225dba2a6b8"
 
 [[projects]]
   digest = "1:c263611800c3a97991dbcf9d3bc4de390f6224aaa8ca0a7226a9d734f65a416a"

--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -43,7 +43,7 @@ import (
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utilflag "k8s.io/component-base/cli/flag"
-	csitranslationlib "k8s.io/csi-translation-lib"
+	csitrans "k8s.io/csi-translation-lib"
 )
 
 var (
@@ -169,9 +169,11 @@ func main() {
 		controller.CreateProvisionedPVLimiter(workqueue.DefaultControllerRateLimiter()),
 	}
 
+	translator := csitrans.New()
+
 	supportsMigrationFromInTreePluginName := ""
-	if csitranslationlib.IsMigratedCSIDriverByName(provisionerName) {
-		supportsMigrationFromInTreePluginName, err = csitranslationlib.GetInTreeNameFromCSIName(provisionerName)
+	if translator.IsMigratedCSIDriverByName(provisionerName) {
+		supportsMigrationFromInTreePluginName, err = translator.GetInTreeNameFromCSIName(provisionerName)
 		if err != nil {
 			klog.Fatalf("Failed to get InTree plugin name for migrated CSI plugin %s: %v", provisionerName, err)
 		}
@@ -181,7 +183,9 @@ func main() {
 
 	// Create the provisioner: it implements the Provisioner interface expected by
 	// the controller
-	csiProvisioner := ctrl.NewCSIProvisioner(clientset, *operationTimeout, identity, *volumeNamePrefix, *volumeNameUUIDLength, grpcClient, snapClient, provisionerName, pluginCapabilities, controllerCapabilities, supportsMigrationFromInTreePluginName, *strictTopology)
+	csiProvisioner := ctrl.NewCSIProvisioner(clientset, *operationTimeout, identity, *volumeNamePrefix,
+		*volumeNameUUIDLength, grpcClient, snapClient, provisionerName, pluginCapabilities,
+		controllerCapabilities, supportsMigrationFromInTreePluginName, *strictTopology, translator)
 	provisionController = controller.NewProvisionController(
 		clientset,
 		provisionerName,

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -51,6 +51,7 @@ import (
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 	utilfeaturetesting "k8s.io/component-base/featuregate/testing"
+	csitrans "k8s.io/csi-translation-lib"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
 )
 
@@ -398,7 +399,7 @@ func TestCreateDriverReturnsInvalidCapacityDuringProvision(t *testing.T) {
 	defer driver.Stop()
 
 	pluginCaps, controllerCaps := provisionCapabilities()
-	csiProvisioner := NewCSIProvisioner(nil, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false)
+	csiProvisioner := NewCSIProvisioner(nil, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, csitrans.New())
 
 	// Requested PVC with requestedBytes storage
 	deletePolicy := v1.PersistentVolumeReclaimDelete
@@ -1502,7 +1503,7 @@ func runProvisionTest(t *testing.T, k string, tc provisioningTestcase, requested
 	}
 
 	pluginCaps, controllerCaps := provisionCapabilities()
-	csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, provisionDriverName, pluginCaps, controllerCaps, supportsMigrationFromInTreePluginName, false)
+	csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, provisionDriverName, pluginCaps, controllerCaps, supportsMigrationFromInTreePluginName, false, csitrans.New())
 
 	out := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
@@ -2068,7 +2069,7 @@ func TestProvisionFromSnapshot(t *testing.T) {
 		})
 
 		pluginCaps, controllerCaps := provisionFromSnapshotCapabilities()
-		csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, client, driverName, pluginCaps, controllerCaps, "", false)
+		csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, client, driverName, pluginCaps, controllerCaps, "", false, csitrans.New())
 
 		out := &csi.CreateVolumeResponse{
 			Volume: &csi.Volume{
@@ -2237,7 +2238,7 @@ func TestProvisionWithTopologyEnabled(t *testing.T) {
 			}
 
 			clientSet := fakeclientset.NewSimpleClientset(nodes, nodeInfos)
-			csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false)
+			csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, csitrans.New())
 
 			pv, err := csiProvisioner.Provision(controller.ProvisionOptions{
 				StorageClass: &storagev1.StorageClass{},
@@ -2291,7 +2292,7 @@ func TestProvisionWithTopologyDisabled(t *testing.T) {
 
 	clientSet := fakeclientset.NewSimpleClientset()
 	pluginCaps, controllerCaps := provisionWithTopologyCapabilities()
-	csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false)
+	csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, csitrans.New())
 
 	out := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
@@ -2470,7 +2471,7 @@ func runDeleteTest(t *testing.T, k string, tc deleteTestcase) {
 	}
 
 	pluginCaps, controllerCaps := provisionCapabilities()
-	csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false)
+	csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, csitrans.New())
 
 	err = csiProvisioner.Delete(tc.persistentVolume)
 	if tc.expectErr && err == nil {
@@ -3125,7 +3126,7 @@ func TestProvisionFromPVC(t *testing.T) {
 			controllerServer.EXPECT().CreateVolume(gomock.Any(), gomock.Any()).Return(nil, errors.New("source volume size is bigger than requested volume size")).Times(1)
 		}
 
-		csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false)
+		csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, csitrans.New())
 
 		pv, err := csiProvisioner.Provision(tc.volOpts)
 		if tc.expectErr && err == nil {

--- a/vendor/k8s.io/csi-translation-lib/plugins/aws_ebs.go
+++ b/vendor/k8s.io/csi-translation-lib/plugins/aws_ebs.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -57,6 +58,10 @@ func (t *awsElasticBlockStoreCSITranslator) TranslateInTreeInlineVolumeToCSI(vol
 	}
 	ebsSource := volume.AWSElasticBlockStore
 	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			// A.K.A InnerVolumeSpecName required to match for Unmount
+			Name: volume.Name,
+		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				CSI: &v1.CSIPersistentVolumeSource{
@@ -122,7 +127,7 @@ func (t *awsElasticBlockStoreCSITranslator) TranslateCSIPVToInTree(pv *v1.Persis
 	if partition, ok := csiSource.VolumeAttributes["partition"]; ok {
 		partValue, err := strconv.Atoi(partition)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to convert partition %v to integer: %v", partition, err)
+			return nil, fmt.Errorf("failed to convert partition %v to integer: %v", partition, err)
 		}
 		ebsSource.Partition = int32(partValue)
 	}

--- a/vendor/k8s.io/csi-translation-lib/plugins/azure_disk.go
+++ b/vendor/k8s.io/csi-translation-lib/plugins/azure_disk.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -33,6 +34,7 @@ const (
 
 	// Parameter names defined in azure disk CSI driver, refer to
 	// https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/docs/driver-parameters.md
+	azureDiskKind        = "kind"
 	azureDiskCachingMode = "cachingMode"
 	azureDiskFSType      = "fsType"
 )
@@ -67,25 +69,34 @@ func (t *azureDiskCSITranslator) TranslateInTreeInlineVolumeToCSI(volume *v1.Vol
 
 	azureSource := volume.AzureDisk
 	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			// A.K.A InnerVolumeSpecName required to match for Unmount
+			Name: volume.Name,
+		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				CSI: &v1.CSIPersistentVolumeSource{
 					Driver:           AzureDiskDriverName,
 					VolumeHandle:     azureSource.DataDiskURI,
-					ReadOnly:         *azureSource.ReadOnly,
-					FSType:           *azureSource.FSType,
-					VolumeAttributes: map[string]string{},
+					VolumeAttributes: map[string]string{azureDiskKind: "Managed"},
 				},
 			},
 			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 		},
 	}
+	if azureSource.ReadOnly != nil {
+		pv.Spec.PersistentVolumeSource.CSI.ReadOnly = *azureSource.ReadOnly
+	}
 
-	if *azureSource.CachingMode != "" {
+	if azureSource.CachingMode != nil && *azureSource.CachingMode != "" {
 		pv.Spec.PersistentVolumeSource.CSI.VolumeAttributes[azureDiskCachingMode] = string(*azureSource.CachingMode)
 	}
-	if *azureSource.FSType != "" {
+	if azureSource.FSType != nil {
+		pv.Spec.PersistentVolumeSource.CSI.FSType = *azureSource.FSType
 		pv.Spec.PersistentVolumeSource.CSI.VolumeAttributes[azureDiskFSType] = *azureSource.FSType
+	}
+	if azureSource.Kind != nil {
+		pv.Spec.PersistentVolumeSource.CSI.VolumeAttributes[azureDiskKind] = string(*azureSource.Kind)
 	}
 
 	return pv, nil
@@ -106,15 +117,19 @@ func (t *azureDiskCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume)
 		VolumeHandle:     azureSource.DataDiskURI,
 		ReadOnly:         *azureSource.ReadOnly,
 		FSType:           *azureSource.FSType,
-		VolumeAttributes: map[string]string{},
+		VolumeAttributes: map[string]string{azureDiskKind: "Managed"},
 	}
 
-	if *azureSource.CachingMode != "" {
+	if azureSource.CachingMode != nil {
 		csiSource.VolumeAttributes[azureDiskCachingMode] = string(*azureSource.CachingMode)
 	}
 
-	if *azureSource.FSType != "" {
+	if azureSource.FSType != nil {
 		csiSource.VolumeAttributes[azureDiskFSType] = *azureSource.FSType
+	}
+
+	if azureSource.Kind != nil {
+		csiSource.VolumeAttributes[azureDiskKind] = string(*azureSource.Kind)
 	}
 
 	pv.Spec.PersistentVolumeSource.AzureDisk = nil
@@ -139,11 +154,13 @@ func (t *azureDiskCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume)
 	}
 
 	// refer to https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/docs/driver-parameters.md
+	managed := v1.AzureManagedDisk
 	azureSource := &v1.AzureDiskVolumeSource{
 		DiskName:    diskName,
 		DataDiskURI: diskURI,
 		FSType:      &csiSource.FSType,
 		ReadOnly:    &csiSource.ReadOnly,
+		Kind:        &managed,
 	}
 
 	if csiSource.VolumeAttributes != nil {
@@ -154,6 +171,11 @@ func (t *azureDiskCSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume)
 
 		if fsType, ok := csiSource.VolumeAttributes[azureDiskFSType]; ok && fsType != "" {
 			azureSource.FSType = &fsType
+		}
+
+		if kind, ok := csiSource.VolumeAttributes[azureDiskKind]; ok && kind != "" {
+			diskKind := v1.AzureDataDiskKind(kind)
+			azureSource.Kind = &diskKind
 		}
 	}
 

--- a/vendor/k8s.io/csi-translation-lib/plugins/azure_file.go
+++ b/vendor/k8s.io/csi-translation-lib/plugins/azure_file.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -63,6 +64,10 @@ func (t *azureFileCSITranslator) TranslateInTreeInlineVolumeToCSI(volume *v1.Vol
 	azureSource := volume.AzureFile
 
 	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			// A.K.A InnerVolumeSpecName required to match for Unmount
+			Name: volume.Name,
+		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				CSI: &v1.CSIPersistentVolumeSource{

--- a/vendor/k8s.io/csi-translation-lib/plugins/gce_pd.go
+++ b/vendor/k8s.io/csi-translation-lib/plugins/gce_pd.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudvolume "k8s.io/cloud-provider/volume"
 )
@@ -197,6 +198,10 @@ func (g *gcePersistentDiskCSITranslator) TranslateInTreeInlineVolumeToCSI(volume
 	}
 
 	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			// A.K.A InnerVolumeSpecName required to match for Unmount
+			Name: volume.Name,
+		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				CSI: &v1.CSIPersistentVolumeSource{

--- a/vendor/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
+++ b/vendor/k8s.io/csi-translation-lib/plugins/openstack_cinder.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -54,6 +55,10 @@ func (t *osCinderCSITranslator) TranslateInTreeInlineVolumeToCSI(volume *v1.Volu
 
 	cinderSource := volume.Cinder
 	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			// A.K.A InnerVolumeSpecName required to match for Unmount
+			Name: volume.Name,
+		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				CSI: &v1.CSIPersistentVolumeSource{

--- a/vendor/k8s.io/csi-translation-lib/translate.go
+++ b/vendor/k8s.io/csi-translation-lib/translate.go
@@ -35,9 +35,20 @@ var (
 	}
 )
 
+// CSITranslator translates in-tree storage API objects to their equivalent CSI
+// API objects. It also provides many helper functions to determine whether
+// translation logic exists and the mappings between "in-tree plugin <-> csi driver"
+type CSITranslator struct{}
+
+// New creates a new CSITranslator which does real translation
+// for "in-tree plugins <-> csi drivers"
+func New() CSITranslator {
+	return CSITranslator{}
+}
+
 // TranslateInTreeStorageClassToCSI takes in-tree Storage Class
 // and translates it to a set of parameters consumable by CSI plugin
-func TranslateInTreeStorageClassToCSI(inTreePluginName string, sc *storage.StorageClass) (*storage.StorageClass, error) {
+func (ctl CSITranslator) TranslateInTreeStorageClassToCSI(inTreePluginName string, sc *storage.StorageClass) (*storage.StorageClass, error) {
 	newSC := sc.DeepCopy()
 	for _, curPlugin := range inTreePlugins {
 		if inTreePluginName == curPlugin.GetInTreePluginName() {
@@ -50,7 +61,7 @@ func TranslateInTreeStorageClassToCSI(inTreePluginName string, sc *storage.Stora
 // TranslateInTreeInlineVolumeToCSI takes a inline volume and will translate
 // the in-tree volume source to a CSIPersistentVolumeSource (wrapped in a PV)
 // if the translation logic has been implemented.
-func TranslateInTreeInlineVolumeToCSI(volume *v1.Volume) (*v1.PersistentVolume, error) {
+func (ctl CSITranslator) TranslateInTreeInlineVolumeToCSI(volume *v1.Volume) (*v1.PersistentVolume, error) {
 	if volume == nil {
 		return nil, fmt.Errorf("persistent volume was nil")
 	}
@@ -66,7 +77,7 @@ func TranslateInTreeInlineVolumeToCSI(volume *v1.Volume) (*v1.PersistentVolume, 
 // the in-tree source to a CSI Source if the translation logic
 // has been implemented. The input persistent volume will not
 // be modified
-func TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+func (ctl CSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
 	if pv == nil {
 		return nil, errors.New("persistent volume was nil")
 	}
@@ -82,7 +93,7 @@ func TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, erro
 // TranslateCSIPVToInTree takes a PV with a CSI PersistentVolume Source and will translate
 // it to a in-tree Persistent Volume Source for the specific in-tree volume specified
 // by the `Driver` field in the CSI Source. The input PV object will not be modified.
-func TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+func (ctl CSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
 	if pv == nil || pv.Spec.CSI == nil {
 		return nil, errors.New("CSI persistent volume was nil")
 	}
@@ -97,7 +108,7 @@ func TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.PersistentVolume, erro
 
 // IsMigratableIntreePluginByName tests whether there is migration logic for the in-tree plugin
 // whose name matches the given name
-func IsMigratableIntreePluginByName(inTreePluginName string) bool {
+func (ctl CSITranslator) IsMigratableIntreePluginByName(inTreePluginName string) bool {
 	for _, curPlugin := range inTreePlugins {
 		if curPlugin.GetInTreePluginName() == inTreePluginName {
 			return true
@@ -108,7 +119,7 @@ func IsMigratableIntreePluginByName(inTreePluginName string) bool {
 
 // IsMigratedCSIDriverByName tests whether there exists an in-tree plugin with logic
 // to migrate to the CSI driver with given name
-func IsMigratedCSIDriverByName(csiPluginName string) bool {
+func (ctl CSITranslator) IsMigratedCSIDriverByName(csiPluginName string) bool {
 	if _, ok := inTreePlugins[csiPluginName]; ok {
 		return true
 	}
@@ -116,7 +127,7 @@ func IsMigratedCSIDriverByName(csiPluginName string) bool {
 }
 
 // GetInTreePluginNameFromSpec returns the plugin name
-func GetInTreePluginNameFromSpec(pv *v1.PersistentVolume, vol *v1.Volume) (string, error) {
+func (ctl CSITranslator) GetInTreePluginNameFromSpec(pv *v1.PersistentVolume, vol *v1.Volume) (string, error) {
 	if pv != nil {
 		for _, curPlugin := range inTreePlugins {
 			if curPlugin.CanSupport(pv) {
@@ -125,8 +136,12 @@ func GetInTreePluginNameFromSpec(pv *v1.PersistentVolume, vol *v1.Volume) (strin
 		}
 		return "", fmt.Errorf("could not find in-tree plugin name from persistent volume %v", pv)
 	} else if vol != nil {
-		// TODO(dyzz): Implement inline volume migration support
-		return "", errors.New("inline volume migration not yet supported")
+		for _, curPlugin := range inTreePlugins {
+			if curPlugin.CanSupportInline(vol) {
+				return curPlugin.GetInTreePluginName(), nil
+			}
+		}
+		return "", fmt.Errorf("could not find in-tree plugin name from volume %v", vol)
 	} else {
 		return "", errors.New("both persistent volume and volume are nil")
 	}
@@ -134,7 +149,7 @@ func GetInTreePluginNameFromSpec(pv *v1.PersistentVolume, vol *v1.Volume) (strin
 
 // GetCSINameFromInTreeName returns the name of a CSI driver that supersedes the
 // in-tree plugin with the given name
-func GetCSINameFromInTreeName(pluginName string) (string, error) {
+func (ctl CSITranslator) GetCSINameFromInTreeName(pluginName string) (string, error) {
 	for csiDriverName, curPlugin := range inTreePlugins {
 		if curPlugin.GetInTreePluginName() == pluginName {
 			return csiDriverName, nil
@@ -145,15 +160,15 @@ func GetCSINameFromInTreeName(pluginName string) (string, error) {
 
 // GetInTreeNameFromCSIName returns the name of the in-tree plugin superseded by
 // a CSI driver with the given name
-func GetInTreeNameFromCSIName(pluginName string) (string, error) {
+func (ctl CSITranslator) GetInTreeNameFromCSIName(pluginName string) (string, error) {
 	if plugin, ok := inTreePlugins[pluginName]; ok {
 		return plugin.GetInTreePluginName(), nil
 	}
-	return "", fmt.Errorf("Could not find In-Tree driver name for CSI plugin %v", pluginName)
+	return "", fmt.Errorf("could not find In-Tree driver name for CSI plugin %v", pluginName)
 }
 
 // IsPVMigratable tests whether there is migration logic for the given Persistent Volume
-func IsPVMigratable(pv *v1.PersistentVolume) bool {
+func (ctl CSITranslator) IsPVMigratable(pv *v1.PersistentVolume) bool {
 	for _, curPlugin := range inTreePlugins {
 		if curPlugin.CanSupport(pv) {
 			return true
@@ -163,7 +178,7 @@ func IsPVMigratable(pv *v1.PersistentVolume) bool {
 }
 
 // IsInlineMigratable tests whether there is Migration logic for the given Inline Volume
-func IsInlineMigratable(vol *v1.Volume) bool {
+func (ctl CSITranslator) IsInlineMigratable(vol *v1.Volume) bool {
 	for _, curPlugin := range inTreePlugins {
 		if curPlugin.CanSupportInline(vol) {
 			return true


### PR DESCRIPTION
Bumps the csi-translation-lib to head and makes it injectable. Contains some functional changes - none of which affect the behavior of the external-provisioner (except for the bug fix that did nil checks for Azure: https://github.com/kubernetes/kubernetes/pull/83249)

csi-translation-lib versioning TBA :)

/assign @misterikkit @msau42 
/cc @ddebroy 

/kind cleanup
/kind feature

```release-note
NONE
```
