### PR TITLE
update sig-storage-lib-external-provisioner to v6.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	k8s.io/klog/v2 v2.4.0
 	k8s.io/kubernetes v1.20.0
 	sigs.k8s.io/controller-runtime v0.7.0
-	sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.2.0
+	sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0
 )
 
 replace k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -1287,8 +1287,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyz
 sigs.k8s.io/controller-runtime v0.7.0 h1:bU20IBBEPccWz5+zXpLnpVsgBYxqclaHu1pVDl/gEt8=
 sigs.k8s.io/controller-runtime v0.7.0/go.mod h1:pJ3YBrJiAqMAZKi6UVGuE98ZrroV1p+pIhoHsMm9wdU=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
-sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.2.0 h1:W9pg6FBDxI8A/G0FbDjwKXvIG7ZDfyQODtoGzHFxa60=
-sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.2.0/go.mod h1:DhZ52sQMJHW21+JXyA2LRUPRIxKnrNrwh+QFV+2tVA4=
+sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0 h1:IKsKAnscMyIOqyl8s8V7guTcx0QBEa6OT57EPgAgpmM=
+sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0/go.mod h1:DhZ52sQMJHW21+JXyA2LRUPRIxKnrNrwh+QFV+2tVA4=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2 h1:YHQV7Dajm86OuqnIR6zAelnDWBRjo+YhYV9PmGrh1s8=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -600,7 +600,7 @@ sigs.k8s.io/controller-runtime/pkg/client
 sigs.k8s.io/controller-runtime/pkg/client/apiutil
 sigs.k8s.io/controller-runtime/pkg/client/fake
 sigs.k8s.io/controller-runtime/pkg/internal/objectutil
-# sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.2.0
+# sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0
 ## explicit
 sigs.k8s.io/sig-storage-lib-external-provisioner/v6/controller
 sigs.k8s.io/sig-storage-lib-external-provisioner/v6/controller/metrics


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This imports a fix for missing PVC updates in certain scenarios.

**Does this PR introduce a user-facing change?**:
```release-note
external-provisioner may have [stopped provisioning](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/pull/103) for a PVC depending on certain timing conditions (provisioning failed once, next attempt currently running, PVC update arrives from API server).
```
