### PR TITLE
added labels to the resources to be used for collective operation

### DIFF
--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -6,6 +6,8 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: csi-provisioner
+  labels:
+    app: csi-provisioner
 spec:
   replicas: 3
   selector:

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -14,12 +14,16 @@ metadata:
   name: csi-provisioner
   # replace with non-default namespace name
   namespace: default
+  labels:
+    app: csi-provisioner
 
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: external-provisioner-runner
+  labels:
+    app: csi-provisioner
 rules:
   # The following rule should be uncommented for plugins that require secrets
   # for provisioning.
@@ -63,6 +67,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-provisioner-role
+  labels:
+    app: csi-provisioner
 subjects:
   - kind: ServiceAccount
     name: csi-provisioner
@@ -82,6 +88,8 @@ metadata:
   # replace with non-default namespace name
   namespace: default
   name: external-provisioner-cfg
+  labels:
+    app: csi-provisioner
 rules:
 # Only one of the following rules for endpoints or leases is required based on
 # what is set for `--leader-election-type`. Endpoints are deprecated in favor of Leases.
@@ -114,6 +122,8 @@ metadata:
   name: csi-provisioner-role-cfg
   # replace with non-default namespace name
   namespace: default
+  labels:
+    app: csi-provisioner
 subjects:
   - kind: ServiceAccount
     name: csi-provisioner

--- a/deploy/kubernetes/storage-capacity.yaml
+++ b/deploy/kubernetes/storage-capacity.yaml
@@ -9,6 +9,8 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: csi-provisioner
+  labels:
+    app: csi-provisioner
 spec:
   replicas: 3
   selector:


### PR DESCRIPTION
What type of PR is this?
/kind feature

What this PR does / why we need it:
We need to add the common/generic labels to all the resources which are being deployed as the part of any csi driver. It is the part of this [PR](https://github.com/kubernetes-csi/csi-driver-host-path/pull/216)

Special notes for your reviewer:
Since there was no common labels to identify all the items in one set of resources installed, these labels can help us to identify resources and operate on them in a collective manner

Does this PR introduce a user-facing change?:

NONE
