### PR TITLE
extraCreateMetadata support labels/annotations

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -607,6 +607,13 @@ func (p *csiProvisioner) ProvisionExt(options controller.ProvisionOptions) (*v1.
 		req.Parameters[pvcNameKey] = options.PVC.GetName()
 		req.Parameters[pvcNamespaceKey] = options.PVC.GetNamespace()
 		req.Parameters[pvNameKey] = pvName
+		// add pvc labels/annotations to request for use by the plugin
+		for key, value := range options.PVC.Annotations {
+			req.Parameters[key] = value
+		}
+		for key, value := range options.PVC.Labels {
+			req.Parameters[key] = value
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), p.timeout)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
>
> /kind feature

**What this PR does / why we need it**:

> Currently, CSI controller cannot get any extra configuration from pvc. But in some situations, user need define configurations in pvc, not only in storageclass.
>
> extraCreateMetadata provide the way to add extra pvc metadata to controller server, but not labels or annotations. This feature is to achieve that.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
no need to change current configuration. extraCreateMetadata is added info for controller server. No effect for plugin if user not use it.
```
