### PR TITLE
Remove Brad Childs from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,4 @@
 approvers:
-- childsb
 - jsafrane
 - lpabon
 - msau42


### PR DESCRIPTION
This PR remove Brad Childs' github ID from the OWNERS files where it appears.

Associated with kubernetes/community#4418