### PR TITLE
Start clone protection only when capability matches

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -253,6 +253,7 @@ func main() {
 		claimLister,
 		claimInformer,
 		claimQueue,
+		controllerCapabilities,
 	)
 
 	run := func(context.Context) {
@@ -265,7 +266,9 @@ func main() {
 			}
 		}
 
-		go csiClaimController.Run(int(*finalizerThreads), stopCh)
+		if csiClaimController != nil {
+			go csiClaimController.Run(int(*finalizerThreads), stopCh)
+		}
 		provisionController.Run(wait.NeverStop)
 	}
 

--- a/pkg/controller/clone_controller.go
+++ b/pkg/controller/clone_controller.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-csi/csi-lib-utils/rpc"
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -43,7 +45,11 @@ func NewCloningProtectionController(
 	claimLister corelisters.PersistentVolumeClaimLister,
 	claimInformer cache.SharedInformer,
 	claimQueue workqueue.RateLimitingInterface,
+	controllerCapabilities rpc.ControllerCapabilitySet,
 ) *CloningProtectionController {
+	if !controllerCapabilities[csi.ControllerServiceCapability_RPC_CLONE_VOLUME] {
+		return nil
+	}
 	controller := &CloningProtectionController{
 		client:        client,
 		claimLister:   claimLister,

--- a/pkg/controller/clone_controller_test.go
+++ b/pkg/controller/clone_controller_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-csi/csi-lib-utils/rpc"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -176,6 +178,9 @@ func TestEnqueueClaimUpadate(t *testing.T) {
 
 func fakeCloningProtector(client *fakeclientset.Clientset, objects ...runtime.Object) *CloningProtectionController {
 	utilruntime.ReallyCrash = false
+	controllerCapabilities := rpc.ControllerCapabilitySet{
+		csi.ControllerServiceCapability_RPC_CLONE_VOLUME: true,
+	}
 
 	informerFactory := informers.NewSharedInformerFactory(client, 1*time.Second)
 	claimInformer := informerFactory.Core().V1().PersistentVolumeClaims().Informer()
@@ -195,5 +200,6 @@ func fakeCloningProtector(client *fakeclientset.Clientset, objects ...runtime.Ob
 		claimLister,
 		claimInformer,
 		claimQueue,
+		controllerCapabilities,
 	)
 }


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug


**What this PR does / why we need it**:

Adds a capability check, to prevent cloning protection from starting, when `CLONE_VOLUME` is not set on the driver.

**Which issue(s) this PR fixes**:

Fixes #431 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
