### PR TITLE
2.0.x: optional volume attachments

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -202,7 +202,13 @@ func main() {
 	claimLister := factory.Core().V1().PersistentVolumeClaims().Lister()
 
 	var csiNodeLister storagelistersv1.CSINodeLister
-	vaLister := factory.Storage().V1().VolumeAttachments().Lister()
+	var vaLister storagelistersv1.VolumeAttachmentLister
+	if controllerCapabilities[csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME] {
+		klog.Info("CSI driver supports PUBLISH_UNPUBLISH_VOLUME, watching VolumeAttachments")
+		vaLister = factory.Storage().V1().VolumeAttachments().Lister()
+	} else {
+		klog.Info("CSI driver does not support PUBLISH_UNPUBLISH_VOLUME, not watching VolumeAttachments")
+	}
 	var nodeLister v1.NodeLister
 	if ctrl.SupportsTopology(pluginCapabilities) {
 		csiNodeLister = factory.Storage().V1().CSINodes().Lister()

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -50,6 +50,10 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
+  # Access to volumeattachments is only needed when the CSI driver
+  # has the PUBLISH_UNPUBLISH_VOLUME controller capability.
+  # In that case, external-provisioner will watch volumeattachments
+  # to determine when it is safe to delete a volume.
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Backport of PR #479 for the release branch.

**Does this PR introduce a user-facing change?**:
```release-note
the watch of VolumeAttachements is avoided for drivers which don't support attach/detach (aka controller PUBLISH_UNPUBLISH_VOLUME)
```
