### PR TITLE
Support make container on arm64 architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM gcr.io/distroless/static:latest
+ARG BASE_IMAGE=gcr.io/distroless/static:latest
+FROM $BASE_IMAGE
 LABEL maintainers="Kubernetes Authors"
 LABEL description="CSI External Provisioner"
 

--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -63,6 +63,7 @@ endif
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
 
 # Specific BASE_IMAGE for different arch, default BASE_IMAGE gcr.io/distroless is for x86, discolix/static is for arm.
+BASE_IMAGE=gcr.io/distroless/static:latest
 ifeq (${ARCH}, arm64)
   BASE_IMAGE=discolix/static:latest
 endif

--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -62,6 +62,11 @@ endif
 
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
 
+# Specific BASE_IMAGE for different arch, default BASE_IMAGE gcr.io/distroless is for x86, discolix/static is for arm.
+ifeq (${ARCH}, arm64)
+  BASE_IMAGE=discolix/static:latest
+endif
+
 # Specific packages can be excluded from each of the tests below by setting the *_FILTER_CMD variables
 # to something like "| grep -v 'github.com/kubernetes-csi/project/pkg/foobar'". See usage below.
 
@@ -73,7 +78,7 @@ build-%: check-go-version-go
 	fi
 
 container-%: build-%
-	docker build -t $*:latest -f $(shell if [ -e ./cmd/$*/Dockerfile ]; then echo ./cmd/$*/Dockerfile; else echo Dockerfile; fi) --label revision=$(REV) .
+	docker build -t $*:latest -f $(shell if [ -e ./cmd/$*/Dockerfile ]; then echo ./cmd/$*/Dockerfile; else echo Dockerfile; fi) --label revision=$(REV) --build-arg BASE_IMAGE=${BASE_IMAGE} .
 
 push-%: container-%
 	set -ex; \


### PR DESCRIPTION
Signed-off-by: wangzihao <wangzihao18@huawei.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Add support for multi-arch
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #381

**Special notes for your reviewer**:
use Kunpeng920(arm) and Xeon 6148(x86) to test building.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- Replace gcr.io/distroless/static:latest with BASE_IMAGE in Dockerfile. And judge the arch in build.make, set BASE_IMAGE to discolix/static:latest when ARCH is arm64.
```
