### PR TITLE
Make fstype configurable in external provisioner

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -71,7 +71,7 @@ var (
 	metricsAddress = flag.String("metrics-address", "", "The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled.")
 	metricsPath    = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
 
-	defaultFSType = flag.String("default-fstype", "ext4", "Specify the filesystem type of the volume. If not specified,  external-provisioner will set default as `ext4`.")
+	defaultFSType = flag.String("default-fstype", "", "Specify the filesystem type of the volume. If not specified,  external-provisioner will not set any default filesystem type.")
 
 	featureGates        map[string]bool
 	provisionController *controller.ProvisionController

--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -71,7 +71,7 @@ var (
 	metricsAddress = flag.String("metrics-address", "", "The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled.")
 	metricsPath    = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
 
-	defaultFSType = flag.String("default-fstype", "", "Specify the filesystem type of the volume. If not specified,  external-provisioner will not set any default filesystem type.")
+	defaultFSType = flag.String("default-fstype", "", "The default filesystem type of the volume to provision when fstype is unspecified in the StorageClass. If the default is not set and fstype is unset in the StorageClass, then no fstype will be set")
 
 	featureGates        map[string]bool
 	provisionController *controller.ProvisionController

--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -26,28 +26,25 @@ import (
 	"strings"
 	"time"
 
-	flag "github.com/spf13/pflag"
-
 	"github.com/kubernetes-csi/csi-lib-utils/deprecatedflags"
 	"github.com/kubernetes-csi/csi-lib-utils/leaderelection"
 	"github.com/kubernetes-csi/csi-lib-utils/metrics"
 	ctrl "github.com/kubernetes-csi/external-provisioner/pkg/controller"
 	snapclientset "github.com/kubernetes-csi/external-snapshotter/pkg/client/clientset/versioned"
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/v5/controller"
-
+	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/listers/core/v1"
+	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
-
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/client-go/informers"
-	v1 "k8s.io/client-go/listers/core/v1"
-	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
 	utilflag "k8s.io/component-base/cli/flag"
 	csitrans "k8s.io/csi-translation-lib"
+	"k8s.io/klog"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v5/controller"
 )
 
 var (
@@ -73,6 +70,8 @@ var (
 
 	metricsAddress = flag.String("metrics-address", "", "The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled.")
 	metricsPath    = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
+
+	defaultFSType = flag.String("default-fstype", "ext4", "Specify the filesystem type of the volume. If not specified,  external-provisioner will set default as `ext4`.")
 
 	featureGates        map[string]bool
 	provisionController *controller.ProvisionController
@@ -240,6 +239,7 @@ func main() {
 		claimLister,
 		vaLister,
 		*extraCreateMetadata,
+		*defaultFSType,
 	)
 
 	provisionController = controller.NewProvisionController(

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -116,8 +116,6 @@ const (
 	backoffFactor   = 1.2
 	backoffSteps    = 10
 
-	defaultFSType = "ext4"
-
 	snapshotKind     = "VolumeSnapshot"
 	snapshotAPIGroup = snapapi.GroupName       // "snapshot.storage.k8s.io"
 	pvcKind          = "PersistentVolumeClaim" // Native types don't require an API group
@@ -211,6 +209,7 @@ type csiProvisioner struct {
 	timeout                               time.Duration
 	identity                              string
 	volumeNamePrefix                      string
+	defaultFSType                         string
 	volumeNameUUIDLength                  int
 	config                                *rest.Config
 	driverName                            string
@@ -292,6 +291,7 @@ func NewCSIProvisioner(client kubernetes.Interface,
 	claimLister corelisters.PersistentVolumeClaimLister,
 	vaLister storagelistersv1.VolumeAttachmentLister,
 	extraCreateMetadata bool,
+	defaultFSType string,
 ) controller.Provisioner {
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartLogging(klog.Infof)
@@ -307,6 +307,7 @@ func NewCSIProvisioner(client kubernetes.Interface,
 		timeout:                               connectionTimeout,
 		identity:                              identity,
 		volumeNamePrefix:                      volumeNamePrefix,
+		defaultFSType:                         defaultFSType,
 		volumeNameUUIDLength:                  volumeNameUUIDLength,
 		driverName:                            driverName,
 		pluginCapabilities:                    pluginCapabilities,
@@ -518,8 +519,8 @@ func (p *csiProvisioner) ProvisionExt(options controller.ProvisionOptions) (*v1.
 	if fsTypesFound > 1 {
 		return nil, controller.ProvisioningFinished, fmt.Errorf("fstype specified in parameters with both \"fstype\" and \"%s\" keys", prefixedFsTypeKey)
 	}
-	if len(fsType) == 0 {
-		fsType = defaultFSType
+	if fsType == "" && p.defaultFSType != "none" {
+		fsType = p.defaultFSType
 	}
 
 	capacity := options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -519,7 +519,7 @@ func (p *csiProvisioner) ProvisionExt(options controller.ProvisionOptions) (*v1.
 	if fsTypesFound > 1 {
 		return nil, controller.ProvisioningFinished, fmt.Errorf("fstype specified in parameters with both \"fstype\" and \"%s\" keys", prefixedFsTypeKey)
 	}
-	if fsType == "" && p.defaultFSType != "none" {
+	if fsType == "" && p.defaultFSType != "" {
 		fsType = p.defaultFSType
 	}
 


### PR DESCRIPTION
At present the fstype is set to `ext4` if nothing is passed in storage-class.
However a SP could prefer to have different fstype for many reasons for their
driver/volumes. This patch enables SP who is using the external-provisioner
to choose the  fstype which they want to have it.

Fix# https://github.com/kubernetes-csi/external-provisioner/issues/328

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

> /kind bug

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
 The `defaultFStype` arg is no longer default to "ext4" filesystem type. This arg is available for SP's to use when they deploy provisioner sidecar. Admins can also specify this fstype via storage class parameter. If `fstype` is set in storage class parameter, it will be used. The sidecar arg is only checked if fstype is not set in the SC param.

-->
```release-note
 The `defaultFStype` arg is no longer default to "ext4" filesystem type. This arg is available for SP to use when they deploy provisioner sidecar. Admins can also specify this `fstype` via storage class parameter. If `fstype` is set in storage class parameter, it will be used. The sidecar arg is only checked if fstype is not set in the SC param.
```
