### PR TITLE
Capacity informer race

### DIFF
--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -85,8 +85,11 @@ type Controller struct {
 	pollPeriod       time.Duration
 	immediateBinding bool
 
-	// capacities contains one entry for each object that is supposed
-	// to exist.
+	// capacities contains one entry for each object that is
+	// supposed to exist. Entries that exist on the API server
+	// have a non-nil pointer. Those get added and updated
+	// exclusively through the informer event handler to avoid
+	// races.
 	capacities     map[workItem]*storagev1alpha1.CSIStorageCapacity
 	capacitiesLock sync.Mutex
 }
@@ -513,7 +516,11 @@ func (c *Controller) syncCapacity(ctx context.Context, item workItem) error {
 		if err != nil {
 			return fmt.Errorf("create CSIStorageCapacity for %+v: %v", item, err)
 		}
-		klog.V(5).Infof("Capacity Controller: created %s for %+v with capacity %v", capacity.Name, item, quantity)
+		klog.V(5).Infof("Capacity Controller: created %s with resource version %s for %+v with capacity %v", capacity.Name, capacity.ResourceVersion, item, quantity)
+		// We intentionally avoid storing the created object in c.capacities because that
+		// would race with receiving that object through the event handler. In the unlikely
+		// scenario that we end up creating two objects for the same work item, the second
+		// one will be recognized as duplicate and get deleted again once we receive it.
 	} else if capacity.Capacity.Value() == quantity.Value() {
 		klog.V(5).Infof("Capacity Controller: no need to update %s for %+v, same capacity %v", capacity.Name, item, quantity)
 		return nil
@@ -527,6 +534,9 @@ func (c *Controller) syncCapacity(ctx context.Context, item workItem) error {
 		if err != nil {
 			return fmt.Errorf("update CSIStorageCapacity for %+v: %v", item, err)
 		}
+		klog.V(5).Infof("Capacity Controller: updated %s with new resource version %s for %+v with capacity %v", capacity.Name, capacity.ResourceVersion, item, quantity)
+		// As for Create above, c.capacities intentionally doesn't get updated with the modified
+		// object to avoid races.
 	}
 
 	return nil
@@ -567,7 +577,7 @@ func (c *Controller) onCAddOrUpdate(ctx context.Context, capacity *storagev1alph
 	for item, capacity2 := range c.capacities {
 		if capacity2 != nil && capacity2.UID == capacity.UID {
 			// We already have matched the object.
-			klog.V(5).Infof("Capacity Controller: CSIStorageCapacity %s is already known to match %+v", capacity.Name, item)
+			klog.V(5).Infof("Capacity Controller: CSIStorageCapacity %s with resource version %s is already known to match %+v", capacity.Name, capacity.ResourceVersion, item)
 			// Either way, remember the new object revision to avoid the "conflict" error
 			// when we try to update the old object.
 			c.capacities[item] = capacity
@@ -578,13 +588,13 @@ func (c *Controller) onCAddOrUpdate(ctx context.Context, capacity *storagev1alph
 			reflect.DeepEqual(item.segment.GetLabelSelector(), capacity.NodeTopology) {
 			// This is the capacity object for this particular combination
 			// of parameters. Reuse it.
-			klog.V(5).Infof("Capacity Controller: CSIStorageCapacity %s matches %+v", capacity.Name, item)
+			klog.V(5).Infof("Capacity Controller: CSIStorageCapacity %s with resource version %s matches %+v", capacity.Name, capacity.ResourceVersion, item)
 			c.capacities[item] = capacity
 			return
 		}
 	}
 	// The CSIStorageCapacity object is obsolete, delete it.
-	klog.V(5).Infof("Capacity Controller: CSIStorageCapacity %s is obsolete, enqueue for removal", capacity.Name)
+	klog.V(5).Infof("Capacity Controller: CSIStorageCapacity %s with resource version %s is obsolete, enqueue for removal", capacity.Name, capacity.ResourceVersion)
 	c.queue.Add(capacity)
 }
 

--- a/pkg/capacity/capacity_test.go
+++ b/pkg/capacity/capacity_test.go
@@ -522,43 +522,6 @@ func TestController(t *testing.T) {
 				},
 			},
 		},
-		"fix modified capacity": {
-			topology: topology.NewMock(&layer0),
-			storage: mockCapacity{
-				capacity: map[string]interface{}{
-					// This matches layer0.
-					"foo": "1Gi",
-				},
-			},
-			initialSCs: []testSC{
-				{
-					name:       "other-sc",
-					driverName: driverName,
-				},
-			},
-			expectedCapacities: []testCapacity{
-				{
-					uid:              "CSISC-UID-1",
-					resourceVersion:  csiscRev + "0",
-					segment:          layer0,
-					storageClassName: "other-sc",
-					quantity:         "1Gi",
-				},
-			},
-			modify: func(ctx context.Context, clientSet *fakeclientset.Clientset, expected []testCapacity) ([]testCapacity, error) {
-				capacities, err := clientSet.StorageV1alpha1().CSIStorageCapacities(ownerNamespace).List(ctx, metav1.ListOptions{})
-				if err != nil {
-					return nil, err
-				}
-				capacity := capacities.Items[0]
-				capacity.Capacity = &mb
-				if _, err := clientSet.StorageV1alpha1().CSIStorageCapacities(ownerNamespace).Update(ctx, &capacity, metav1.UpdateOptions{}); err != nil {
-					return nil, err
-				}
-				expected[0].resourceVersion = csiscRev + "2"
-				return expected, nil
-			},
-		},
 		"re-create capacity": {
 			topology: topology.NewMock(&layer0),
 			storage: mockCapacity{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Fixes a race.

**Which issue(s) this PR fixes**:
Fixes #554

**Special notes for your reviewer**:

This supersedes https://github.com/kubernetes-csi/external-provisioner/pull/559 (squashed commits, test fix, additional comments and logging).

**Does this PR introduce a user-facing change?**:
```release-note
producing storage capacity may have failed with `the object has been modified` errors
```
