### PR TITLE
Cleanup and fix, clone unit tests

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -783,10 +783,13 @@ func (p *csiProvisioner) getPVCSource(options controller.ProvisionOptions) (*csi
 		return nil, fmt.Errorf("the source PVC and destination PVCs must be in the same storage class for cloning.  Source is in %v, but new PVC is in %v",
 			*sourcePVC.Spec.StorageClassName, *options.PVC.Spec.StorageClassName)
 	}
+
 	capacity := options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	requestedSize := capacity.Value()
-	if requestedSize < int64(sourcePVC.Spec.Size()) {
-		return nil, fmt.Errorf("error, new PVC request must be greater than or equal in size to the specified PVC data source, requested %v but source is %v", requestedSize, sourcePVC.Spec.Size())
+	srcCapacity := sourcePVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
+	srcPVCSize := srcCapacity.Value()
+	if requestedSize < srcPVCSize {
+		return nil, fmt.Errorf("error, new PVC request must be greater than or equal in size to the specified PVC data source, requested %v but source is %v", requestedSize, srcPVCSize)
 	}
 
 	if sourcePVC.Spec.VolumeName == "" {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
There was quite a bit of repetitive code in each test case definition,
this has been cleaned up. Further following changes were done as some failures
during the cleanup were noted,

- Corrected size checks in controller.go, to use sourcePVC size instead
of gRPC payload size for comparison
- Updated fakeClaim in controller_test.go, to reflect correct sourcePVC
size (instead of defaulting to 1Gi for a 1000 byte request)
- Defined and reused a defaultPVCRequest across tests
- Removed unused test case struct elements
- Removed restating default test case parameters per test
- Refactored core test case loop into phases, and removed any duplicate
calls/variables
- Corrected expected RPC calls when sourcePVC size is greater than
requestedPVC

Tested for flakes by running the following bash loop,
for i in {1..50}; do go clean -testcache; make test-go; done

Tested using, go version go1.13.6 linux/amd64

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
- Should we add checks in the code to prevent a CreateVolume->DeleteVolume set of calls when the requested PVC size is greater than source PVC?
    - IOW, avoid hitting [this](https://github.com/kubernetes-csi/external-provisioner/blob/40297715f5409a617c35b2aa29f1c812df63dc29/pkg/controller/controller.go#L619-L630) condition when DataSource is a PVC and we know the sizes mismatch, by checking ahead [here](https://github.com/kubernetes-csi/external-provisioner/blob/40297715f5409a617c35b2aa29f1c812df63dc29/pkg/controller/controller.go#L786-L790).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
