### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -69,12 +69,17 @@ endif
 # toolchain.
 BUILD_PLATFORMS =
 
+# Add go ldflags using LDFLAGS at the time of compilation.
+IMPORTPATH_LDFLAGS = -X main.version=$(REV) 
+EXT_LDFLAGS = -extldflags "-static"
+LDFLAGS = 
+FULL_LDFLAGS = $(LDFLAGS) $(IMPORTPATH_LDFLAGS) $(EXT_LDFLAGS)
 # This builds each command (= the sub-directories of ./cmd) for the target platform(s)
 # defined by BUILD_PLATFORMS.
 $(CMDS:%=build-%): build-%: check-go-version-go
 	mkdir -p bin
 	echo '$(BUILD_PLATFORMS)' | tr ';' '\n' | while read -r os arch suffix; do \
-		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o "./bin/$*$$suffix" ./cmd/$*); then \
+		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '$(FULL_LDFLAGS)' -o "./bin/$*$$suffix" ./cmd/$*); then \
 			echo "Building $* for GOOS=$$os GOARCH=$$arch failed, see error(s) above."; \
 			exit 1; \
 		fi; \

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -33,9 +33,9 @@
 # The expected environment is:
 # - $GOPATH/src/<import path> for the repository that is to be tested,
 #   with PR branch merged (when testing a PR)
+# - optional: bazel installed (when testing against Kubernetes master),
+#   must be recent enough for Kubernetes master
 # - running on linux-amd64
-# - bazel installed (when testing against Kubernetes master), must be recent
-#   enough for Kubernetes master
 # - kind (https://github.com/kubernetes-sigs/kind) installed
 # - optional: Go already installed
 
@@ -50,26 +50,6 @@ configvar () {
     # shellcheck disable=SC2140
     eval : \$\{"$1":="\$2"\}
     eval echo "\$3:" "$1=\${$1}"
-}
-
-# Takes the minor version of $CSI_PROW_KUBERNETES_VERSION and overrides it to
-# $1 if they are equal minor versions. Ignores versions that begin with
-# "release-".
-override_k8s_version () {
-    local current_minor_version
-    local override_minor_version
-
-    # Ignore: See if you can use ${variable//search/replace} instead.
-    # shellcheck disable=SC2001
-    current_minor_version="$(echo "${CSI_PROW_KUBERNETES_VERSION}" | sed -e 's/\([0-9]*\)\.\([0-9]*\).*/\1\.\2/')"
-
-    # Ignore: See if you can use ${variable//search/replace} instead.
-    # shellcheck disable=SC2001
-    override_minor_version="$(echo "${1}" | sed -e 's/\([0-9]*\)\.\([0-9]*\).*/\1\.\2/')"
-    if [ "${current_minor_version}" == "${override_minor_version}" ]; then
-      CSI_PROW_KUBERNETES_VERSION="$1"
-      echo "Overriding CSI_PROW_KUBERNETES_VERSION with $1: $CSI_PROW_KUBERNETES_VERSION"
-    fi
 }
 
 # Prints the value of a variable + version suffix, falling back to variable + "LATEST".
@@ -107,9 +87,22 @@ configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version fo
 configvar CSI_PROW_GO_VERSION_GINKGO "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building ginkgo" # depends on CSI_PROW_GINKGO_VERSION below
 
 # kind version to use. If the pre-installed version is different,
-# the desired version is downloaded from https://github.com/kubernetes-sigs/kind/releases/download/
+# the desired version is downloaded from https://github.com/kubernetes-sigs/kind/releases
 # (if available), otherwise it is built from source.
-configvar CSI_PROW_KIND_VERSION "v0.6.0" "kind"
+configvar CSI_PROW_KIND_VERSION "v0.9.0" "kind"
+
+# kind images to use. Must match the kind version.
+# The release notes of each kind release list the supported images.
+configvar CSI_PROW_KIND_IMAGES "kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600
+kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
+kindest/node:v1.17.11@sha256:5240a7a2c34bf241afb54ac05669f8a46661912eab05705d660971eeb12f6555
+kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
+kindest/node:v1.15.12@sha256:d9b939055c1e852fe3d86955ee24976cab46cba518abcb8b13ba70917e6547a6
+kindest/node:v1.14.10@sha256:ce4355398a704fca68006f8a29f37aafb49f8fc2f64ede3ccd0d9198da910146
+kindest/node:v1.13.12@sha256:1c1a48c2bfcbae4d5f4fa4310b5ed10756facad0b7a2ca93c7a4b5bae5db29f5" "kind images"
+
+# Use kind node-image --type=bazel by default, but allow to disable that.
+configvar CSI_PROW_USE_BAZEL true "use Bazel during 'kind node-image' invocation"
 
 # ginkgo test runner version to use. If the pre-installed version is
 # different, the desired version is built from source.
@@ -124,10 +117,13 @@ configvar CSI_PROW_GINKO_PARALLEL "-p" "Ginko parallelism parameter(s)"
 configvar CSI_PROW_BUILD_JOB true "building code in repo enabled"
 
 # Kubernetes version to test against. This must be a version number
-# (like 1.13.3) for which there is a pre-built kind image (see
-# https://hub.docker.com/r/kindest/node/tags), "latest" (builds
-# Kubernetes from the master branch) or "release-x.yy" (builds
-# Kubernetes from a release branch).
+# (like 1.13.3), "latest" (builds Kubernetes from the master branch)
+# or "release-x.yy" (builds Kubernetes from a release branch).
+#
+# The patch version is only relevant for picking the E2E test suite
+# that is used for testing. The script automatically picks
+# the kind images for the major/minor version of Kubernetes
+# that the kind release supports.
 #
 # This can also be a version that was not released yet at the time
 # that the settings below were chose. The script will then
