### PR TITLE
Fix wrong flag name in deployment.yaml

### DIFF
--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -22,7 +22,7 @@ spec:
           image: quay.io/k8scsi/csi-provisioner:canary
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--enable-leader-election"
+            - "--leader-election"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/mock.socket


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes renamed flag in deployment.yaml

**Which issue(s) this PR fixes**:
Fixes #454 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
