### PR TITLE
Add more tests for provsionsing from PVC as DataSource

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -822,6 +822,11 @@ func (p *csiProvisioner) getPVCSource(options controller.ProvisionOptions) (*csi
 		return nil, fmt.Errorf("claim in dataSource not bound or invalid")
 	}
 
+	if sourcePV.Status.Phase != v1.VolumeBound {
+		klog.Warningf("the source volume %s for PVC %s/%s status is \"%s\", should instead be \"%s\"", sourcePVC.Spec.VolumeName, sourcePVC.Namespace, sourcePVC.Name, sourcePV.Status.Phase, v1.VolumeBound)
+		return nil, fmt.Errorf("claim in dataSource not bound or invalid")
+	}
+
 	volumeSource := csi.VolumeContentSource_Volume{
 		Volume: &csi.VolumeContentSource_VolumeSource{
 			VolumeId: sourcePV.Spec.CSI.VolumeHandle,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This commit adds 6 more tests to the existing unit tests
for creating PVC given a DataSource as another PVC, IOW
cloning feature.

The tests are added in 2 categories,
- When source PVCs Status.Phase is different than,
  ClaimBound
- When clone PV source's Status.Phase is other than,
  VolumeBound

The tests did open up a code issue, where PV Status was
not checked for VolumeBound status. This is also fixed
in this commit.

Tested using `make test-go` against go compiler
version go1.13.6 linux/amd64

**Which issue(s) this PR fixes**:
NA, Added to help move clone feature to GA.

**Special notes for your reviewer**:
- If PV `Spec.ClaimRef` is non-nil, can `Status.Phase` be anything other than bound? IOW, is this test valid and needed?

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
