### PR TITLE
Remove topology fallback logic for nodes < 1.14

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2821,7 +2821,7 @@ func TestProvisionWithTopologyEnabled(t *testing.T) {
 				controllerServer.EXPECT().CreateVolume(gomock.Any(), gomock.Any()).Return(createVolumeOut, nil).Times(1)
 			}
 
-			nodes := buildNodes(tc.nodeLabels, k8sTopologyBetaVersion.String())
+			nodes := buildNodes(tc.nodeLabels)
 			csiNodes := buildCSINodes(tc.topologyKeys)
 
 			var (
@@ -2928,7 +2928,7 @@ func TestProvisionErrorHandling(t *testing.T) {
 					errOut := status.Error(code, "fake error")
 					controllerServer.EXPECT().CreateVolume(gomock.Any(), gomock.Any()).Return(nil, errOut).Times(1)
 
-					nodes := buildNodes(nodeLabels, k8sTopologyBetaVersion.String())
+					nodes := buildNodes(nodeLabels)
 					csiNodes := buildCSINodes(topologyKeys)
 					clientSet := fakeclientset.NewSimpleClientset(nodes, csiNodes)
 					scLister, csiNodeLister, nodeLister, claimLister, vaLister, stopChan := listers(clientSet)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We now require the API server to be on at least 1.17, which means we can remove node support for < 1.15.

Another major change in behavior made here is that if the topology feature gate is enabled, then we assume that the driver on the nodes are correctly reporting topology. We no longer fallback to "no topology" behavior. This means that if you are a driver that is going to upgrade to support topology, then it's a two step process. First, upgrade the driver on the nodes to start reporting topology, then flip the feature gate on the controller.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #257

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The topology feature is GA and requires K8s api server >= 1.17 and K8s nodes >= 1.15
```
