### PR TITLE
Use v1.CSINode in the external-provisioner

### DIFF
--- a/.prow.sh
+++ b/.prow.sh
@@ -2,4 +2,26 @@
 
 . release-tools/prow.sh
 
+# This check assumes that the current configuration uses a driver deployment
+# which has been updated to use v1 APIs that aren't available in Kubernetes < 1.17.
+# TODO: The check can be removed when all Prow jobs for Kubernetes < 1.17 are removed.
+if ! (version_gt "${CSI_PROW_KUBERNETES_VERSION}" "1.16.255" || [ "${CSI_PROW_KUBERNETES_VERSION}" == "latest" ]); then
+    filtered_tests=
+    skipped_tests=
+    for test in ${CSI_PROW_TESTS}; do
+	case "$test" in
+	    parallel | parallel | serial | parallel-alpha | serial-alpha)
+		skipped_tests="$skipped_tests $test"
+		;;
+	    *)
+		filtered_tests="$filtered_tests $test"
+		;;
+	esac
+    done
+    if [ "$skipped_tests" ]; then
+	info "Testing on Kubernetes ${CSI_PROW_KUBERNETES_VERSION} is no longer supported. Skipping CSI_PROW_TESTS: $skipped_tests."
+	CSI_PROW_TESTS="$filtered_tests"
+    fi
+fi
+
 main

--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -45,7 +45,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	v1 "k8s.io/client-go/listers/core/v1"
-	storagelistersv1beta1 "k8s.io/client-go/listers/storage/v1beta1"
+	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
 	utilflag "k8s.io/component-base/cli/flag"
 	csitrans "k8s.io/csi-translation-lib"
 )
