### PR TITLE
Document correct flag name for --extra-create-metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Note that the external-provisioner does not scale with more replicas. Only one e
 
 * `--metrics-path`: The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.
 
-* `--extraCreateMetadata`: Enables the injection of extra PVC and PV metadata as parameters when calling `CreateVolume` on the driver (keys: "csi.storage.k8s.io/pvc/name", "csi.storage.k8s.io/pvc/namespace", "csi.storage.k8s.io/pv/name") 
+* `--extra-create-metadata`: Enables the injection of extra PVC and PV metadata as parameters when calling `CreateVolume` on the driver (keys: "csi.storage.k8s.io/pvc/name", "csi.storage.k8s.io/pvc/namespace", "csi.storage.k8s.io/pv/name") 
 
 #### Other recognized arguments
 * `--feature-gates <gates>`: A set of comma separated `<feature-name>=<true|false>` pairs that describe feature gates for alpha/experimental features. See [list of features](#feature-status) or `--help` output for list of recognized features. Example: `--feature-gates Topology=true` to enable Topology feature that's disabled by default.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Incorrect documentation for the new feature flag.

**Which issue(s) this PR fixes**:
No issues currently open for this.

Logs using current docs:
```
unknown flag: --extraCreateMetadata
Usage of /csi-provisioner:
...
      --extra-create-metadata              If set, add pv/pvc metadata to plugin create requests as parameters.
...
```

```release-note
NONE
```