### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -69,12 +69,17 @@ endif
 # toolchain.
 BUILD_PLATFORMS =
 
+# Add go ldflags using LDFLAGS at the time of compilation.
+IMPORTPATH_LDFLAGS = -X main.version=$(REV) 
+EXT_LDFLAGS = -extldflags "-static"
+LDFLAGS = 
+FULL_LDFLAGS = $(LDFLAGS) $(IMPORTPATH_LDFLAGS) $(EXT_LDFLAGS)
 # This builds each command (= the sub-directories of ./cmd) for the target platform(s)
 # defined by BUILD_PLATFORMS.
 $(CMDS:%=build-%): build-%: check-go-version-go
 	mkdir -p bin
 	echo '$(BUILD_PLATFORMS)' | tr ';' '\n' | while read -r os arch suffix; do \
-		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o "./bin/$*$$suffix" ./cmd/$*); then \
+		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '$(FULL_LDFLAGS)' -o "./bin/$*$$suffix" ./cmd/$*); then \
 			echo "Building $* for GOOS=$$os GOARCH=$$arch failed, see error(s) above."; \
 			exit 1; \
 		fi; \


### PR DESCRIPTION
Squashed 'release-tools/' changes from 3041b8a42..4aff857d8

[4aff857d8](https://github.com/kubernetes-csi/csi-release-tools/commit/4aff857d8) Merge pull request #109 from pohly/alpha-test-defaults
[0427289d5](https://github.com/kubernetes-csi/csi-release-tools/commit/0427289d5) Merge pull request #110 from pohly/kind-0.9-bazel-build-workaround
[9a370ab90](https://github.com/kubernetes-csi/csi-release-tools/commit/9a370ab90) prow.sh: work around "kind build node-image" failure
[522361ec9](https://github.com/kubernetes-csi/csi-release-tools/commit/522361ec9) prow.sh: only run alpha tests for latest Kubernetes release
[22c0395c9](https://github.com/kubernetes-csi/csi-release-tools/commit/22c0395c9) Merge pull request #108 from bnrjee/master
[b5b447b50](https://github.com/kubernetes-csi/csi-release-tools/commit/b5b447b50) Add go ldflags using LDFLAGS at the time of compilation
[16f4afbd8](https://github.com/kubernetes-csi/csi-release-tools/commit/16f4afbd8) Merge pull request #107 from pohly/kind-update
[7bcee13d7](https://github.com/kubernetes-csi/csi-release-tools/commit/7bcee13d7) prow.sh: update to kind 0.9, support Kubernetes 1.19
[df518fbd6](https://github.com/kubernetes-csi/csi-release-tools/commit/df518fbd6) prow.sh: usage of Bazel optional
[c3afd427e](https://github.com/kubernetes-csi/csi-release-tools/commit/c3afd427e) Merge pull request #104 from xing-yang/snapshot
[dde93b220](https://github.com/kubernetes-csi/csi-release-tools/commit/dde93b220) Update to snapshot-controller v3.0.0
[a0f195cc2](https://github.com/kubernetes-csi/csi-release-tools/commit/a0f195cc2) Merge pull request #106 from msau42/fix-canary
[7100c1209](https://github.com/kubernetes-csi/csi-release-tools/commit/7100c1209) Only set staging registry when running canary job
[b3c65f9c7](https://github.com/kubernetes-csi/csi-release-tools/commit/b3c65f9c7) Merge pull request #99 from msau42/add-release-process
[e53f3e85b](https://github.com/kubernetes-csi/csi-release-tools/commit/e53f3e85b) Merge pull request #103 from msau42/fix-canary
[d12946287](https://github.com/kubernetes-csi/csi-release-tools/commit/d12946287) Document new method for adding CI jobs are new K8s versions
[e73c2ce53](https://github.com/kubernetes-csi/csi-release-tools/commit/e73c2ce53) Use staging registry for canary tests
[2c098465d](https://github.com/kubernetes-csi/csi-release-tools/commit/2c098465d) Add cleanup instructions to release-notes generation
[60e1cd3d0](https://github.com/kubernetes-csi/csi-release-tools/commit/60e1cd3d0) Merge pull request #98 from pohly/kubernetes-1-19-fixes
[0979c0910](https://github.com/kubernetes-csi/csi-release-tools/commit/0979c0910) prow.sh: fix E2E suite for Kubernetes >= 1.18
[3b4a2f1d9](https://github.com/kubernetes-csi/csi-release-tools/commit/3b4a2f1d9) prow.sh: fix installing Go for Kubernetes 1.19.0
[1fbb636cb](https://github.com/kubernetes-csi/csi-release-tools/commit/1fbb636cb) Merge pull request #97 from pohly/go-1.15
[82d108acd](https://github.com/kubernetes-csi/csi-release-tools/commit/82d108acd) switch to Go 1.15
[d8a253005](https://github.com/kubernetes-csi/csi-release-tools/commit/d8a253005) Merge pull request #95 from msau42/add-release-process
[843bddca1](https://github.com/kubernetes-csi/csi-release-tools/commit/843bddca1) Add steps on promoting release images
[0345a835e](https://github.com/kubernetes-csi/csi-release-tools/commit/0345a835e) Merge pull request #94 from linux-on-ibm-z/bump-timeout
[1fdf2d53c](https://github.com/kubernetes-csi/csi-release-tools/commit/1fdf2d53c) cloud build: bump timeout in Prow job
[41ec6d153](https://github.com/kubernetes-csi/csi-release-tools/commit/41ec6d153) Merge pull request #93 from animeshk08/patch-1
[5a54e67d8](https://github.com/kubernetes-csi/csi-release-tools/commit/5a54e67d8) filter-junit: Fix gofmt error
[0676fcbd7](https://github.com/kubernetes-csi/csi-release-tools/commit/0676fcbd7) Merge pull request #92 from animeshk08/patch-1
[36ea4ffae](https://github.com/kubernetes-csi/csi-release-tools/commit/36ea4ffae) filter-junit: Fix golint error
[f5a420378](https://github.com/kubernetes-csi/csi-release-tools/commit/f5a420378) Merge pull request #91 from cyb70289/arm64
[43e50d6f6](https://github.com/kubernetes-csi/csi-release-tools/commit/43e50d6f6) prow.sh: enable building arm64 image
[0d5bd8436](https://github.com/kubernetes-csi/csi-release-tools/commit/0d5bd8436) Merge pull request #90 from pohly/k8s-staging-sig-storage
[3df86b7d4](https://github.com/kubernetes-csi/csi-release-tools/commit/3df86b7d4) cloud build: k8s-staging-sig-storage
[c5fd9610f](https://github.com/kubernetes-csi/csi-release-tools/commit/c5fd9610f) Merge pull request #89 from pohly/cloud-build-binfmt
[db0c2a7dc](https://github.com/kubernetes-csi/csi-release-tools/commit/db0c2a7dc) cloud build: initialize support for running commands in Dockerfile
[be902f401](https://github.com/kubernetes-csi/csi-release-tools/commit/be902f401) Merge pull request #88 from pohly/multiarch-windows-fix
[340e082f0](https://github.com/kubernetes-csi/csi-release-tools/commit/340e082f0) build.make: optional inclusion of Windows in multiarch images
[5231f05d8](https://github.com/kubernetes-csi/csi-release-tools/commit/5231f05d8) build.make: properly declare push-multiarch
[4569f27a8](https://github.com/kubernetes-csi/csi-release-tools/commit/4569f27a8) build.make: fix push-multiarch ambiguity
[17dde9ef0](https://github.com/kubernetes-csi/csi-release-tools/commit/17dde9ef0) Merge pull request #87 from pohly/cloud-build
[bd416901d](https://github.com/kubernetes-csi/csi-release-tools/commit/bd416901d) cloud build: initial set of shared files
[9084fecb8](https://github.com/kubernetes-csi/csi-release-tools/commit/9084fecb8) Merge pull request #81 from msau42/add-release-process
[6f2322e80](https://github.com/kubernetes-csi/csi-release-tools/commit/6f2322e80) Update patch release notes generation command
[0fcc3b1bc](https://github.com/kubernetes-csi/csi-release-tools/commit/0fcc3b1bc) Merge pull request #78 from ggriffiths/fix_csi_snapshotter_rbac_version_set
[d8c76fee3](https://github.com/kubernetes-csi/csi-release-tools/commit/d8c76fee3) Support local snapshot RBAC for pull jobs
[c1bdf5bfd](https://github.com/kubernetes-csi/csi-release-tools/commit/c1bdf5bfd) Merge pull request #80 from msau42/add-release-process
[ea1f94aad](https://github.com/kubernetes-csi/csi-release-tools/commit/ea1f94aad) update release tools instructions
[152396e2d](https://github.com/kubernetes-csi/csi-release-tools/commit/152396e2d) Merge pull request #77 from ggriffiths/snapshotter201_update
[7edc1461e](https://github.com/kubernetes-csi/csi-release-tools/commit/7edc1461e) Update snapshotter to version 2.0.1
[4cf843f67](https://github.com/kubernetes-csi/csi-release-tools/commit/4cf843f67) Merge pull request #76 from pohly/build-targets
[3863a0f67](https://github.com/kubernetes-csi/csi-release-tools/commit/3863a0f67) build for multiple platforms only in CI, add s390x
[8322a7d0c](https://github.com/kubernetes-csi/csi-release-tools/commit/8322a7d0c) Merge pull request #72 from pohly/hostpath-update
[7c5a89c8f](https://github.com/kubernetes-csi/csi-release-tools/commit/7c5a89c8f) prow.sh: use 1.3.0 hostpath driver for testing
[b8587b2bf](https://github.com/kubernetes-csi/csi-release-tools/commit/b8587b2bf) Merge pull request #71 from wozniakjan/test-vet
[fdb32183f](https://github.com/kubernetes-csi/csi-release-tools/commit/fdb32183f) Change 'make test-vet' to call 'go vet'
[d717c8c48](https://github.com/kubernetes-csi/csi-release-tools/commit/d717c8c48) Merge pull request #69 from pohly/test-driver-config
[a1432bc97](https://github.com/kubernetes-csi/csi-release-tools/commit/a1432bc97) Merge pull request #70 from pohly/kubelet-feature-gates
[5f74333a4](https://github.com/kubernetes-csi/csi-release-tools/commit/5f74333a4) prow.sh: also configure feature gates for kubelet
[84f78b120](https://github.com/kubernetes-csi/csi-release-tools/commit/84f78b120) prow.sh: generic driver installation
[3c34b4f21](https://github.com/kubernetes-csi/csi-release-tools/commit/3c34b4f21) Merge pull request #67 from windayski/fix-link
[fa90abd07](https://github.com/kubernetes-csi/csi-release-tools/commit/fa90abd07) fix incorrect link
[ff3cc3f1f](https://github.com/kubernetes-csi/csi-release-tools/commit/ff3cc3f1f) Merge pull request #54 from msau42/add-release-process
[ac8a0212b](https://github.com/kubernetes-csi/csi-release-tools/commit/ac8a0212b) Document the process for releasing a new sidecar
[23be65254](https://github.com/kubernetes-csi/csi-release-tools/commit/23be65254) Merge pull request #65 from msau42/update-hostpath
[6582f2ff3](https://github.com/kubernetes-csi/csi-release-tools/commit/6582f2ff3) Update hostpath driver version to get fix for connection-timeout
[4cc917457](https://github.com/kubernetes-csi/csi-release-tools/commit/4cc917457) Merge pull request #64 from ggriffiths/snapshotter_2_version_update
[8191eab6f](https://github.com/kubernetes-csi/csi-release-tools/commit/8191eab6f) Update snapshotter to version v2.0.0
[3c463fb1e](https://github.com/kubernetes-csi/csi-release-tools/commit/3c463fb1e) Merge pull request #61 from msau42/enable-snapshots
[8b0316c7e](https://github.com/kubernetes-csi/csi-release-tools/commit/8b0316c7e) Fix overriding of junit results by using unique names for each e2e run
[5f444b80f](https://github.com/kubernetes-csi/csi-release-tools/commit/5f444b80f) Merge pull request #60 from saad-ali/updateHostpathVersion
[af9549b5a](https://github.com/kubernetes-csi/csi-release-tools/commit/af9549b5a) Update prow hostpath driver version to 1.3.0-rc2
[f6c74b30e](https://github.com/kubernetes-csi/csi-release-tools/commit/f6c74b30e) Merge pull request #57 from ggriffiths/version_gt_kubernetes_fix
[fc8097595](https://github.com/kubernetes-csi/csi-release-tools/commit/fc8097595) Fix version_gt to work with kubernetes prefix
[9f1f3dd84](https://github.com/kubernetes-csi/csi-release-tools/commit/9f1f3dd84) Merge pull request #56 from msau42/enable-snapshots
[b98b2aed0](https://github.com/kubernetes-csi/csi-release-tools/commit/b98b2aed0) Enable snapshot tests in 1.17 to be run in non-alpha jobs.
[9ace02045](https://github.com/kubernetes-csi/csi-release-tools/commit/9ace02045) Merge pull request #52 from msau42/update-readme
[540599ba3](https://github.com/kubernetes-csi/csi-release-tools/commit/540599ba3) Merge pull request #53 from msau42/fix-make
[a4e629966](https://github.com/kubernetes-csi/csi-release-tools/commit/a4e629966) fix syntax for ppc64le build
[771ca6f26](https://github.com/kubernetes-csi/csi-release-tools/commit/771ca6f26) Merge pull request #49 from ggriffiths/prowsh_improve_version_gt
[d7c69d2f9](https://github.com/kubernetes-csi/csi-release-tools/commit/d7c69d2f9) Merge pull request #51 from msau42/enable-multinode
[4ad69492c](https://github.com/kubernetes-csi/csi-release-tools/commit/4ad69492c) Improve snapshot pod running checks and improve version_gt
[53888ae7d](https://github.com/kubernetes-csi/csi-release-tools/commit/53888ae7d) Improve README by adding an explicit Kubernetes dependency section
[9a7a685ee](https://github.com/kubernetes-csi/csi-release-tools/commit/9a7a685ee) Create a kind cluster with two worker nodes so that the topology feature can be tested. Test cases that test accessing volumes from multiple nodes need to be skipped
[4ff2f5f09](https://github.com/kubernetes-csi/csi-release-tools/commit/4ff2f5f09) Merge pull request #50 from darkowlzz/kind-0.6.0
[80bba1fe2](https://github.com/kubernetes-csi/csi-release-tools/commit/80bba1fe2) Use kind v0.6.0
[6d674a7f9](https://github.com/kubernetes-csi/csi-release-tools/commit/6d674a7f9) Merge pull request #47 from Pensu/multi-arch
[8adde494a](https://github.com/kubernetes-csi/csi-release-tools/commit/8adde494a) Merge pull request #45 from ggriffiths/snapshot_beta_crds
[003c14b2d](https://github.com/kubernetes-csi/csi-release-tools/commit/003c14b2d) Add snapshotter CRDs after cluster setup
[a41f38604](https://github.com/kubernetes-csi/csi-release-tools/commit/a41f38604) Merge pull request #46 from mucahitkurt/kind-cluster-cleanup
[1eaaaa1cb](https://github.com/kubernetes-csi/csi-release-tools/commit/1eaaaa1cb) Delete kind cluster after tests run.
[83a4ef15d](https://github.com/kubernetes-csi/csi-release-tools/commit/83a4ef15d) Adding build for ppc64le
[4fcafece5](https://github.com/kubernetes-csi/csi-release-tools/commit/4fcafece5) Merge pull request #43 from pohly/system-pod-logging
[f41c1351a](https://github.com/kubernetes-csi/csi-release-tools/commit/f41c1351a) prow.sh: also log output of system containers
[ee22a9caa](https://github.com/kubernetes-csi/csi-release-tools/commit/ee22a9caa) Merge pull request #42 from pohly/use-vendor-dir
[806784565](https://github.com/kubernetes-csi/csi-release-tools/commit/806784565) travis.yml: also use vendor directory
[23df4aef5](https://github.com/kubernetes-csi/csi-release-tools/commit/23df4aef5) prow.sh: use vendor directory if available
[a53bd4c46](https://github.com/kubernetes-csi/csi-release-tools/commit/a53bd4c46) Merge pull request #41 from pohly/go-version
[c8a1c4af9](https://github.com/kubernetes-csi/csi-release-tools/commit/c8a1c4af9) better handling of Go version
[5e773d2db](https://github.com/kubernetes-csi/csi-release-tools/commit/5e773d2db) update CI to use Go 1.13.3
[f419d7454](https://github.com/kubernetes-csi/csi-release-tools/commit/f419d7454) Merge pull request #40 from msau42/add-1.16
[e0fde8c4f](https://github.com/kubernetes-csi/csi-release-tools/commit/e0fde8c4f) Add new variables for 1.16 and remove 1.13
[adf00feaa](https://github.com/kubernetes-csi/csi-release-tools/commit/adf00feaa) Merge pull request #36 from msau42/full-clone
[f1697d2ca](https://github.com/kubernetes-csi/csi-release-tools/commit/f1697d2ca) Do full git clones in travis. Shallow clones are causing test-subtree errors when the depth is exactly 50.
[2c8191980](https://github.com/kubernetes-csi/csi-release-tools/commit/2c8191980) Merge pull request #34 from pohly/go-mod-tidy
[518d6af6b](https://github.com/kubernetes-csi/csi-release-tools/commit/518d6af6b) Merge pull request #35 from ddebroy/winbld2
[2d6b3ce85](https://github.com/kubernetes-csi/csi-release-tools/commit/2d6b3ce85) Build Windows only for amd64
[c1078a658](https://github.com/kubernetes-csi/csi-release-tools/commit/c1078a658) go-get-kubernetes.sh: automate Kubernetes dependency handling
[194289aa8](https://github.com/kubernetes-csi/csi-release-tools/commit/194289aa8) update Go mod support
[0affdf95a](https://github.com/kubernetes-csi/csi-release-tools/commit/0affdf95a) Merge pull request #33 from gnufied/enable-hostpath-expansion
[6208f6ab4](https://github.com/kubernetes-csi/csi-release-tools/commit/6208f6ab4) Enable hostpath expansion
[6ecaa76eb](https://github.com/kubernetes-csi/csi-release-tools/commit/6ecaa76eb) Merge pull request #30 from msau42/fix-windows
[ea2f1b527](https://github.com/kubernetes-csi/csi-release-tools/commit/ea2f1b527) build windows binaries with .exe suffix
[2d3355064](https://github.com/kubernetes-csi/csi-release-tools/commit/2d3355064) Merge pull request #29 from mucahitkurt/create-2-node-kind-cluster
[a8ea8bcc5](https://github.com/kubernetes-csi/csi-release-tools/commit/a8ea8bcc5) create 2-node kind cluster since topology support is added to hostpath driver
[df8530d9e](https://github.com/kubernetes-csi/csi-release-tools/commit/df8530d9e) Merge pull request #27 from pohly/dep-vendor-check
[35ceaedcb](https://github.com/kubernetes-csi/csi-release-tools/commit/35ceaedcb) prow.sh: install dep if needed
[f85ab5af1](https://github.com/kubernetes-csi/csi-release-tools/commit/f85ab5af1) Merge pull request #26 from ddebroy/windows1
[9fba09b41](https://github.com/kubernetes-csi/csi-release-tools/commit/9fba09b41) Add rule for building Windows binaries
[040086764](https://github.com/kubernetes-csi/csi-release-tools/commit/040086764) Merge pull request #25 from msau42/fix-master-jobs
[dc0a5d838](https://github.com/kubernetes-csi/csi-release-tools/commit/dc0a5d838) Update kind to v0.5.0
[aa85b82ca](https://github.com/kubernetes-csi/csi-release-tools/commit/aa85b82ca) Merge pull request #23 from msau42/fix-master-jobs
[f46191d9a](https://github.com/kubernetes-csi/csi-release-tools/commit/f46191d9a) Kubernetes master changed the way that releases are tagged, which needed changes to kind. There are 3 changes made to prow.sh:
[1cac3af3f](https://github.com/kubernetes-csi/csi-release-tools/commit/1cac3af3f) Merge pull request #22 from msau42/add-1.15-jobs
[0c0dc300c](https://github.com/kubernetes-csi/csi-release-tools/commit/0c0dc300c) prow.sh: tag master images with a large version number
[f4f73cefb](https://github.com/kubernetes-csi/csi-release-tools/commit/f4f73cefb) Merge pull request #21 from msau42/add-1.15-jobs
[4e31f078a](https://github.com/kubernetes-csi/csi-release-tools/commit/4e31f078a) Change default hostpath driver name to hostpath.csi.k8s.io
[4b6fa4a0b](https://github.com/kubernetes-csi/csi-release-tools/commit/4b6fa4a0b) Update hostpath version for sidecar testing to v1.2.0-rc2
[ecc79187c](https://github.com/kubernetes-csi/csi-release-tools/commit/ecc79187c) Update kind to v0.4.0. This requires overriding Kubernetes versions with specific patch versions that kind 0.4.0 supports. Also, feature gate setting is only supported on 1.15+ due to kind.sigs.k8s.io/v1alpha3 and kubeadm.k8s.io/v1beta2 dependencies.
[a6f21d405](https://github.com/kubernetes-csi/csi-release-tools/commit/a6f21d405) Add variables for 1.15
[db8abb6e1](https://github.com/kubernetes-csi/csi-release-tools/commit/db8abb6e1) Merge pull request #20 from pohly/test-driver-config
[b2f4e051d](https://github.com/kubernetes-csi/csi-release-tools/commit/b2f4e051d) prow.sh: flexible test driver config
[03999882f](https://github.com/kubernetes-csi/csi-release-tools/commit/03999882f) Merge pull request #19 from pohly/go-mod-vendor
[066143d14](https://github.com/kubernetes-csi/csi-release-tools/commit/066143d14) build.make: allow repos to use 'go mod' for vendoring
[0bee74933](https://github.com/kubernetes-csi/csi-release-tools/commit/0bee74933) Merge pull request #18 from pohly/go-version
[e157b6b51](https://github.com/kubernetes-csi/csi-release-tools/commit/e157b6b51) update to Go 1.12.4
[88dc9a47e](https://github.com/kubernetes-csi/csi-release-tools/commit/88dc9a47e) Merge pull request #17 from pohly/prow
[0fafc663d](https://github.com/kubernetes-csi/csi-release-tools/commit/0fafc663d) prow.sh: skip sanity testing if component doesn't support it
[bcac1c1fb](https://github.com/kubernetes-csi/csi-release-tools/commit/bcac1c1fb) Merge pull request #16 from pohly/prow
[0b10f6a4b](https://github.com/kubernetes-csi/csi-release-tools/commit/0b10f6a4b) prow.sh: update csi-driver-host-path
[0c2677e8f](https://github.com/kubernetes-csi/csi-release-tools/commit/0c2677e8f) Merge pull request #15 from pengzhisun/master
[ff9bce4a7](https://github.com/kubernetes-csi/csi-release-tools/commit/ff9bce4a7) Replace 'return' to 'exit' to fix shellcheck error
[c60f3823c](https://github.com/kubernetes-csi/csi-release-tools/commit/c60f3823c) Merge pull request #14 from pohly/prow
[7aaac2257](https://github.com/kubernetes-csi/csi-release-tools/commit/7aaac2257) prow.sh: remove AllAlpha=all, part II
[66177736d](https://github.com/kubernetes-csi/csi-release-tools/commit/66177736d) Merge pull request #13 from pohly/prow
[cda2fc587](https://github.com/kubernetes-csi/csi-release-tools/commit/cda2fc587) prow.sh: avoid AllAlpha=true
[546d5504a](https://github.com/kubernetes-csi/csi-release-tools/commit/546d5504a) prow.sh: debug failing KinD cluster creation
[9b0d9cd74](https://github.com/kubernetes-csi/csi-release-tools/commit/9b0d9cd74) build.make: skip shellcheck if Docker is not available
[aa45a1cd9](https://github.com/kubernetes-csi/csi-release-tools/commit/aa45a1cd9) prow.sh: more efficient execution of individual tests
[f3d1d2df5](https://github.com/kubernetes-csi/csi-release-tools/commit/f3d1d2df5) prow.sh: fix hostpath driver version check
[31dfaf31d](https://github.com/kubernetes-csi/csi-release-tools/commit/31dfaf31d) prow.sh: fix running of just "alpha" tests
[f5014439f](https://github.com/kubernetes-csi/csi-release-tools/commit/f5014439f) prow.sh: AllAlpha=true for unknown Kubernetes versions
[95ae9de9a](https://github.com/kubernetes-csi/csi-release-tools/commit/95ae9de9a) Merge pull request #9 from pohly/prow
[d87eccb46](https://github.com/kubernetes-csi/csi-release-tools/commit/d87eccb46) prow.sh: switch back to upstream csi-driver-host-path
[6602d38bf](https://github.com/kubernetes-csi/csi-release-tools/commit/6602d38bf) prow.sh: different E2E suite depending on Kubernetes version
[741319bd3](https://github.com/kubernetes-csi/csi-release-tools/commit/741319bd3) prow.sh: improve building Kubernetes from source
[29545bb01](https://github.com/kubernetes-csi/csi-release-tools/commit/29545bb01) prow.sh: take Go version from Kubernetes source
[429581c52](https://github.com/kubernetes-csi/csi-release-tools/commit/429581c52) prow.sh: pull Go version from travis.yml
[0a0fd49b8](https://github.com/kubernetes-csi/csi-release-tools/commit/0a0fd49b8) prow.sh: comment clarification
[2069a0af3](https://github.com/kubernetes-csi/csi-release-tools/commit/2069a0af3) Merge pull request #11 from pohly/verify-shellcheck
[55212ff2b](https://github.com/kubernetes-csi/csi-release-tools/commit/55212ff2b) initial Prow test job
[6c7ba1be0](https://github.com/kubernetes-csi/csi-release-tools/commit/6c7ba1be0) build.make: integrate shellcheck into "make test"
[b2d25d4f4](https://github.com/kubernetes-csi/csi-release-tools/commit/b2d25d4f4) verify-shellcheck.sh: make it usable in csi-release-tools
[3b6af7b1c](https://github.com/kubernetes-csi/csi-release-tools/commit/3b6af7b1c) Merge pull request #12 from pohly/local-e2e-suite
[104a1ac96](https://github.com/kubernetes-csi/csi-release-tools/commit/104a1ac96) build.make: avoid unit-testing E2E test suite
[34010e752](https://github.com/kubernetes-csi/csi-release-tools/commit/34010e752) Merge pull request #10 from pohly/vendor-check
[e6db50df7](https://github.com/kubernetes-csi/csi-release-tools/commit/e6db50df7) check vendor directory
[fb13c5198](https://github.com/kubernetes-csi/csi-release-tools/commit/fb13c5198) verify-shellcheck.sh: import from Kubernetes
[94fc1e31d](https://github.com/kubernetes-csi/csi-release-tools/commit/94fc1e31d) build.make: avoid unit-testing E2E test suite
[849db0ad2](https://github.com/kubernetes-csi/csi-release-tools/commit/849db0ad2) Merge pull request #8 from pohly/subtree-check-relax
[cc564f929](https://github.com/kubernetes-csi/csi-release-tools/commit/cc564f929) verify-subtree.sh: relax check and ignore old content
[33d58fdc2](https://github.com/kubernetes-csi/csi-release-tools/commit/33d58fdc2) Merge pull request #5 from pohly/test-enhancements
[be8a4400a](https://github.com/kubernetes-csi/csi-release-tools/commit/be8a4400a) Merge pull request #4 from pohly/canary-fix
[b0336b553](https://github.com/kubernetes-csi/csi-release-tools/commit/b0336b553) build.make: more readable "make test" output
[09436b9f9](https://github.com/kubernetes-csi/csi-release-tools/commit/09436b9f9) build.make: fix pushing of "canary" image from master branch
[147892c95](https://github.com/kubernetes-csi/csi-release-tools/commit/147892c95) build.make: support suppressing checks
[154e33d43](https://github.com/kubernetes-csi/csi-release-tools/commit/154e33d43) build.make: clarify usage of "make V=1"

git-subtree-dir: release-tools
git-subtree-split: 4aff857d88149e07951fcd1322f462f765401a86

```release-note
NONE
```