### PR TITLE
Return an error when data source is unsupported

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -489,7 +489,7 @@ func (p *csiProvisioner) Provision(ctx context.Context, options controller.Provi
 			// DataSource is not VolumeSnapshot and PVC
 			// Wait for an external data populator to create the volume
 			p.eventRecorder.Event(options.PVC, v1.EventTypeNormal, "Provisioning", fmt.Sprintf("Waiting for a volume to be created by an external data populator"))
-			return nil, controller.ProvisioningFinished, nil
+			return nil, controller.ProvisioningFinished, fmt.Errorf("data source %s not handled by external provisioner", options.PVC.Spec.DataSource.Kind)
 		}
 	}
 	if err := p.checkDriverCapabilities(rc); err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -485,11 +485,13 @@ func (p *csiProvisioner) Provision(ctx context.Context, options controller.Provi
 		case pvcKind:
 			rc.clone = true
 		default:
-			klog.Infof("DataSource specified (%s) is not supported by the provisioner, waiting for an external data populator to create the volume", options.PVC.Spec.DataSource.Kind)
 			// DataSource is not VolumeSnapshot and PVC
-			// Wait for an external data populator to create the volume
-			p.eventRecorder.Event(options.PVC, v1.EventTypeNormal, "Provisioning", fmt.Sprintf("Waiting for a volume to be created by an external data populator"))
-			return nil, controller.ProvisioningFinished, fmt.Errorf("data source %s not handled by external provisioner", options.PVC.Spec.DataSource.Kind)
+			// Assume external data populator to create the volume, and there is no more work for us to do
+			p.eventRecorder.Event(options.PVC, v1.EventTypeNormal, "Provisioning", fmt.Sprintf("Assuming an external populator will provision the volume"))
+			return nil, controller.ProvisioningFinished, &controller.IgnoredError{
+				Reason: fmt.Sprintf("data source (%s) is not handled by the provisioner, assuming an external populator will provision it",
+					options.PVC.Spec.DataSource.Kind),
+			}
 		}
 	}
 	if err := p.checkDriverCapabilities(rc); err != nil {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1799,7 +1799,7 @@ func TestProvision(t *testing.T) {
 				},
 			},
 			expectState:      controller.ProvisioningFinished,
-			expectErr:        false,
+			expectErr:        true,
 			skipCreateVolume: true,
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fix a panic bug caused by unsupported data source.

**Which issue(s) this PR fixes**:

Fixes #533

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:
```release-note
Fix panic when using an external data source
```
