### PR TITLE
Fix: update old capacity to cache

### DIFF
--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -568,12 +568,6 @@ func (c *Controller) onCAddOrUpdate(ctx context.Context, capacity *storagev1alph
 		if capacity2 != nil && capacity2.UID == capacity.UID {
 			// We already have matched the object.
 			klog.V(5).Infof("Capacity Controller: CSIStorageCapacity %s is already known to match %+v", capacity.Name, item)
-			// If it has a different capacity than our old copy, then someone else must have
-			// modified the capacity and we need to check the capacity anew.
-			if capacity2.Capacity.Value() != capacity.Capacity.Value() {
-				klog.V(5).Infof("Capacity Controller: CSIStorageCapacity %s was modified by someone, enqueueing %v for fixing", capacity.Name, item)
-				c.queue.Add(item)
-			}
 			// Either way, remember the new object revision to avoid the "conflict" error
 			// when we try to update the old object.
 			c.capacities[item] = capacity


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes (https://github.com/kubernetes-csi/external-provisioner/issues/554)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
