### PR TITLE
Add TranslateInTreeStorageClassToCSI in Delete

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1145,6 +1145,14 @@ func (p *csiProvisioner) Delete(ctx context.Context, volume *v1.PersistentVolume
 	storageClassName := util.GetPersistentVolumeClass(volume)
 	if len(storageClassName) != 0 {
 		if storageClass, err := p.scLister.Get(storageClassName); err == nil {
+			if migratedVolume && storageClass.Provisioner == p.supportsMigrationFromInTreePluginName {
+				klog.V(2).Infof("translating storage class for in-tree plugin %s to CSI", storageClass.Provisioner)
+				storageClass, err = p.translator.TranslateInTreeStorageClassToCSI(p.supportsMigrationFromInTreePluginName, storageClass)
+				if err != nil {
+					return err
+				}
+			}
+
 			// Resolve provision secret credentials.
 			provisionerSecretRef, err := getSecretReference(provisionerSecretParams, storageClass.Parameters, volume.Name, &v1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #552

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
If the in-tree providers are depending on StorageClass for DeleteVolume, volumes could not get deleted after migrating from them. So translate in-tree StorageClass to CSI to get SecretReference in DeleteVolume call for CSI Migration scenario.
```
