### PR TITLE
capacity: replace --capacity-controller-deployment-mode=none

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ Note that the external-provisioner does not scale with more replicas. Only one e
 
 See the [storage capacity section](#capacity-support) below for details.
 
+* `--capacity-controller-deployment-mode=central`: Setting this enables producing CSIStorageCapacity objects with capacity information from the driver's GetCapacity call. 'central' is currently the only supported mode. Use it when there is just one active provisioner in the cluster. The default is to not produce CSIStorageCapacity objects.
+
+* `--capacity-ownerref-level <levels>`: The level indicates the number of objects that need to be traversed starting from the pod identified by the POD_NAME and POD_NAMESPACE environment variables to reach the owning object for CSIStorageCapacity objects: 0 for the pod itself, 1 for a StatefulSet, 2 for a Deployment, etc. Defaults to `1` (= StatefulSet).
+
 * `--capacity-threads <num>`: Number of simultaneously running threads, handling CSIStorageCapacity objects. Defaults to `1`.
 
 * `--capacity-poll-interval <interval>`: How long the external-provisioner waits before checking for storage capacity changes. Defaults to `1m`.
-
-* `--capacity-controller-deployment-mode central|none`: Enables producing CSIStorageCapacity objects with capacity information from the driver's GetCapacity call. 'central' is currently the only supported mode. Use it when there is just one active provisioner in the cluster. Defaults to `none`.
-
-* `--capacity-ownerref-level <levels>`: The level indicates the number of objects that need to be traversed starting from the pod identified by the POD_NAME and POD_NAMESPACE environment variables to reach the owning object for CSIStorageCapacity objects: 0 for the pod itself, 1 for a StatefulSet, 2 for a Deployment, etc. Defaults to `1` (= StatefulSet).
 
 * `--capacity-for-immediate-binding <bool>`: Enables producing capacity information for storage classes with immediate binding. Not needed for the Kubernetes scheduler, maybe useful for other consumers or for debugging. Defaults to `false`.
 

--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -83,8 +83,8 @@ var (
 	kubeAPIBurst = flag.Int("kube-api-burst", 10, "Burst to use while communicating with the kubernetes apiserver. Defaults to 10.")
 
 	capacityMode = func() *capacity.DeploymentMode {
-		mode := capacity.DeploymentModeNone
-		flag.Var(&mode, "capacity-controller-deployment-mode", "Enables producing CSIStorageCapacity objects with capacity information from the driver's GetCapacity call. 'central' is currently the only supported mode. Use it when there is just one active provisioner in the cluster.")
+		mode := capacity.DeploymentModeUnset
+		flag.Var(&mode, "capacity-controller-deployment-mode", "Setting this enables producing CSIStorageCapacity objects with capacity information from the driver's GetCapacity call. 'central' is currently the only supported mode. Use it when there is just one active provisioner in the cluster.")
 		return &mode
 	}()
 	capacityImmediateBinding = flag.Bool("capacity-for-immediate-binding", false, "Enables producing capacity information for storage classes with immediate binding. Not needed for the Kubernetes scheduler, maybe useful for other consumers or for debugging.")

--- a/pkg/capacity/mode.go
+++ b/pkg/capacity/mode.go
@@ -36,15 +36,15 @@ const (
 	// is deployed on each node. Not implemented yet.
 	DeploymentModeLocal = DeploymentMode("local")
 
-	// DeploymentModeNone disables capacity support.
-	DeploymentModeNone = DeploymentMode("none")
+	// DeploymentModeUnset disables the capacity feature completely.
+	DeploymentModeUnset = DeploymentMode("")
 )
 
 // Set enables the named features. Multiple features can be listed, separated by commas,
 // with optional whitespace.
 func (mode *DeploymentMode) Set(value string) error {
 	switch DeploymentMode(value) {
-	case DeploymentModeCentral, DeploymentModeNone:
+	case DeploymentModeCentral, DeploymentModeUnset:
 		*mode = DeploymentMode(value)
 	default:
 		return errors.New("invalid value")
@@ -57,7 +57,7 @@ func (mode *DeploymentMode) String() string {
 }
 
 func (mode *DeploymentMode) Type() string {
-	return strings.Join([]string{string(DeploymentModeCentral), string(DeploymentModeNone)}, "|")
+	return strings.Join([]string{string(DeploymentModeCentral) /*, string(DeploymentModeLocal) */}, "|")
 }
 
 var _ flag.Value = new(DeploymentMode)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Instead of "none", the empty string now indicates that the feature
is off. This is a bit more intuitive. To emphasize the importance of
this flag, the parameters in the documentation are order by
relevant (most important first).

**Which issue(s) this PR fixes**:

https://github.com/kubernetes-csi/external-provisioner/pull/450#pullrequestreview-472120848

**Special notes for your reviewer**:

The `--help` output now looks like this:
```
--capacity-controller-deployment-mode central   Setting this enables producing CSIStorageCapacity objects with capacity information from the driver's GetCapacity call. 'central' is currently the only supported mode. Use it when there is just one active provisioner in the cluster.
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
