### PR TITLE
Add VolumeAttachment Lister to CSI Provisioner

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -182,6 +182,7 @@ func main() {
 	claimLister := factory.Core().V1().PersistentVolumeClaims().Lister()
 
 	var csiNodeLister storagelistersv1.CSINodeLister
+	vaLister := factory.Storage().V1().VolumeAttachments().Lister()
 	var nodeLister v1.NodeLister
 	if ctrl.SupportsTopology(pluginCapabilities) {
 		csiNodeLister = factory.Storage().V1().CSINodes().Lister()
@@ -237,6 +238,7 @@ func main() {
 		csiNodeLister,
 		nodeLister,
 		claimLister,
+		vaLister,
 		*extraCreateMetadata,
 	)
 

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -50,6 +50,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding

--- a/pkg/controller/topology_test.go
+++ b/pkg/controller/topology_test.go
@@ -393,7 +393,7 @@ func TestStatefulSetSpreading(t *testing.T) {
 
 	kubeClient := fakeclientset.NewSimpleClientset(nodes, csiNodes)
 
-	_, csiNodeLister, nodeLister, _, stopChan := listers(kubeClient)
+	_, csiNodeLister, nodeLister, _, _, stopChan := listers(kubeClient)
 	defer close(stopChan)
 
 	for name, tc := range testcases {
@@ -1083,7 +1083,7 @@ func TestTopologyAggregation(t *testing.T) {
 
 			kubeClient := fakeclientset.NewSimpleClientset(nodes, csiNodes)
 
-			_, csiNodeLister, nodeLister, _, stopChan := listers(kubeClient)
+			_, csiNodeLister, nodeLister, _, _, stopChan := listers(kubeClient)
 			defer close(stopChan)
 
 			var selectedNode *v1.Node
@@ -1403,7 +1403,7 @@ func TestPreferredTopologies(t *testing.T) {
 			kubeClient := fakeclientset.NewSimpleClientset(nodes, csiNodes)
 			selectedNode := &nodes.Items[0]
 
-			_, csiNodeLister, nodeLister, _, stopChan := listers(kubeClient)
+			_, csiNodeLister, nodeLister, _, _, stopChan := listers(kubeClient)
 			defer close(stopChan)
 
 			requirements, err := GenerateAccessibilityRequirements(
@@ -1622,6 +1622,7 @@ func listers(kubeClient *fakeclientset.Clientset) (
 	storagelistersv1.CSINodeLister,
 	corelisters.NodeLister,
 	corelisters.PersistentVolumeClaimLister,
+	storagelistersv1.VolumeAttachmentLister,
 	chan struct{}) {
 	factory := informers.NewSharedInformerFactory(kubeClient, ResyncPeriodOfCsiNodeInformer)
 	stopChan := make(chan struct{})
@@ -1629,7 +1630,8 @@ func listers(kubeClient *fakeclientset.Clientset) (
 	csiNodeLister := factory.Storage().V1().CSINodes().Lister()
 	nodeLister := factory.Core().V1().Nodes().Lister()
 	claimLister := factory.Core().V1().PersistentVolumeClaims().Lister()
+	vaLister := factory.Storage().V1().VolumeAttachments().Lister()
 	factory.Start(stopChan)
 	factory.WaitForCacheSync(stopChan)
-	return scLister, csiNodeLister, nodeLister, claimLister, stopChan
+	return scLister, csiNodeLister, nodeLister, claimLister, vaLister, stopChan
 }


### PR DESCRIPTION
This change prevents calling DeleteVolume on the CSI plugin for volumes that are still attached to a kubernetes node.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Currently, external-provisioner does not check if a volume is attached to a node before trying to delete it. 
This can happen when there's a race between Pod and PVC deletion (like deleting a ns). 
NOTE: PVC protection does not apply here because the Pod is deleted from k8s, but the volume is still attached. 

Based on discussion in https://github.com/kubernetes/kubernetes/issues/84226, this change adds a volumeattachment lister to verify if a volume is still attached to a node before attempting to delete it. 

Testing:

Deleting a volume that is not attached to a node works as expected:

```
{"log":"I0513 18:32:21.365637       1 controller.go:1422] delete \"pvc-80f3eaf0-e4f5-487a-a048-1e884a5ee13b\": started\n","stream":"stderr","time":"2020-05-13T18:32:21.372039744Z"}
{"log":"I0513 18:32:23.737215       1 controller.go:1450] delete \"pvc-80f3eaf0-e4f5-487a-a048-1e884a5ee13b\": volume deleted\n","stream":"stderr","time":"2020-05-13T18:32:23.739834928Z"}
{"log":"I0513 18:32:23.758050       1 controller.go:1496] delete \"pvc-80f3eaf0-e4f5-487a-a048-1e884a5ee13b\": persistentvolume deleted\n","stream":"stderr","time":"2020-05-13T18:32:23.758428374Z"}
{"log":"I0513 18:32:23.759194       1 controller.go:1498] delete \"pvc-80f3eaf0-e4f5-487a-a048-1e884a5ee13b\": succeeded\n","stream":"stderr","time":"2020-05-13T18:32:23.759331067Z"}
```

Deleting the namespace and creating a race between detach and delete:

```
{"log":"I0513 18:41:53.980570       1 controller.go:1422] delete \"pvc-fce3b92c-093f-4a74-86f7-1fc9cb6d3be0\": started\n","stream":"stderr","time":"2020-05-13T18:41:53.98129317Z"}
{"log":"E0513 18:41:53.986309       1 controller.go:1445] delete \"pvc-fce3b92c-093f-4a74-86f7-1fc9cb6d3be0\": volume deletion failed: persistentvolume pvc-fce3b92c-093f-4a74-86f7-1fc9cb6d3be0 is still attached to node k8s-node-0572\n","stream":"stderr","time":"2020-05-13T18:41:53.986566278Z"}
{"log":"W0513 18:41:53.986780       1 controller.go:965] Retrying syncing volume \"pvc-fce3b92c-093f-4a74-86f7-1fc9cb6d3be0\", failure 0\n","stream":"stderr","time":"2020-05-13T18:41:53.986890274Z"}
{"log":"E0513 18:41:53.987122       1 controller.go:983] error syncing volume \"pvc-fce3b92c-093f-4a74-86f7-1fc9cb6d3be0\": persistentvolume pvc-fce3b92c-093f-4a74-86f7-1fc9cb6d3be0 is still attached to node k8s-node-0572\n","stream":"stderr","time":"2020-05-13T18:41:53.987286288Z"}
{"log":"I0513 18:41:53.987990       1 event.go:281] Event(v1.ObjectReference{Kind:\"PersistentVolume\", Namespace:\"\", Name:\"pvc-fce3b92c-093f-4a74-86f7-1fc9cb6d3be0\", UID:\"79fa52d2-ccdd-49cf-a3ed-e5eb081528af\", APIVersion:\"v1\", ResourceVersion:\"5383\", FieldPath:\"\"}): type: 'Warning' reason: 'VolumeFailedDelete' persistentvolume pvc-fce3b92c-093f-4a74-86f7-1fc9cb6d3be0 is still attached to node k8s-node-0572\n","stream":"stderr","time":"2020-05-13T18:41:53.988209321Z"}
...
{"log":"I0513 18:42:01.006230       1 controller.go:1422] delete \"pvc-fce3b92c-093f-4a74-86f7-1fc9cb6d3be0\": started\n","stream":"stderr","time":"2020-05-13T18:42:01.007199938Z"}
{"log":"I0513 18:42:03.968729       1 controller.go:1450] delete \"pvc-fce3b92c-093f-4a74-86f7-1fc9cb6d3be0\": volume deleted\n","stream":"stderr","time":"2020-05-13T18:42:03.969879653Z"}
{"log":"I0513 18:42:04.025931       1 controller.go:1496] delete \"pvc-fce3b92c-093f-4a74-86f7-1fc9cb6d3be0\": persistentvolume deleted\n","stream":"stderr","time":"2020-05-13T18:42:04.02633573Z"}
{"log":"I0513 18:42:04.025978       1 controller.go:1498] delete \"pvc-fce3b92c-093f-4a74-86f7-1fc9cb6d3be0\": succeeded\n","stream":"stderr","time":"2020-05-13T18:42:04.026375078Z"}
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/84226

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add VolumeAttachment Lister to  prevent calling DeleteVolume on the CSI plugin for volumes that are still attached to a kubernetes node.
```
