### PR TITLE
avoid one GET Node per volume with late binding

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -231,6 +231,7 @@ func main() {
 		controller.Threadiness(int(*workerThreads)),
 		controller.CreateProvisionedPVLimiter(workqueue.DefaultControllerRateLimiter()),
 		controller.ClaimsInformer(claimInformer),
+		controller.NodesLister(nodeLister),
 	}
 
 	translator := csitrans.New()

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	k8s.io/klog/v2 v2.3.0
 	k8s.io/kubernetes v1.19.0
 	sigs.k8s.io/controller-runtime v0.6.2
-	sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.1.0
+	sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.2.0
 )
 
 replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -917,8 +917,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9/go.mod h1:dzAXnQb
 sigs.k8s.io/controller-runtime v0.6.2 h1:jkAnfdTYBpFwlmBn3pS5HFO06SfxvnTZ1p5PeEF/zAA=
 sigs.k8s.io/controller-runtime v0.6.2/go.mod h1:vhcq/rlnENJ09SIRp3EveTaZ0yqH526hjf9iJdbUJ/E=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
-sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.1.0 h1:4kyxBJ/3fzLooWOZkx5NEO/pUN6woM9JBnHuyWzqkc8=
-sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.1.0/go.mod h1:DhZ52sQMJHW21+JXyA2LRUPRIxKnrNrwh+QFV+2tVA4=
+sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.2.0 h1:W9pg6FBDxI8A/G0FbDjwKXvIG7ZDfyQODtoGzHFxa60=
+sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.2.0/go.mod h1:DhZ52sQMJHW21+JXyA2LRUPRIxKnrNrwh+QFV+2tVA4=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1 h1:YXTMot5Qz/X1iBRJhAt+vI+HVttY0WkSqqhKxQ0xVbA=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -560,7 +560,7 @@ sigs.k8s.io/controller-runtime/pkg/client
 sigs.k8s.io/controller-runtime/pkg/client/apiutil
 sigs.k8s.io/controller-runtime/pkg/client/fake
 sigs.k8s.io/controller-runtime/pkg/internal/objectutil
-# sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.1.0
+# sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.2.0
 ## explicit
 sigs.k8s.io/sig-storage-lib-external-provisioner/v6/controller
 sigs.k8s.io/sig-storage-lib-external-provisioner/v6/controller/metrics


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

sig-storage-lib-external-provisioner used to do one GET of the Node
object when provisioning volumes with a selected node (= late
binding). Scale testing showed that this caused significant traffic
that can easily be avoided by granting the lib access to the shared
informer that external-provisioner has already.

**Special notes for your reviewer**:

This is also part of PR #524 but can be merged separately.

**Does this PR introduce a user-facing change?**:
```release-note
more efficient provisioning of volumes with late binding by avoiding one GET Node per volume
```
