### PR TITLE
Allow some PVC annotations to be passed to CreateVolume()

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -71,11 +71,12 @@ var (
 	strictTopology          = flag.Bool("strict-topology", false, "Late binding: pass only selected node topology to CreateVolume Request, unlike default behavior of passing aggregated cluster topologies that match with topology keys of the selected node.")
 	immediateTopology       = flag.Bool("immediate-topology", true, "Immediate binding: pass aggregated cluster topologies for all nodes where the CSI driver is available (enabled, the default) or no topology requirements (if disabled).")
 	extraCreateMetadata     = flag.Bool("extra-create-metadata", false, "If set, add pv/pvc metadata to plugin create requests as parameters.")
+	annotationPrefix        = flag.String("annotation-prefix", "", "PVC annotations prefixed with this string will be included along with storage class parameters when creating volumes. If not set, no annotations will be sent to the CSI plugin. Defaults to not set.")
 
 	metricsAddress = flag.String("metrics-address", "", "The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled.")
 	metricsPath    = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
 
-	defaultFSType = flag.String("default-fstype", "", "The default filesystem type of the volume to provision when fstype is unspecified in the StorageClass. If the default is not set and fstype is unset in the StorageClass, then no fstype will be set")
+	defaultFSType = flag.String("default-fstype", "", "The default filesystem type of the volume to provision when fstype is unspecified in the StorageClass. If the default is not set and fstype is unset in the StorageClass, then no fstype will be set.")
 
 	kubeAPIQPS   = flag.Float32("kube-api-qps", 5, "QPS to use while communicating with the kubernetes apiserver. Defaults to 5.0.")
 	kubeAPIBurst = flag.Int("kube-api-burst", 10, "Burst to use while communicating with the kubernetes apiserver. Defaults to 10.")
@@ -269,6 +270,7 @@ func main() {
 		vaLister,
 		*extraCreateMetadata,
 		*defaultFSType,
+		*annotationPrefix,
 	)
 
 	provisionController = controller.NewProvisionController(


### PR DESCRIPTION
Add an option to the external-provisioner sidecar to pass a subset of the
PVC annotations to CreateVolume(). Using a vendor or administrator-specified
prefix, PVC annotations matching that prefix will be included alongside
storage class parameters.

This avoids conflicts between storage class parameters and PVC annotations
by only allowing annotations with a speficic prefix to be passed through.
Vendors must use vendor-specific prefixes to avoid conflicts between CSI
plugins.

The options defaults to disabled, and requires vendor support in the CSI
plugin to enable. Administrators may override this and disable it by
modifying the sidecar container to not pass the option.

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This allows per-PVC options to be passed through in a way that minimizes the problematic reasons we've rejected similar proposals in the past.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
TBD
```