@@ -181,10 +181,10 @@ func main() {
 	scLister := factory.Storage().V1().StorageClasses().Lister()
 	claimLister := factory.Core().V1().PersistentVolumeClaims().Lister()
 
-	var csiNodeLister storagelistersv1beta1.CSINodeLister
+	var csiNodeLister storagelistersv1.CSINodeLister
 	var nodeLister v1.NodeLister
 	if ctrl.SupportsTopology(pluginCapabilities) {
-		csiNodeLister = factory.Storage().V1beta1().CSINodes().Lister()
+		csiNodeLister = factory.Storage().V1().CSINodes().Lister()
 		nodeLister = factory.Core().V1().Nodes().Lister()
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -44,7 +44,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
-	storagelistersv1beta1 "k8s.io/client-go/listers/storage/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v5/controller"
@@ -217,7 +216,7 @@ type csiProvisioner struct {
 	strictTopology                        bool
 	translator                            ProvisionerCSITranslator
 	scLister                              storagelistersv1.StorageClassLister
-	csiNodeLister                         storagelistersv1beta1.CSINodeLister
+	csiNodeLister                         storagelistersv1.CSINodeLister
 	nodeLister                            corelisters.NodeLister
 	claimLister                           corelisters.PersistentVolumeClaimLister
 	extraCreateMetadata                   bool
@@ -282,7 +281,7 @@ func NewCSIProvisioner(client kubernetes.Interface,
 	strictTopology bool,
 	translator ProvisionerCSITranslator,
 	scLister storagelistersv1.StorageClassLister,
-	csiNodeLister storagelistersv1beta1.CSINodeLister,
+	csiNodeLister storagelistersv1.CSINodeLister,
 	nodeLister corelisters.NodeLister,
 	claimLister corelisters.PersistentVolumeClaimLister,
 	extraCreateMetadata bool,

--- a/pkg/controller/topology.go
+++ b/pkg/controller/topology.go
@@ -28,14 +28,14 @@ import (
 	"github.com/kubernetes-csi/csi-lib-utils/rpc"
 	"github.com/kubernetes-csi/external-provisioner/pkg/features"
 	v1 "k8s.io/api/core/v1"
-	storage "k8s.io/api/storage/v1beta1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	storagelisters "k8s.io/client-go/listers/storage/v1beta1"
+	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/klog"
 )
 
@@ -153,12 +153,12 @@ func GenerateAccessibilityRequirements(
 	allowedTopologies []v1.TopologySelectorTerm,
 	selectedNode *v1.Node,
 	strictTopology bool,
-	csiNodeLister storagelisters.CSINodeLister,
+	csiNodeLister storagelistersv1.CSINodeLister,
 	nodeLister corelisters.NodeLister) (*csi.TopologyRequirement, error) {
 	requirement := &csi.TopologyRequirement{}
 
 	var (
-		selectedCSINode  *storage.CSINode
+		selectedCSINode  *storagev1.CSINode
 		selectedTopology topologyTerm
 		requisiteTerms   []topologyTerm
 		err              error
@@ -277,8 +277,8 @@ func GenerateAccessibilityRequirements(
 
 // getSelectedCSINode returns the CSINode object for the given selectedNode.
 func getSelectedCSINode(
-	csiNodeLister storagelisters.CSINodeLister,
-	selectedNode *v1.Node) (*storage.CSINode, error) {
+	csiNodeLister storagelistersv1.CSINodeLister,
+	selectedNode *v1.Node) (*storagev1.CSINode, error) {
 
 	selectedCSINode, err := csiNodeLister.Get(selectedNode.Name)
 	if err != nil {
@@ -310,8 +310,8 @@ func getSelectedCSINode(
 func aggregateTopologies(
 	kubeClient kubernetes.Interface,
 	driverName string,
-	selectedCSINode *storage.CSINode,
-	csiNodeLister storagelisters.CSINodeLister,
+	selectedCSINode *storagev1.CSINode,
+	csiNodeLister storagelistersv1.CSINodeLister,
 	nodeLister corelisters.NodeLister) ([]topologyTerm, error) {
 
 	// 1. Determine topologyKeys to use for aggregation
@@ -489,7 +489,7 @@ func sortAndShift(terms []topologyTerm, primary topologyTerm, shiftIndex uint32)
 	return preferredTerms
 }
 
-func getTopologyKeys(csiNode *storage.CSINode, driverName string) []string {
+func getTopologyKeys(csiNode *storagev1.CSINode, driverName string) []string {
 	for _, driver := range csiNode.Spec.Drivers {
 		if driver.Name == driverName {
 			return driver.TopologyKeys

--- a/pkg/controller/topology_test.go
+++ b/pkg/controller/topology_test.go
@@ -22,15 +22,13 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	v1 "k8s.io/api/core/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
-
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
-	storagelistersv1beta1 "k8s.io/client-go/listers/storage/v1beta1"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
 )
 
@@ -1473,19 +1471,19 @@ func buildNodes(nodeLabels []map[string]string, nodeVersion string) *v1.NodeList
 	return list
 }
 
-func buildCSINodes(csiNodes []map[string][]string) *storagev1beta1.CSINodeList {
-	list := &storagev1beta1.CSINodeList{}
+func buildCSINodes(csiNodes []map[string][]string) *storagev1.CSINodeList {
+	list := &storagev1.CSINodeList{}
 	i := 0
 	for _, csiNode := range csiNodes {
 		nodeName := fmt.Sprintf("node-%d", i)
-		n := storagev1beta1.CSINode{
+		n := storagev1.CSINode{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: nodeName,
 			},
 		}
-		var csiDrivers []storagev1beta1.CSINodeDriver
+		var csiDrivers []storagev1.CSINodeDriver
 		for driver, topologyKeys := range csiNode {
-			driverInfos := []storagev1beta1.CSINodeDriver{
+			driverInfos := []storagev1.CSINodeDriver{
 				{
 					Name:         driver,
 					NodeID:       nodeName,
@@ -1499,7 +1497,7 @@ func buildCSINodes(csiNodes []map[string][]string) *storagev1beta1.CSINodeList {
 			}
 			csiDrivers = append(csiDrivers, driverInfos...)
 		}
-		n.Spec = storagev1beta1.CSINodeSpec{Drivers: csiDrivers}
+		n.Spec = storagev1.CSINodeSpec{Drivers: csiDrivers}
 		list.Items = append(list.Items, n)
 		i++
 	}
@@ -1621,14 +1619,14 @@ func requisiteEqual(t1, t2 []*csi.Topology) bool {
 
 func listers(kubeClient *fakeclientset.Clientset) (
 	storagelistersv1.StorageClassLister,
-	storagelistersv1beta1.CSINodeLister,
+	storagelistersv1.CSINodeLister,
 	corelisters.NodeLister,
 	corelisters.PersistentVolumeClaimLister,
 	chan struct{}) {
 	factory := informers.NewSharedInformerFactory(kubeClient, ResyncPeriodOfCsiNodeInformer)
 	stopChan := make(chan struct{})
 	scLister := factory.Storage().V1().StorageClasses().Lister()
-	csiNodeLister := factory.Storage().V1beta1().CSINodes().Lister()
+	csiNodeLister := factory.Storage().V1().CSINodes().Lister()
 	nodeLister := factory.Core().V1().Nodes().Lister()
 	claimLister := factory.Core().V1().PersistentVolumeClaims().Lister()
 	factory.Start(stopChan)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR updates the external provisioner to use the GA version of the CSINode object.

**Which issue(s) this PR fixes**:

Fixes #385

**Does this PR introduce a user-facing change?**:

```release-note
Use GA version of CSINode object.
```