@@ -135,16 +131,6 @@ configvar CSI_PROW_BUILD_JOB true "building code in repo enabled"
 # as long as there are no breaking changes in Kubernetes, like
 # deprecating or changing the implementation of an alpha feature.
 configvar CSI_PROW_KUBERNETES_VERSION 1.17.0 "Kubernetes"
-
-# This is a hack to workaround the issue that each version
-# of kind currently only supports specific patch versions of
-# Kubernetes. We need to override CSI_PROW_KUBERNETES_VERSION
-# passed in by our CI/pull jobs to the versions that
-# kind v0.5.0 supports.
-#
-# If the version is prefixed with "release-", then nothing
-# is overridden.
-override_k8s_version "1.15.3"
 
 # CSI_PROW_KUBERNETES_VERSION reduced to first two version numbers and
 # with underscore (1_13 instead of 1.13.3) and in uppercase (LATEST
@@ -298,11 +284,7 @@ tests_need_alpha_cluster () {
 
 # Regex for non-alpha, feature-tagged tests that should be run.
 #
-# Starting with 1.17, snapshots is beta, but the E2E tests still have the
-# [Feature:] tag. They need to be explicitly enabled.
-configvar CSI_PROW_E2E_FOCUS_1_15 '^' "non-alpha, feature-tagged tests for Kubernetes = 1.15" # no tests to run, match nothing
-configvar CSI_PROW_E2E_FOCUS_1_16 '^' "non-alpha, feature-tagged tests for Kubernetes = 1.16" # no tests to run, match nothing
-configvar CSI_PROW_E2E_FOCUS_LATEST '\[Feature:VolumeSnapshotDataSource\]' "non-alpha, feature-tagged tests for Kubernetes >= 1.17"
+configvar CSI_PROW_E2E_FOCUS_LATEST '\[Feature:VolumeSnapshotDataSource\]' "non-alpha, feature-tagged tests for latest Kubernetes version"
 configvar CSI_PROW_E2E_FOCUS "$(get_versioned_variable CSI_PROW_E2E_FOCUS "${csi_prow_kubernetes_version_suffix}")" "non-alpha, feature-tagged tests"
 
 # Serial vs. parallel is always determined by these regular expressions.
@@ -324,7 +306,7 @@ regex_join () {
 # alpha in previous Kubernetes releases. This was considered too
 # error prone. Therefore we use E2E tests that match the Kubernetes
 # version that is getting tested.
-configvar CSI_PROW_E2E_ALPHA_LATEST '\[Feature:' "alpha tests for Kubernetes >= 1.14" # there's no need to update this, adding a new case for CSI_PROW_E2E for a new Kubernetes is enough
+configvar CSI_PROW_E2E_ALPHA_LATEST '\[Feature:' "alpha tests for latest Kubernetes version" # there's no need to update this, adding a new case for CSI_PROW_E2E for a new Kubernetes is enough
 configvar CSI_PROW_E2E_ALPHA "$(get_versioned_variable CSI_PROW_E2E_ALPHA "${csi_prow_kubernetes_version_suffix}")" "alpha tests"
 
 # After the parallel E2E test without alpha features, a test cluster
@@ -339,15 +321,11 @@ configvar CSI_PROW_E2E_ALPHA "$(get_versioned_variable CSI_PROW_E2E_ALPHA "${csi
 # kubernetes-csi components must be updated, either by disabling
 # the failing test for "latest" or by updating the test and not running
 # it anymore for older releases.
-configvar CSI_PROW_E2E_ALPHA_GATES_1_15 'VolumeSnapshotDataSource=true,ExpandCSIVolumes=true' "alpha feature gates for Kubernetes 1.15"
-configvar CSI_PROW_E2E_ALPHA_GATES_1_16 'VolumeSnapshotDataSource=true' "alpha feature gates for Kubernetes 1.16"
-# TODO: add new CSI_PROW_ALPHA_GATES_xxx entry for future Kubernetes releases and
-# add new gates to CSI_PROW_E2E_ALPHA_GATES_LATEST.
-configvar CSI_PROW_E2E_ALPHA_GATES_LATEST '' "alpha feature gates for latest Kubernetes"
+configvar CSI_PROW_E2E_ALPHA_GATES_LATEST 'GenericEphemeralVolume=true,CSIStorageCapacity=true' "alpha feature gates for latest Kubernetes"
 configvar CSI_PROW_E2E_ALPHA_GATES "$(get_versioned_variable CSI_PROW_E2E_ALPHA_GATES "${csi_prow_kubernetes_version_suffix}")" "alpha E2E feature gates"
 
 # Which external-snapshotter tag to use for the snapshotter CRD and snapshot-controller deployment
-configvar CSI_SNAPSHOTTER_VERSION 'v2.0.1' "external-snapshotter version tag"
+configvar CSI_SNAPSHOTTER_VERSION 'v3.0.0' "external-snapshotter version tag"
 
 # Some tests are known to be unusable in a KinD cluster. For example,
 # stopping kubelet with "ssh <node IP> systemctl stop kubelet" simply
@@ -507,6 +485,22 @@ list_gates () (
     done
 )
 
+# Turn feature gates in the format foo=true,bar=false into
+# a YAML map with the corresponding API groups for use
+# with https://kind.sigs.k8s.io/docs/user/configuration/#runtime-config
+list_api_groups () (
+    set -f; IFS=','
+    # Ignore: Double quote to prevent globbing and word splitting.
+    # shellcheck disable=SC2086
+    set -- $1
+    while [ "$1" ]; do
+        if [ "$1" = 'CSIStorageCapacity=true' ]; then
+            echo '   "storage.k8s.io/v1alpha1": "true"'
+        fi
+        shift
+    done
+)
+
 go_version_for_kubernetes () (
     local path="$1"
     local version="$2"
@@ -536,77 +530,51 @@ start_cluster () {
         run kind delete cluster --name=csi-prow || die "kind delete failed"
     fi
 
-    # Build from source?
-    if [[ "${CSI_PROW_KUBERNETES_VERSION}" =~ ^release-|^latest$ ]]; then
+    # Try to find a pre-built kind image if asked to use a specific version.
+    if ! [[ "${CSI_PROW_KUBERNETES_VERSION}" =~ ^release-|^latest$ ]]; then
+        # Ignore: See if you can use ${variable//search/replace} instead.
+        # shellcheck disable=SC2001
+        major_minor=$(echo "${CSI_PROW_KUBERNETES_VERSION}" | sed -e 's/^\([0-9]*\)\.\([0-9]*\).*/\1.\2/')
+        for i in ${CSI_PROW_KIND_IMAGES}; do
+            if echo "$i" | grep -q "kindest/node:v${major_minor}"; then
+                image="$i"
+                break
+            fi
+        done
+    fi
+
+    # Need to build from source?
+    if ! [ "$image" ]; then
         if ! ${csi_prow_kind_have_kubernetes}; then
             local version="${CSI_PROW_KUBERNETES_VERSION}"
             if [ "$version" = "latest" ]; then
                 version=master
             fi
+            if ${CSI_PROW_USE_BAZEL}; then
+                type="bazel"
+            else
+                type="docker"
+            fi
             git_clone_branch https://github.com/kubernetes/kubernetes "${CSI_PROW_WORK}/src/kubernetes" "$version" || die "checking out Kubernetes $version failed"
 
             go_version="$(go_version_for_kubernetes "${CSI_PROW_WORK}/src/kubernetes" "$version")" || die "cannot proceed without knowing Go version for Kubernetes"
-            run_with_go "$go_version" kind build node-image --type bazel --image csiprow/node:latest --kube-root "${CSI_PROW_WORK}/src/kubernetes" || die "'kind build node-image' failed"
+            run_with_go "$go_version" kind build node-image --image csiprow/node:latest --type="$type" --kube-root "${CSI_PROW_WORK}/src/kubernetes" || die "'kind build node-image' failed"
             csi_prow_kind_have_kubernetes=true
         fi
         image="csiprow/node:latest"
-    else
-        image="kindest/node:v${CSI_PROW_KUBERNETES_VERSION}"
     fi
     cat >"${CSI_PROW_WORK}/kind-config.yaml" <<EOF
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker
 - role: worker
-EOF
-
-    # kubeadm has API dependencies between apiVersion and Kubernetes version
-    # 1.15+ requires kubeadm.k8s.io/v1beta2
-    # We only run alpha tests against master so we don't need to maintain
-    # different patches for different Kubernetes releases.
-    if [[ -n "$gates" ]]; then
-        cat >>"${CSI_PROW_WORK}/kind-config.yaml" <<EOF
-kubeadmConfigPatches:
-- |
-  apiVersion: kubeadm.k8s.io/v1beta2
-  kind: ClusterConfiguration
-  metadata:
-    name: config
-  apiServer:
-    extraArgs:
-      "feature-gates": "$gates"
-  controllerManager:
-    extraArgs:
-      "feature-gates": "$gates"
-  scheduler:
-    extraArgs:
-      "feature-gates": "$gates"
-- |
-  apiVersion: kubeadm.k8s.io/v1beta2
-  kind: InitConfiguration
-  metadata:
-    name: config
-  nodeRegistration:
-    kubeletExtraArgs:
-      "feature-gates": "$gates"
-- |
-  apiVersion: kubelet.config.k8s.io/v1beta1
-  kind: KubeletConfiguration
-  metadata:
-    name: config
-  featureGates:
+featureGates:
 $(list_gates "$gates")
-- |
-  apiVersion: kubeproxy.config.k8s.io/v1alpha1
-  kind: KubeProxyConfiguration
-  metadata:
-    name: config
-  featureGates:
-$(list_gates "$gates")
+runtimeConfig:
+$(list_api_groups "$gates")
 EOF
-    fi
 
     info "kind-config.yaml:"
     cat "${CSI_PROW_WORK}/kind-config.yaml"
@@ -718,7 +686,7 @@ install_csi_driver () {
 # Installs all nessesary snapshotter CRDs  
 install_snapshot_crds() {
   # Wait until volumesnapshot CRDs are in place.
-  CRD_BASE_DIR="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${CSI_SNAPSHOTTER_VERSION}/config/crd"
+  CRD_BASE_DIR="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${CSI_SNAPSHOTTER_VERSION}/client/config/crd"
   kubectl apply -f "${CRD_BASE_DIR}/snapshot.storage.k8s.io_volumesnapshotclasses.yaml" --validate=false
   kubectl apply -f "${CRD_BASE_DIR}/snapshot.storage.k8s.io_volumesnapshots.yaml" --validate=false
   kubectl apply -f "${CRD_BASE_DIR}/snapshot.storage.k8s.io_volumesnapshotcontents.yaml" --validate=false
@@ -1101,14 +1069,8 @@ main () {
             start_cluster || die "starting the non-alpha cluster failed"
 
             # Install necessary snapshot CRDs and snapshot controller
-            # For Kubernetes 1.17+, we will install the CRDs and snapshot controller.
-            if version_gt "${CSI_PROW_KUBERNETES_VERSION}" "1.16.255" || "${CSI_PROW_KUBERNETES_VERSION}" == "latest"; then
-                info "Version ${CSI_PROW_KUBERNETES_VERSION}, installing CRDs and snapshot controller"
-                install_snapshot_crds
-                install_snapshot_controller
-            else
-                info "Version ${CSI_PROW_KUBERNETES_VERSION}, skipping CRDs and snapshot controller"
-            fi
+            install_snapshot_crds
+            install_snapshot_controller
 
             # Installing the driver might be disabled.
             if ${CSI_PROW_DRIVER_INSTALL} "$images"; then
@@ -1158,14 +1120,8 @@ main () {
             start_cluster "${CSI_PROW_E2E_ALPHA_GATES}" || die "starting alpha cluster failed"
 
             # Install necessary snapshot CRDs and snapshot controller
-            # For Kubernetes 1.17+, we will install the CRDs and snapshot controller.
-            if version_gt "${CSI_PROW_KUBERNETES_VERSION}" "1.16.255" || "${CSI_PROW_KUBERNETES_VERSION}" == "latest"; then
-                info "Version ${CSI_PROW_KUBERNETES_VERSION}, installing CRDs and snapshot controller"
-                install_snapshot_crds
-                install_snapshot_controller
-            else
-                info "Version ${CSI_PROW_KUBERNETES_VERSION}, skipping CRDs and snapshot controller"
-            fi
+            install_snapshot_crds
+            install_snapshot_controller
 
             # Installing the driver might be disabled.
             if ${CSI_PROW_DRIVER_INSTALL} "$images"; then


### PR DESCRIPTION
Squashed 'release-tools/' changes from 3041b8a42..22c0395c9

[22c0395c9](https://github.com/kubernetes-csi/csi-release-tools/commit/22c0395c9) Merge pull request #108 from bnrjee/master
[b5b447b50](https://github.com/kubernetes-csi/csi-release-tools/commit/b5b447b50) Add go ldflags using LDFLAGS at the time of compilation
[16f4afbd8](https://github.com/kubernetes-csi/csi-release-tools/commit/16f4afbd8) Merge pull request #107 from pohly/kind-update
[7bcee13d7](https://github.com/kubernetes-csi/csi-release-tools/commit/7bcee13d7) prow.sh: update to kind 0.9, support Kubernetes 1.19
[df518fbd6](https://github.com/kubernetes-csi/csi-release-tools/commit/df518fbd6) prow.sh: usage of Bazel optional
[c3afd427e](https://github.com/kubernetes-csi/csi-release-tools/commit/c3afd427e) Merge pull request #104 from xing-yang/snapshot
[dde93b220](https://github.com/kubernetes-csi/csi-release-tools/commit/dde93b220) Update to snapshot-controller v3.0.0
[a0f195cc2](https://github.com/kubernetes-csi/csi-release-tools/commit/a0f195cc2) Merge pull request #106 from msau42/fix-canary
[7100c1209](https://github.com/kubernetes-csi/csi-release-tools/commit/7100c1209) Only set staging registry when running canary job
[b3c65f9c7](https://github.com/kubernetes-csi/csi-release-tools/commit/b3c65f9c7) Merge pull request #99 from msau42/add-release-process
[e53f3e85b](https://github.com/kubernetes-csi/csi-release-tools/commit/e53f3e85b) Merge pull request #103 from msau42/fix-canary
[d12946287](https://github.com/kubernetes-csi/csi-release-tools/commit/d12946287) Document new method for adding CI jobs are new K8s versions
[e73c2ce53](https://github.com/kubernetes-csi/csi-release-tools/commit/e73c2ce53) Use staging registry for canary tests
[2c098465d](https://github.com/kubernetes-csi/csi-release-tools/commit/2c098465d) Add cleanup instructions to release-notes generation
[60e1cd3d0](https://github.com/kubernetes-csi/csi-release-tools/commit/60e1cd3d0) Merge pull request #98 from pohly/kubernetes-1-19-fixes
[0979c0910](https://github.com/kubernetes-csi/csi-release-tools/commit/0979c0910) prow.sh: fix E2E suite for Kubernetes >= 1.18
[3b4a2f1d9](https://github.com/kubernetes-csi/csi-release-tools/commit/3b4a2f1d9) prow.sh: fix installing Go for Kubernetes 1.19.0
[1fbb636cb](https://github.com/kubernetes-csi/csi-release-tools/commit/1fbb636cb) Merge pull request #97 from pohly/go-1.15
[82d108acd](https://github.com/kubernetes-csi/csi-release-tools/commit/82d108acd) switch to Go 1.15
[d8a253005](https://github.com/kubernetes-csi/csi-release-tools/commit/d8a253005) Merge pull request #95 from msau42/add-release-process
[843bddca1](https://github.com/kubernetes-csi/csi-release-tools/commit/843bddca1) Add steps on promoting release images
[0345a835e](https://github.com/kubernetes-csi/csi-release-tools/commit/0345a835e) Merge pull request #94 from linux-on-ibm-z/bump-timeout
[1fdf2d53c](https://github.com/kubernetes-csi/csi-release-tools/commit/1fdf2d53c) cloud build: bump timeout in Prow job
[41ec6d153](https://github.com/kubernetes-csi/csi-release-tools/commit/41ec6d153) Merge pull request #93 from animeshk08/patch-1
[5a54e67d8](https://github.com/kubernetes-csi/csi-release-tools/commit/5a54e67d8) filter-junit: Fix gofmt error
[0676fcbd7](https://github.com/kubernetes-csi/csi-release-tools/commit/0676fcbd7) Merge pull request #92 from animeshk08/patch-1
[36ea4ffae](https://github.com/kubernetes-csi/csi-release-tools/commit/36ea4ffae) filter-junit: Fix golint error
[f5a420378](https://github.com/kubernetes-csi/csi-release-tools/commit/f5a420378) Merge pull request #91 from cyb70289/arm64
[43e50d6f6](https://github.com/kubernetes-csi/csi-release-tools/commit/43e50d6f6) prow.sh: enable building arm64 image
[0d5bd8436](https://github.com/kubernetes-csi/csi-release-tools/commit/0d5bd8436) Merge pull request #90 from pohly/k8s-staging-sig-storage
[3df86b7d4](https://github.com/kubernetes-csi/csi-release-tools/commit/3df86b7d4) cloud build: k8s-staging-sig-storage
[c5fd9610f](https://github.com/kubernetes-csi/csi-release-tools/commit/c5fd9610f) Merge pull request #89 from pohly/cloud-build-binfmt
[db0c2a7dc](https://github.com/kubernetes-csi/csi-release-tools/commit/db0c2a7dc) cloud build: initialize support for running commands in Dockerfile
[be902f401](https://github.com/kubernetes-csi/csi-release-tools/commit/be902f401) Merge pull request #88 from pohly/multiarch-windows-fix
[340e082f0](https://github.com/kubernetes-csi/csi-release-tools/commit/340e082f0) build.make: optional inclusion of Windows in multiarch images
[5231f05d8](https://github.com/kubernetes-csi/csi-release-tools/commit/5231f05d8) build.make: properly declare push-multiarch
[4569f27a8](https://github.com/kubernetes-csi/csi-release-tools/commit/4569f27a8) build.make: fix push-multiarch ambiguity
[17dde9ef0](https://github.com/kubernetes-csi/csi-release-tools/commit/17dde9ef0) Merge pull request #87 from pohly/cloud-build
[bd416901d](https://github.com/kubernetes-csi/csi-release-tools/commit/bd416901d) cloud build: initial set of shared files
[9084fecb8](https://github.com/kubernetes-csi/csi-release-tools/commit/9084fecb8) Merge pull request #81 from msau42/add-release-process
[6f2322e80](https://github.com/kubernetes-csi/csi-release-tools/commit/6f2322e80) Update patch release notes generation command
[0fcc3b1bc](https://github.com/kubernetes-csi/csi-release-tools/commit/0fcc3b1bc) Merge pull request #78 from ggriffiths/fix_csi_snapshotter_rbac_version_set
[d8c76fee3](https://github.com/kubernetes-csi/csi-release-tools/commit/d8c76fee3) Support local snapshot RBAC for pull jobs
[c1bdf5bfd](https://github.com/kubernetes-csi/csi-release-tools/commit/c1bdf5bfd) Merge pull request #80 from msau42/add-release-process
[ea1f94aad](https://github.com/kubernetes-csi/csi-release-tools/commit/ea1f94aad) update release tools instructions
[152396e2d](https://github.com/kubernetes-csi/csi-release-tools/commit/152396e2d) Merge pull request #77 from ggriffiths/snapshotter201_update
[7edc1461e](https://github.com/kubernetes-csi/csi-release-tools/commit/7edc1461e) Update snapshotter to version 2.0.1
[4cf843f67](https://github.com/kubernetes-csi/csi-release-tools/commit/4cf843f67) Merge pull request #76 from pohly/build-targets
[3863a0f67](https://github.com/kubernetes-csi/csi-release-tools/commit/3863a0f67) build for multiple platforms only in CI, add s390x
[8322a7d0c](https://github.com/kubernetes-csi/csi-release-tools/commit/8322a7d0c) Merge pull request #72 from pohly/hostpath-update
[7c5a89c8f](https://github.com/kubernetes-csi/csi-release-tools/commit/7c5a89c8f) prow.sh: use 1.3.0 hostpath driver for testing
[b8587b2bf](https://github.com/kubernetes-csi/csi-release-tools/commit/b8587b2bf) Merge pull request #71 from wozniakjan/test-vet
[fdb32183f](https://github.com/kubernetes-csi/csi-release-tools/commit/fdb32183f) Change 'make test-vet' to call 'go vet'
[d717c8c48](https://github.com/kubernetes-csi/csi-release-tools/commit/d717c8c48) Merge pull request #69 from pohly/test-driver-config
[a1432bc97](https://github.com/kubernetes-csi/csi-release-tools/commit/a1432bc97) Merge pull request #70 from pohly/kubelet-feature-gates
[5f74333a4](https://github.com/kubernetes-csi/csi-release-tools/commit/5f74333a4) prow.sh: also configure feature gates for kubelet
[84f78b120](https://github.com/kubernetes-csi/csi-release-tools/commit/84f78b120) prow.sh: generic driver installation
[3c34b4f21](https://github.com/kubernetes-csi/csi-release-tools/commit/3c34b4f21) Merge pull request #67 from windayski/fix-link
[fa90abd07](https://github.com/kubernetes-csi/csi-release-tools/commit/fa90abd07) fix incorrect link
[ff3cc3f1f](https://github.com/kubernetes-csi/csi-release-tools/commit/ff3cc3f1f) Merge pull request #54 from msau42/add-release-process
[ac8a0212b](https://github.com/kubernetes-csi/csi-release-tools/commit/ac8a0212b) Document the process for releasing a new sidecar
[23be65254](https://github.com/kubernetes-csi/csi-release-tools/commit/23be65254) Merge pull request #65 from msau42/update-hostpath
[6582f2ff3](https://github.com/kubernetes-csi/csi-release-tools/commit/6582f2ff3) Update hostpath driver version to get fix for connection-timeout
[4cc917457](https://github.com/kubernetes-csi/csi-release-tools/commit/4cc917457) Merge pull request #64 from ggriffiths/snapshotter_2_version_update
[8191eab6f](https://github.com/kubernetes-csi/csi-release-tools/commit/8191eab6f) Update snapshotter to version v2.0.0
[3c463fb1e](https://github.com/kubernetes-csi/csi-release-tools/commit/3c463fb1e) Merge pull request #61 from msau42/enable-snapshots
[8b0316c7e](https://github.com/kubernetes-csi/csi-release-tools/commit/8b0316c7e) Fix overriding of junit results by using unique names for each e2e run
[5f444b80f](https://github.com/kubernetes-csi/csi-release-tools/commit/5f444b80f) Merge pull request #60 from saad-ali/updateHostpathVersion
[af9549b5a](https://github.com/kubernetes-csi/csi-release-tools/commit/af9549b5a) Update prow hostpath driver version to 1.3.0-rc2
[f6c74b30e](https://github.com/kubernetes-csi/csi-release-tools/commit/f6c74b30e) Merge pull request #57 from ggriffiths/version_gt_kubernetes_fix
[fc8097595](https://github.com/kubernetes-csi/csi-release-tools/commit/fc8097595) Fix version_gt to work with kubernetes prefix
[9f1f3dd84](https://github.com/kubernetes-csi/csi-release-tools/commit/9f1f3dd84) Merge pull request #56 from msau42/enable-snapshots
[b98b2aed0](https://github.com/kubernetes-csi/csi-release-tools/commit/b98b2aed0) Enable snapshot tests in 1.17 to be run in non-alpha jobs.
[9ace02045](https://github.com/kubernetes-csi/csi-release-tools/commit/9ace02045) Merge pull request #52 from msau42/update-readme
[540599ba3](https://github.com/kubernetes-csi/csi-release-tools/commit/540599ba3) Merge pull request #53 from msau42/fix-make
[a4e629966](https://github.com/kubernetes-csi/csi-release-tools/commit/a4e629966) fix syntax for ppc64le build
[771ca6f26](https://github.com/kubernetes-csi/csi-release-tools/commit/771ca6f26) Merge pull request #49 from ggriffiths/prowsh_improve_version_gt
[d7c69d2f9](https://github.com/kubernetes-csi/csi-release-tools/commit/d7c69d2f9) Merge pull request #51 from msau42/enable-multinode
[4ad69492c](https://github.com/kubernetes-csi/csi-release-tools/commit/4ad69492c) Improve snapshot pod running checks and improve version_gt
[53888ae7d](https://github.com/kubernetes-csi/csi-release-tools/commit/53888ae7d) Improve README by adding an explicit Kubernetes dependency section
[9a7a685ee](https://github.com/kubernetes-csi/csi-release-tools/commit/9a7a685ee) Create a kind cluster with two worker nodes so that the topology feature can be tested. Test cases that test accessing volumes from multiple nodes need to be skipped
[4ff2f5f09](https://github.com/kubernetes-csi/csi-release-tools/commit/4ff2f5f09) Merge pull request #50 from darkowlzz/kind-0.6.0
[80bba1fe2](https://github.com/kubernetes-csi/csi-release-tools/commit/80bba1fe2) Use kind v0.6.0
[6d674a7f9](https://github.com/kubernetes-csi/csi-release-tools/commit/6d674a7f9) Merge pull request #47 from Pensu/multi-arch
[8adde494a](https://github.com/kubernetes-csi/csi-release-tools/commit/8adde494a) Merge pull request #45 from ggriffiths/snapshot_beta_crds
[003c14b2d](https://github.com/kubernetes-csi/csi-release-tools/commit/003c14b2d) Add snapshotter CRDs after cluster setup
[a41f38604](https://github.com/kubernetes-csi/csi-release-tools/commit/a41f38604) Merge pull request #46 from mucahitkurt/kind-cluster-cleanup
[1eaaaa1cb](https://github.com/kubernetes-csi/csi-release-tools/commit/1eaaaa1cb) Delete kind cluster after tests run.
[83a4ef15d](https://github.com/kubernetes-csi/csi-release-tools/commit/83a4ef15d) Adding build for ppc64le
[4fcafece5](https://github.com/kubernetes-csi/csi-release-tools/commit/4fcafece5) Merge pull request #43 from pohly/system-pod-logging
[f41c1351a](https://github.com/kubernetes-csi/csi-release-tools/commit/f41c1351a) prow.sh: also log output of system containers
[ee22a9caa](https://github.com/kubernetes-csi/csi-release-tools/commit/ee22a9caa) Merge pull request #42 from pohly/use-vendor-dir
[806784565](https://github.com/kubernetes-csi/csi-release-tools/commit/806784565) travis.yml: also use vendor directory
[23df4aef5](https://github.com/kubernetes-csi/csi-release-tools/commit/23df4aef5) prow.sh: use vendor directory if available
[a53bd4c46](https://github.com/kubernetes-csi/csi-release-tools/commit/a53bd4c46) Merge pull request #41 from pohly/go-version
[c8a1c4af9](https://github.com/kubernetes-csi/csi-release-tools/commit/c8a1c4af9) better handling of Go version
[5e773d2db](https://github.com/kubernetes-csi/csi-release-tools/commit/5e773d2db) update CI to use Go 1.13.3
[f419d7454](https://github.com/kubernetes-csi/csi-release-tools/commit/f419d7454) Merge pull request #40 from msau42/add-1.16
[e0fde8c4f](https://github.com/kubernetes-csi/csi-release-tools/commit/e0fde8c4f) Add new variables for 1.16 and remove 1.13
[adf00feaa](https://github.com/kubernetes-csi/csi-release-tools/commit/adf00feaa) Merge pull request #36 from msau42/full-clone
[f1697d2ca](https://github.com/kubernetes-csi/csi-release-tools/commit/f1697d2ca) Do full git clones in travis. Shallow clones are causing test-subtree errors when the depth is exactly 50.
[2c8191980](https://github.com/kubernetes-csi/csi-release-tools/commit/2c8191980) Merge pull request #34 from pohly/go-mod-tidy
[518d6af6b](https://github.com/kubernetes-csi/csi-release-tools/commit/518d6af6b) Merge pull request #35 from ddebroy/winbld2
[2d6b3ce85](https://github.com/kubernetes-csi/csi-release-tools/commit/2d6b3ce85) Build Windows only for amd64
[c1078a658](https://github.com/kubernetes-csi/csi-release-tools/commit/c1078a658) go-get-kubernetes.sh: automate Kubernetes dependency handling
[194289aa8](https://github.com/kubernetes-csi/csi-release-tools/commit/194289aa8) update Go mod support
[0affdf95a](https://github.com/kubernetes-csi/csi-release-tools/commit/0affdf95a) Merge pull request #33 from gnufied/enable-hostpath-expansion
[6208f6ab4](https://github.com/kubernetes-csi/csi-release-tools/commit/6208f6ab4) Enable hostpath expansion
[6ecaa76eb](https://github.com/kubernetes-csi/csi-release-tools/commit/6ecaa76eb) Merge pull request #30 from msau42/fix-windows
[ea2f1b527](https://github.com/kubernetes-csi/csi-release-tools/commit/ea2f1b527) build windows binaries with .exe suffix
[2d3355064](https://github.com/kubernetes-csi/csi-release-tools/commit/2d3355064) Merge pull request #29 from mucahitkurt/create-2-node-kind-cluster
[a8ea8bcc5](https://github.com/kubernetes-csi/csi-release-tools/commit/a8ea8bcc5) create 2-node kind cluster since topology support is added to hostpath driver
[df8530d9e](https://github.com/kubernetes-csi/csi-release-tools/commit/df8530d9e) Merge pull request #27 from pohly/dep-vendor-check
[35ceaedcb](https://github.com/kubernetes-csi/csi-release-tools/commit/35ceaedcb) prow.sh: install dep if needed
[f85ab5af1](https://github.com/kubernetes-csi/csi-release-tools/commit/f85ab5af1) Merge pull request #26 from ddebroy/windows1
[9fba09b41](https://github.com/kubernetes-csi/csi-release-tools/commit/9fba09b41) Add rule for building Windows binaries
[040086764](https://github.com/kubernetes-csi/csi-release-tools/commit/040086764) Merge pull request #25 from msau42/fix-master-jobs
[dc0a5d838](https://github.com/kubernetes-csi/csi-release-tools/commit/dc0a5d838) Update kind to v0.5.0
[aa85b82ca](https://github.com/kubernetes-csi/csi-release-tools/commit/aa85b82ca) Merge pull request #23 from msau42/fix-master-jobs
[f46191d9a](https://github.com/kubernetes-csi/csi-release-tools/commit/f46191d9a) Kubernetes master changed the way that releases are tagged, which needed changes to kind. There are 3 changes made to prow.sh:
[1cac3af3f](https://github.com/kubernetes-csi/csi-release-tools/commit/1cac3af3f) Merge pull request #22 from msau42/add-1.15-jobs
[0c0dc300c](https://github.com/kubernetes-csi/csi-release-tools/commit/0c0dc300c) prow.sh: tag master images with a large version number
[f4f73cefb](https://github.com/kubernetes-csi/csi-release-tools/commit/f4f73cefb) Merge pull request #21 from msau42/add-1.15-jobs
[4e31f078a](https://github.com/kubernetes-csi/csi-release-tools/commit/4e31f078a) Change default hostpath driver name to hostpath.csi.k8s.io
[4b6fa4a0b](https://github.com/kubernetes-csi/csi-release-tools/commit/4b6fa4a0b) Update hostpath version for sidecar testing to v1.2.0-rc2
[ecc79187c](https://github.com/kubernetes-csi/csi-release-tools/commit/ecc79187c) Update kind to v0.4.0. This requires overriding Kubernetes versions with specific patch versions that kind 0.4.0 supports. Also, feature gate setting is only supported on 1.15+ due to kind.sigs.k8s.io/v1alpha3 and kubeadm.k8s.io/v1beta2 dependencies.
[a6f21d405](https://github.com/kubernetes-csi/csi-release-tools/commit/a6f21d405) Add variables for 1.15
[db8abb6e1](https://github.com/kubernetes-csi/csi-release-tools/commit/db8abb6e1) Merge pull request #20 from pohly/test-driver-config
[b2f4e051d](https://github.com/kubernetes-csi/csi-release-tools/commit/b2f4e051d) prow.sh: flexible test driver config
[03999882f](https://github.com/kubernetes-csi/csi-release-tools/commit/03999882f) Merge pull request #19 from pohly/go-mod-vendor
[066143d14](https://github.com/kubernetes-csi/csi-release-tools/commit/066143d14) build.make: allow repos to use 'go mod' for vendoring
[0bee74933](https://github.com/kubernetes-csi/csi-release-tools/commit/0bee74933) Merge pull request #18 from pohly/go-version
[e157b6b51](https://github.com/kubernetes-csi/csi-release-tools/commit/e157b6b51) update to Go 1.12.4
[88dc9a47e](https://github.com/kubernetes-csi/csi-release-tools/commit/88dc9a47e) Merge pull request #17 from pohly/prow
[0fafc663d](https://github.com/kubernetes-csi/csi-release-tools/commit/0fafc663d) prow.sh: skip sanity testing if component doesn't support it
[bcac1c1fb](https://github.com/kubernetes-csi/csi-release-tools/commit/bcac1c1fb) Merge pull request #16 from pohly/prow
[0b10f6a4b](https://github.com/kubernetes-csi/csi-release-tools/commit/0b10f6a4b) prow.sh: update csi-driver-host-path
[0c2677e8f](https://github.com/kubernetes-csi/csi-release-tools/commit/0c2677e8f) Merge pull request #15 from pengzhisun/master
[ff9bce4a7](https://github.com/kubernetes-csi/csi-release-tools/commit/ff9bce4a7) Replace 'return' to 'exit' to fix shellcheck error
[c60f3823c](https://github.com/kubernetes-csi/csi-release-tools/commit/c60f3823c) Merge pull request #14 from pohly/prow
[7aaac2257](https://github.com/kubernetes-csi/csi-release-tools/commit/7aaac2257) prow.sh: remove AllAlpha=all, part II
[66177736d](https://github.com/kubernetes-csi/csi-release-tools/commit/66177736d) Merge pull request #13 from pohly/prow
[cda2fc587](https://github.com/kubernetes-csi/csi-release-tools/commit/cda2fc587) prow.sh: avoid AllAlpha=true
[546d5504a](https://github.com/kubernetes-csi/csi-release-tools/commit/546d5504a) prow.sh: debug failing KinD cluster creation
[9b0d9cd74](https://github.com/kubernetes-csi/csi-release-tools/commit/9b0d9cd74) build.make: skip shellcheck if Docker is not available
[aa45a1cd9](https://github.com/kubernetes-csi/csi-release-tools/commit/aa45a1cd9) prow.sh: more efficient execution of individual tests
[f3d1d2df5](https://github.com/kubernetes-csi/csi-release-tools/commit/f3d1d2df5) prow.sh: fix hostpath driver version check
[31dfaf31d](https://github.com/kubernetes-csi/csi-release-tools/commit/31dfaf31d) prow.sh: fix running of just "alpha" tests
[f5014439f](https://github.com/kubernetes-csi/csi-release-tools/commit/f5014439f) prow.sh: AllAlpha=true for unknown Kubernetes versions
[95ae9de9a](https://github.com/kubernetes-csi/csi-release-tools/commit/95ae9de9a) Merge pull request #9 from pohly/prow
[d87eccb46](https://github.com/kubernetes-csi/csi-release-tools/commit/d87eccb46) prow.sh: switch back to upstream csi-driver-host-path
[6602d38bf](https://github.com/kubernetes-csi/csi-release-tools/commit/6602d38bf) prow.sh: different E2E suite depending on Kubernetes version
[741319bd3](https://github.com/kubernetes-csi/csi-release-tools/commit/741319bd3) prow.sh: improve building Kubernetes from source
[29545bb01](https://github.com/kubernetes-csi/csi-release-tools/commit/29545bb01) prow.sh: take Go version from Kubernetes source
[429581c52](https://github.com/kubernetes-csi/csi-release-tools/commit/429581c52) prow.sh: pull Go version from travis.yml
[0a0fd49b8](https://github.com/kubernetes-csi/csi-release-tools/commit/0a0fd49b8) prow.sh: comment clarification
[2069a0af3](https://github.com/kubernetes-csi/csi-release-tools/commit/2069a0af3) Merge pull request #11 from pohly/verify-shellcheck
[55212ff2b](https://github.com/kubernetes-csi/csi-release-tools/commit/55212ff2b) initial Prow test job
[6c7ba1be0](https://github.com/kubernetes-csi/csi-release-tools/commit/6c7ba1be0) build.make: integrate shellcheck into "make test"
[b2d25d4f4](https://github.com/kubernetes-csi/csi-release-tools/commit/b2d25d4f4) verify-shellcheck.sh: make it usable in csi-release-tools
[3b6af7b1c](https://github.com/kubernetes-csi/csi-release-tools/commit/3b6af7b1c) Merge pull request #12 from pohly/local-e2e-suite
[104a1ac96](https://github.com/kubernetes-csi/csi-release-tools/commit/104a1ac96) build.make: avoid unit-testing E2E test suite
[34010e752](https://github.com/kubernetes-csi/csi-release-tools/commit/34010e752) Merge pull request #10 from pohly/vendor-check
[e6db50df7](https://github.com/kubernetes-csi/csi-release-tools/commit/e6db50df7) check vendor directory
[fb13c5198](https://github.com/kubernetes-csi/csi-release-tools/commit/fb13c5198) verify-shellcheck.sh: import from Kubernetes
[94fc1e31d](https://github.com/kubernetes-csi/csi-release-tools/commit/94fc1e31d) build.make: avoid unit-testing E2E test suite
[849db0ad2](https://github.com/kubernetes-csi/csi-release-tools/commit/849db0ad2) Merge pull request #8 from pohly/subtree-check-relax
[cc564f929](https://github.com/kubernetes-csi/csi-release-tools/commit/cc564f929) verify-subtree.sh: relax check and ignore old content
[33d58fdc2](https://github.com/kubernetes-csi/csi-release-tools/commit/33d58fdc2) Merge pull request #5 from pohly/test-enhancements
[be8a4400a](https://github.com/kubernetes-csi/csi-release-tools/commit/be8a4400a) Merge pull request #4 from pohly/canary-fix
[b0336b553](https://github.com/kubernetes-csi/csi-release-tools/commit/b0336b553) build.make: more readable "make test" output
[09436b9f9](https://github.com/kubernetes-csi/csi-release-tools/commit/09436b9f9) build.make: fix pushing of "canary" image from master branch
[147892c95](https://github.com/kubernetes-csi/csi-release-tools/commit/147892c95) build.make: support suppressing checks
[154e33d43](https://github.com/kubernetes-csi/csi-release-tools/commit/154e33d43) build.make: clarify usage of "make V=1"

git-subtree-dir: release-tools
git-subtree-split: 22c0395c9cb16a65d47197b405a8cc3cc82fced9

```release-note
NONE
```