### PR TITLE
additional metrics

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -28,6 +28,8 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	flag "github.com/spf13/pflag"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -42,6 +44,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
 	utilflag "k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/metrics/legacyregistry"
+	_ "k8s.io/component-base/metrics/prometheus/clientgo/leaderelection" // register leader election in the default legacy registry
+	_ "k8s.io/component-base/metrics/prometheus/workqueue"               // register work queues in the default legacy registry
 	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v6/controller"
@@ -180,7 +185,11 @@ func main() {
 		klog.Fatalf("Error getting server version: %v", err)
 	}
 
-	metricsManager := metrics.NewCSIMetricsManager("" /* driverName */)
+	metricsManager := metrics.NewCSIMetricsManagerWithOptions("", /* driverName */
+		// Will be provided via default gatherer.
+		metrics.WithProcessStartTime(false),
+		metrics.WithSubsystem(metrics.SubsystemSidecar),
+	)
 
 	grpcClient, err := ctrl.Connect(*csiEndpoint, metricsManager)
 	if err != nil {
@@ -200,6 +209,7 @@ func main() {
 		klog.Fatalf("Error getting CSI driver name: %s", err)
 	}
 	klog.V(2).Infof("Detected CSI driver %s", provisionerName)
+	metricsManager.SetDriverName(provisionerName)
 
 	translator := csitrans.New()
 	supportsMigrationFromInTreePluginName := ""
@@ -229,16 +239,16 @@ func main() {
 
 	// Prepare http endpoint for metrics + leader election healthz
 	mux := http.NewServeMux()
-	if addr != "" {
-		metricsManager.RegisterToServer(mux, *metricsPath)
-		metricsManager.SetDriverName(provisionerName)
-		go func() {
-			klog.Infof("ServeMux listening at %q", addr)
-			err := http.ListenAndServe(addr, mux)
-			if err != nil {
-				klog.Fatalf("Failed to start HTTP server at specified address (%q) and metrics path (%q): %s", addr, *metricsPath, err)
-			}
-		}()
+	gatherers := prometheus.Gatherers{
+		// For workqueue and leader election metrics, set up via the anonymous imports of:
+		// https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
+		// https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/metrics/prometheus/clientgo/leaderelection/metrics.go
+		//
+		// Also to happens to include Go runtime and process metrics:
+		// https://github.com/kubernetes/kubernetes/blob/9780d88cb6a4b5b067256ecb4abf56892093ee87/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go#L46-L49
+		legacyregistry.DefaultGatherer,
+		// For CSI operations.
+		metricsManager.GetRegistry(),
 	}
 
 	pluginCapabilities, controllerCapabilities, err := ctrl.GetDriverCapabilities(grpcClient, *operationTimeout)
@@ -448,7 +458,7 @@ func main() {
 			csi.NewControllerClient(grpcClient),
 			provisionerName,
 			clientset,
-			// TODO: metrics for the queue?!
+			// Metrics for the queue is available in the default registry.
 			workqueue.NewNamedRateLimitingQueue(rateLimiter, "csistoragecapacity"),
 			*controller,
 			namespace,
@@ -458,6 +468,31 @@ func main() {
 			*capacityPollInterval,
 			*capacityImmediateBinding,
 		)
+	}
+
+	// Start HTTP server, regardless whether we are the leader or not.
+	if addr != "" {
+		// To collect metrics data from the metric handler itself, we
+		// let it register itself and then collect from that registry.
+		reg := prometheus.NewRegistry()
+		gatherers = append(gatherers, reg)
+
+		// This is similar to k8s.io/component-base/metrics HandlerWithReset
+		// except that we gather from multiple sources. This is necessary
+		// because both CSI metrics manager and component-base manage
+		// their own registry. Probably could be avoided by making
+		// CSI metrics manager a bit more flexible.
+		mux.Handle(*metricsPath,
+			promhttp.InstrumentMetricHandler(
+				reg,
+				promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{})))
+		go func() {
+			klog.Infof("ServeMux listening at %q", addr)
+			err := http.ListenAndServe(addr, mux)
+			if err != nil {
+				klog.Fatalf("Failed to start HTTP server at specified address (%q) and metrics path (%q): %s", addr, *metricsPath, err)
+			}
+		}()
 	}
 
 	run := func(ctx context.Context) {

--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -468,6 +468,7 @@ func main() {
 			*capacityPollInterval,
 			*capacityImmediateBinding,
 		)
+		legacyregistry.CustomMustRegister(capacityController)
 	}
 
 	// Start HTTP server, regardless whether we are the leader or not.

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/kubernetes-csi/csi-test/v4 v4.0.2
 	github.com/kubernetes-csi/external-snapshotter/client/v3 v3.0.0
 	github.com/miekg/dns v1.1.40 // indirect
-	github.com/prometheus/client_golang v1.9.0 // indirect
+	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/common v0.19.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/spf13/pflag v1.0.5

--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/component-base/metrics"
 	"k8s.io/klog/v2"
 )
 
@@ -73,6 +74,8 @@ const (
 // and storage class name as some other object. That should never happen,
 // but the controller is prepared to clean that up, just in case.
 type Controller struct {
+	metrics.BaseStableCollector
+
 	csiController    CSICapacityClient
 	driverName       string
 	client           kubernetes.Interface
@@ -107,6 +110,28 @@ var (
 		Factor:   1.1,
 		Steps:    10,
 	}
+
+	objectsGoalDesc = metrics.NewDesc(
+		"csistoragecapacities_desired_goal",
+		"Number of CSIStorageCapacity objects that are supposed to be managed automatically.",
+		nil, nil,
+		metrics.ALPHA,
+		"",
+	)
+	objectsCurrentDesc = metrics.NewDesc(
+		"csistoragecapacities_desired_current",
+		"Number of CSIStorageCapacity objects that exist and are supposed to be managed automatically.",
+		nil, nil,
+		metrics.ALPHA,
+		"",
+	)
+	objectsObsoleteDesc = metrics.NewDesc(
+		"csistoragecapacities_obsolete",
+		"Number of CSIStorageCapacity objects that exist and will be deleted automatically. Objects that exist and may need an update are not considered obsolete and therefore not included in this value.",
+		nil, nil,
+		metrics.ALPHA,
+		"",
+	)
 )
 
 // CSICapacityClient is the relevant subset of csi.ControllerClient.
@@ -115,6 +140,8 @@ type CSICapacityClient interface {
 }
 
 // NewController creates a new controller for CSIStorageCapacity objects.
+// It implements metrics.StableCollector and thus can be registered in
+// a registry.
 func NewCentralCapacityController(
 	csiController CSICapacityClient,
 	driverName string,
@@ -185,6 +212,8 @@ func NewCentralCapacityController(
 
 	return c
 }
+
+var _ metrics.StableCollector = &Controller{}
 
 // Run is a main Controller handler
 func (c *Controller) Run(ctx context.Context, threadiness int) {
@@ -358,8 +387,11 @@ func (c *Controller) addWorkItem(segment *topology.Segment, sc *storagev1.Storag
 		storageClassName: sc.Name,
 	}
 	// Ensure that we have an entry for it...
-	capacity := c.capacities[item]
-	c.capacities[item] = capacity
+	_, found := c.capacities[item]
+	if !found {
+		c.capacities[item] = nil
+	}
+
 	// ... and then tell our workers to update
 	// or create that capacity object.
 	klog.V(5).Infof("Capacity Controller: enqueuing %+v", item)
@@ -611,6 +643,83 @@ func (c *Controller) onCDelete(ctx context.Context, capacity *storagev1alpha1.CS
 			return
 		}
 	}
+}
+
+// DescribeWithStability implements the metrics.StableCollector interface.
+func (c *Controller) DescribeWithStability(ch chan<- *metrics.Desc) {
+	ch <- objectsGoalDesc
+	ch <- objectsCurrentDesc
+	ch <- objectsObsoleteDesc
+}
+
+// CollectWithStability implements the metrics.StableCollector interface.
+func (c *Controller) CollectWithStability(ch chan<- metrics.Metric) {
+	c.capacitiesLock.Lock()
+	defer c.capacitiesLock.Unlock()
+
+	ch <- metrics.NewLazyConstMetric(objectsGoalDesc,
+		metrics.GaugeValue,
+		float64(c.getObjectsGoal()),
+	)
+	ch <- metrics.NewLazyConstMetric(objectsCurrentDesc,
+		metrics.GaugeValue,
+		float64(c.getObjectsCurrent()),
+	)
+	ch <- metrics.NewLazyConstMetric(objectsObsoleteDesc,
+		metrics.GaugeValue,
+		float64(c.getObjectsObsolete()),
+	)
+}
+
+// getObjectsGoal is called during metrics gathering and calculates the number
+// of CSIStorageCapacity objects which are are meant to
+// to exist.
+func (c *Controller) getObjectsGoal() int64 {
+	return int64(len(c.capacities))
+}
+
+// getObjectsCurrent is called during metrics gathering and calculates the number
+// of CSIStorageCapacity objects which are currently exist and are meant to
+// continue to exist.
+func (c *Controller) getObjectsCurrent() int64 {
+	current := int64(0)
+	for _, capacity := range c.capacities {
+		if capacity != nil {
+			current++
+		}
+	}
+	return current
+}
+
+// getObsoleteObjects is called during metrics gathering and calculates the number
+// of CSIStorageCapacity objects which currently exist (according to our informer)
+// and which are no longer needed.
+func (c *Controller) getObjectsObsolete() int64 {
+	obsolete := int64(0)
+	capacities, _ := c.cInformer.Lister().List(labels.Everything())
+	if capacities == nil {
+		// Shouldn't happen, local operation.
+		return 0
+	}
+	for _, capacity := range capacities {
+		if !c.isControlledByUs(capacity.OwnerReferences) {
+			continue
+		}
+		if c.isObsolete(capacity) {
+			obsolete++
+		}
+	}
+	return obsolete
+}
+
+func (c *Controller) isObsolete(capacity *storagev1alpha1.CSIStorageCapacity) bool {
+	for item, _ := range c.capacities {
+		if item.storageClassName == capacity.StorageClassName &&
+			reflect.DeepEqual(item.segment.GetLabelSelector(), capacity.NodeTopology) {
+			return false
+		}
+	}
+	return true
 }
 
 // isControlledByUs implements the same logic as https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1?tab=doc#IsControlledBy,

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
+)
+
+// CollectAndLint registers the provided Collector with a newly created pedantic
+// Registry. It then calls GatherAndLint with that Registry and with the
+// provided metricNames.
+func CollectAndLint(c prometheus.Collector, metricNames ...string) ([]promlint.Problem, error) {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return nil, fmt.Errorf("registering collector failed: %s", err)
+	}
+	return GatherAndLint(reg, metricNames...)
+}
+
+// GatherAndLint gathers all metrics from the provided Gatherer and checks them
+// with the linter in the promlint package. If any metricNames are provided,
+// only metrics with those names are checked.
+func GatherAndLint(g prometheus.Gatherer, metricNames ...string) ([]promlint.Problem, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return nil, fmt.Errorf("gathering metrics failed: %s", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+	return promlint.NewWithMetricFamilies(got).Lint()
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
@@ -1,0 +1,386 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package promlint provides a linter for Prometheus metrics.
+package promlint
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// A Linter is a Prometheus metrics linter.  It identifies issues with metric
+// names, types, and metadata, and reports them to the caller.
+type Linter struct {
+	// The linter will read metrics in the Prometheus text format from r and
+	// then lint it, _and_ it will lint the metrics provided directly as
+	// MetricFamily proto messages in mfs. Note, however, that the current
+	// constructor functions New and NewWithMetricFamilies only ever set one
+	// of them.
+	r   io.Reader
+	mfs []*dto.MetricFamily
+}
+
+// A Problem is an issue detected by a Linter.
+type Problem struct {
+	// The name of the metric indicated by this Problem.
+	Metric string
+
+	// A description of the issue for this Problem.
+	Text string
+}
+
+// newProblem is helper function to create a Problem.
+func newProblem(mf *dto.MetricFamily, text string) Problem {
+	return Problem{
+		Metric: mf.GetName(),
+		Text:   text,
+	}
+}
+
+// New creates a new Linter that reads an input stream of Prometheus metrics in
+// the Prometheus text exposition format.
+func New(r io.Reader) *Linter {
+	return &Linter{
+		r: r,
+	}
+}
+
+// NewWithMetricFamilies creates a new Linter that reads from a slice of
+// MetricFamily protobuf messages.
+func NewWithMetricFamilies(mfs []*dto.MetricFamily) *Linter {
+	return &Linter{
+		mfs: mfs,
+	}
+}
+
+// Lint performs a linting pass, returning a slice of Problems indicating any
+// issues found in the metrics stream. The slice is sorted by metric name
+// and issue description.
+func (l *Linter) Lint() ([]Problem, error) {
+	var problems []Problem
+
+	if l.r != nil {
+		d := expfmt.NewDecoder(l.r, expfmt.FmtText)
+
+		mf := &dto.MetricFamily{}
+		for {
+			if err := d.Decode(mf); err != nil {
+				if err == io.EOF {
+					break
+				}
+
+				return nil, err
+			}
+
+			problems = append(problems, lint(mf)...)
+		}
+	}
+	for _, mf := range l.mfs {
+		problems = append(problems, lint(mf)...)
+	}
+
+	// Ensure deterministic output.
+	sort.SliceStable(problems, func(i, j int) bool {
+		if problems[i].Metric == problems[j].Metric {
+			return problems[i].Text < problems[j].Text
+		}
+		return problems[i].Metric < problems[j].Metric
+	})
+
+	return problems, nil
+}
+
+// lint is the entry point for linting a single metric.
+func lint(mf *dto.MetricFamily) []Problem {
+	fns := []func(mf *dto.MetricFamily) []Problem{
+		lintHelp,
+		lintMetricUnits,
+		lintCounter,
+		lintHistogramSummaryReserved,
+		lintMetricTypeInName,
+		lintReservedChars,
+		lintCamelCase,
+		lintUnitAbbreviations,
+	}
+
+	var problems []Problem
+	for _, fn := range fns {
+		problems = append(problems, fn(mf)...)
+	}
+
+	// TODO(mdlayher): lint rules for specific metrics types.
+	return problems
+}
+
+// lintHelp detects issues related to the help text for a metric.
+func lintHelp(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	// Expect all metrics to have help text available.
+	if mf.Help == nil {
+		problems = append(problems, newProblem(mf, "no help text"))
+	}
+
+	return problems
+}
+
+// lintMetricUnits detects issues with metric unit names.
+func lintMetricUnits(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	unit, base, ok := metricUnits(*mf.Name)
+	if !ok {
+		// No known units detected.
+		return nil
+	}
+
+	// Unit is already a base unit.
+	if unit == base {
+		return nil
+	}
+
+	problems = append(problems, newProblem(mf, fmt.Sprintf("use base unit %q instead of %q", base, unit)))
+
+	return problems
+}
+
+// lintCounter detects issues specific to counters, as well as patterns that should
+// only be used with counters.
+func lintCounter(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	isCounter := mf.GetType() == dto.MetricType_COUNTER
+	isUntyped := mf.GetType() == dto.MetricType_UNTYPED
+	hasTotalSuffix := strings.HasSuffix(mf.GetName(), "_total")
+
+	switch {
+	case isCounter && !hasTotalSuffix:
+		problems = append(problems, newProblem(mf, `counter metrics should have "_total" suffix`))
+	case !isUntyped && !isCounter && hasTotalSuffix:
+		problems = append(problems, newProblem(mf, `non-counter metrics should not have "_total" suffix`))
+	}
+
+	return problems
+}
+
+// lintHistogramSummaryReserved detects when other types of metrics use names or labels
+// reserved for use by histograms and/or summaries.
+func lintHistogramSummaryReserved(mf *dto.MetricFamily) []Problem {
+	// These rules do not apply to untyped metrics.
+	t := mf.GetType()
+	if t == dto.MetricType_UNTYPED {
+		return nil
+	}
+
+	var problems []Problem
+
+	isHistogram := t == dto.MetricType_HISTOGRAM
+	isSummary := t == dto.MetricType_SUMMARY
+
+	n := mf.GetName()
+
+	if !isHistogram && strings.HasSuffix(n, "_bucket") {
+		problems = append(problems, newProblem(mf, `non-histogram metrics should not have "_bucket" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_count") {
+		problems = append(problems, newProblem(mf, `non-histogram and non-summary metrics should not have "_count" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_sum") {
+		problems = append(problems, newProblem(mf, `non-histogram and non-summary metrics should not have "_sum" suffix`))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			ln := l.GetName()
+
+			if !isHistogram && ln == "le" {
+				problems = append(problems, newProblem(mf, `non-histogram metrics should not have "le" label`))
+			}
+			if !isSummary && ln == "quantile" {
+				problems = append(problems, newProblem(mf, `non-summary metrics should not have "quantile" label`))
+			}
+		}
+	}
+
+	return problems
+}
+
+// lintMetricTypeInName detects when metric types are included in the metric name.
+func lintMetricTypeInName(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	n := strings.ToLower(mf.GetName())
+
+	for i, t := range dto.MetricType_name {
+		if i == int32(dto.MetricType_UNTYPED) {
+			continue
+		}
+
+		typename := strings.ToLower(t)
+		if strings.Contains(n, "_"+typename+"_") || strings.HasSuffix(n, "_"+typename) {
+			problems = append(problems, newProblem(mf, fmt.Sprintf(`metric name should not include type '%s'`, typename)))
+		}
+	}
+	return problems
+}
+
+// lintReservedChars detects colons in metric names.
+func lintReservedChars(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	if strings.Contains(mf.GetName(), ":") {
+		problems = append(problems, newProblem(mf, "metric names should not contain ':'"))
+	}
+	return problems
+}
+
+var camelCase = regexp.MustCompile(`[a-z][A-Z]`)
+
+// lintCamelCase detects metric names and label names written in camelCase.
+func lintCamelCase(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	if camelCase.FindString(mf.GetName()) != "" {
+		problems = append(problems, newProblem(mf, "metric names should be written in 'snake_case' not 'camelCase'"))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			if camelCase.FindString(l.GetName()) != "" {
+				problems = append(problems, newProblem(mf, "label names should be written in 'snake_case' not 'camelCase'"))
+			}
+		}
+	}
+	return problems
+}
+
+// lintUnitAbbreviations detects abbreviated units in the metric name.
+func lintUnitAbbreviations(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+	n := strings.ToLower(mf.GetName())
+	for _, s := range unitAbbreviations {
+		if strings.Contains(n, "_"+s+"_") || strings.HasSuffix(n, "_"+s) {
+			problems = append(problems, newProblem(mf, "metric names should not contain abbreviated units"))
+		}
+	}
+	return problems
+}
+
+// metricUnits attempts to detect known unit types used as part of a metric name,
+// e.g. "foo_bytes_total" or "bar_baz_milligrams".
+func metricUnits(m string) (unit string, base string, ok bool) {
+	ss := strings.Split(m, "_")
+
+	for unit, base := range units {
+		// Also check for "no prefix".
+		for _, p := range append(unitPrefixes, "") {
+			for _, s := range ss {
+				// Attempt to explicitly match a known unit with a known prefix,
+				// as some words may look like "units" when matching suffix.
+				//
+				// As an example, "thermometers" should not match "meters", but
+				// "kilometers" should.
+				if s == p+unit {
+					return p + unit, base, true
+				}
+			}
+		}
+	}
+
+	return "", "", false
+}
+
+// Units and their possible prefixes recognized by this library.  More can be
+// added over time as needed.
+var (
+	// map a unit to the appropriate base unit.
+	units = map[string]string{
+		// Base units.
+		"amperes": "amperes",
+		"bytes":   "bytes",
+		"celsius": "celsius", // Also allow Celsius because it is common in typical Prometheus use cases.
+		"grams":   "grams",
+		"joules":  "joules",
+		"kelvin":  "kelvin", // SI base unit, used in special cases (e.g. color temperature, scientific measurements).
+		"meters":  "meters", // Both American and international spelling permitted.
+		"metres":  "metres",
+		"seconds": "seconds",
+		"volts":   "volts",
+
+		// Non base units.
+		// Time.
+		"minutes": "seconds",
+		"hours":   "seconds",
+		"days":    "seconds",
+		"weeks":   "seconds",
+		// Temperature.
+		"kelvins":    "kelvin",
+		"fahrenheit": "celsius",
+		"rankine":    "celsius",
+		// Length.
+		"inches": "meters",
+		"yards":  "meters",
+		"miles":  "meters",
+		// Bytes.
+		"bits": "bytes",
+		// Energy.
+		"calories": "joules",
+		// Mass.
+		"pounds": "grams",
+		"ounces": "grams",
+	}
+
+	unitPrefixes = []string{
+		"pico",
+		"nano",
+		"micro",
+		"milli",
+		"centi",
+		"deci",
+		"deca",
+		"hecto",
+		"kilo",
+		"kibi",
+		"mega",
+		"mibi",
+		"giga",
+		"gibi",
+		"tera",
+		"tebi",
+		"peta",
+		"pebi",
+	}
+
+	// Common abbreviations that we'd like to discourage.
+	unitAbbreviations = []string{
+		"s",
+		"ms",
+		"us",
+		"ns",
+		"sec",
+		"b",
+		"kb",
+		"mb",
+		"gb",
+		"tb",
+		"pb",
+		"m",
+		"h",
+		"d",
+	}
+)

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
@@ -1,0 +1,230 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides helpers to test code using the prometheus package
+// of client_golang.
+//
+// While writing unit tests to verify correct instrumentation of your code, it's
+// a common mistake to mostly test the instrumentation library instead of your
+// own code. Rather than verifying that a prometheus.Counter's value has changed
+// as expected or that it shows up in the exposition after registration, it is
+// in general more robust and more faithful to the concept of unit tests to use
+// mock implementations of the prometheus.Counter and prometheus.Registerer
+// interfaces that simply assert that the Add or Register methods have been
+// called with the expected arguments. However, this might be overkill in simple
+// scenarios. The ToFloat64 function is provided for simple inspection of a
+// single-value metric, but it has to be used with caution.
+//
+// End-to-end tests to verify all or larger parts of the metrics exposition can
+// be implemented with the CollectAndCompare or GatherAndCompare functions. The
+// most appropriate use is not so much testing instrumentation of your code, but
+// testing custom prometheus.Collector implementations and in particular whole
+// exporters, i.e. programs that retrieve telemetry data from a 3rd party source
+// and convert it into Prometheus metrics.
+//
+// In a similar pattern, CollectAndLint and GatherAndLint can be used to detect
+// metrics that have issues with their name, type, or metadata without being
+// necessarily invalid, e.g. a counter with a name missing the “_total” suffix.
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/internal"
+)
+
+// ToFloat64 collects all Metrics from the provided Collector. It expects that
+// this results in exactly one Metric being collected, which must be a Gauge,
+// Counter, or Untyped. In all other cases, ToFloat64 panics. ToFloat64 returns
+// the value of the collected Metric.
+//
+// The Collector provided is typically a simple instance of Gauge or Counter, or
+// – less commonly – a GaugeVec or CounterVec with exactly one element. But any
+// Collector fulfilling the prerequisites described above will do.
+//
+// Use this function with caution. It is computationally very expensive and thus
+// not suited at all to read values from Metrics in regular code. This is really
+// only for testing purposes, and even for testing, other approaches are often
+// more appropriate (see this package's documentation).
+//
+// A clear anti-pattern would be to use a metric type from the prometheus
+// package to track values that are also needed for something else than the
+// exposition of Prometheus metrics. For example, you would like to track the
+// number of items in a queue because your code should reject queuing further
+// items if a certain limit is reached. It is tempting to track the number of
+// items in a prometheus.Gauge, as it is then easily available as a metric for
+// exposition, too. However, then you would need to call ToFloat64 in your
+// regular code, potentially quite often. The recommended way is to track the
+// number of items conventionally (in the way you would have done it without
+// considering Prometheus metrics) and then expose the number with a
+// prometheus.GaugeFunc.
+func ToFloat64(c prometheus.Collector) float64 {
+	var (
+		m      prometheus.Metric
+		mCount int
+		mChan  = make(chan prometheus.Metric)
+		done   = make(chan struct{})
+	)
+
+	go func() {
+		for m = range mChan {
+			mCount++
+		}
+		close(done)
+	}()
+
+	c.Collect(mChan)
+	close(mChan)
+	<-done
+
+	if mCount != 1 {
+		panic(fmt.Errorf("collected %d metrics instead of exactly 1", mCount))
+	}
+
+	pb := &dto.Metric{}
+	m.Write(pb)
+	if pb.Gauge != nil {
+		return pb.Gauge.GetValue()
+	}
+	if pb.Counter != nil {
+		return pb.Counter.GetValue()
+	}
+	if pb.Untyped != nil {
+		return pb.Untyped.GetValue()
+	}
+	panic(fmt.Errorf("collected a non-gauge/counter/untyped metric: %s", pb))
+}
+
+// CollectAndCount registers the provided Collector with a newly created
+// pedantic Registry. It then calls GatherAndCount with that Registry and with
+// the provided metricNames. In the unlikely case that the registration or the
+// gathering fails, this function panics. (This is inconsistent with the other
+// CollectAnd… functions in this package and has historical reasons. Changing
+// the function signature would be a breaking change and will therefore only
+// happen with the next major version bump.)
+func CollectAndCount(c prometheus.Collector, metricNames ...string) int {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		panic(fmt.Errorf("registering collector failed: %s", err))
+	}
+	result, err := GatherAndCount(reg, metricNames...)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+// GatherAndCount gathers all metrics from the provided Gatherer and counts
+// them. It returns the number of metric children in all gathered metric
+// families together. If any metricNames are provided, only metrics with those
+// names are counted.
+func GatherAndCount(g prometheus.Gatherer, metricNames ...string) (int, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return 0, fmt.Errorf("gathering metrics failed: %s", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+
+	result := 0
+	for _, mf := range got {
+		result += len(mf.GetMetric())
+	}
+	return result, nil
+}
+
+// CollectAndCompare registers the provided Collector with a newly created
+// pedantic Registry. It then calls GatherAndCompare with that Registry and with
+// the provided metricNames.
+func CollectAndCompare(c prometheus.Collector, expected io.Reader, metricNames ...string) error {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return fmt.Errorf("registering collector failed: %s", err)
+	}
+	return GatherAndCompare(reg, expected, metricNames...)
+}
+
+// GatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+func GatherAndCompare(g prometheus.Gatherer, expected io.Reader, metricNames ...string) error {
+	got, err := g.Gather()
+	if err != nil {
+		return fmt.Errorf("gathering metrics failed: %s", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+	var tp expfmt.TextParser
+	wantRaw, err := tp.TextToMetricFamilies(expected)
+	if err != nil {
+		return fmt.Errorf("parsing expected metrics failed: %s", err)
+	}
+	want := internal.NormalizeMetricFamilies(wantRaw)
+
+	return compare(got, want)
+}
+
+// compare encodes both provided slices of metric families into the text format,
+// compares their string message, and returns an error if they do not match.
+// The error contains the encoded text of both the desired and the actual
+// result.
+func compare(got, want []*dto.MetricFamily) error {
+	var gotBuf, wantBuf bytes.Buffer
+	enc := expfmt.NewEncoder(&gotBuf, expfmt.FmtText)
+	for _, mf := range got {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding gathered metrics failed: %s", err)
+		}
+	}
+	enc = expfmt.NewEncoder(&wantBuf, expfmt.FmtText)
+	for _, mf := range want {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding expected metrics failed: %s", err)
+		}
+	}
+
+	if wantBuf.String() != gotBuf.String() {
+		return fmt.Errorf(`
+metric output does not match expectation; want:
+
+%s
+got:
+
+%s`, wantBuf.String(), gotBuf.String())
+
+	}
+	return nil
+}
+
+func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFamily {
+	var filtered []*dto.MetricFamily
+	for _, m := range metrics {
+		for _, name := range names {
+			if m.GetName() == name {
+				filtered = append(filtered, m)
+				break
+			}
+		}
+	}
+	return filtered
+}

--- a/vendor/k8s.io/component-base/metrics/legacyregistry/registry.go
+++ b/vendor/k8s.io/component-base/metrics/legacyregistry/registry.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacyregistry
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"k8s.io/component-base/metrics"
+)
+
+var (
+	defaultRegistry = metrics.NewKubeRegistry()
+	// DefaultGatherer exposes the global registry gatherer
+	DefaultGatherer metrics.Gatherer = defaultRegistry
+	// Reset calls reset on the global registry
+	Reset = defaultRegistry.Reset
+	// MustRegister registers registerable metrics but uses the global registry.
+	MustRegister = defaultRegistry.MustRegister
+	// RawMustRegister registers prometheus collectors but uses the global registry, this
+	// bypasses the metric stability framework
+	//
+	// Deprecated
+	RawMustRegister = defaultRegistry.RawMustRegister
+
+	// Register registers a collectable metric but uses the global registry
+	Register = defaultRegistry.Register
+)
+
+func init() {
+	RawMustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+	RawMustRegister(prometheus.NewGoCollector())
+}
+
+// Handler returns an HTTP handler for the DefaultGatherer. It is
+// already instrumented with InstrumentHandler (using "prometheus" as handler
+// name).
+//
+// Deprecated: Please note the issues described in the doc comment of
+// InstrumentHandler. You might want to consider using promhttp.Handler instead.
+func Handler() http.Handler {
+	return promhttp.InstrumentMetricHandler(prometheus.DefaultRegisterer, promhttp.HandlerFor(defaultRegistry, promhttp.HandlerOpts{}))
+}
+
+// HandlerWithReset returns an HTTP handler for the DefaultGatherer but invokes
+// registry reset if the http method is DELETE.
+func HandlerWithReset() http.Handler {
+	return promhttp.InstrumentMetricHandler(
+		prometheus.DefaultRegisterer,
+		metrics.HandlerWithReset(defaultRegistry, metrics.HandlerOpts{}))
+}
+
+// CustomRegister registers a custom collector but uses the global registry.
+func CustomRegister(c metrics.StableCollector) error {
+	err := defaultRegistry.CustomRegister(c)
+
+	//TODO(RainbowMango): Maybe we can wrap this error by error wrapping.(Golang 1.13)
+	_ = prometheus.Register(c)
+
+	return err
+}
+
+// CustomMustRegister registers custom collectors but uses the global registry.
+func CustomMustRegister(cs ...metrics.StableCollector) {
+	defaultRegistry.CustomMustRegister(cs...)
+
+	for _, c := range cs {
+		prometheus.MustRegister(c)
+	}
+}

--- a/vendor/k8s.io/component-base/metrics/prometheus/clientgo/leaderelection/metrics.go
+++ b/vendor/k8s.io/component-base/metrics/prometheus/clientgo/leaderelection/metrics.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"k8s.io/client-go/tools/leaderelection"
+	k8smetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+var (
+	leaderGauge = k8smetrics.NewGaugeVec(&k8smetrics.GaugeOpts{
+		Name: "leader_election_master_status",
+		Help: "Gauge of if the reporting system is master of the relevant lease, 0 indicates backup, 1 indicates master. 'name' is the string used to identify the lease. Please make sure to group by name.",
+	}, []string{"name"})
+)
+
+func init() {
+	legacyregistry.MustRegister(leaderGauge)
+	leaderelection.SetProvider(prometheusMetricsProvider{})
+}
+
+type prometheusMetricsProvider struct{}
+
+func (prometheusMetricsProvider) NewLeaderMetric() leaderelection.SwitchMetric {
+	return &switchAdapter{gauge: leaderGauge}
+}
+
+type switchAdapter struct {
+	gauge *k8smetrics.GaugeVec
+}
+
+func (s *switchAdapter) On(name string) {
+	s.gauge.WithLabelValues(name).Set(1.0)
+}
+
+func (s *switchAdapter) Off(name string) {
+	s.gauge.WithLabelValues(name).Set(0.0)
+}

--- a/vendor/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
+++ b/vendor/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"k8s.io/client-go/util/workqueue"
+	k8smetrics "k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+// Package prometheus sets the workqueue DefaultMetricsFactory to produce
+// prometheus metrics. To use this package, you just have to import it.
+
+// Metrics subsystem and keys used by the workqueue.
+const (
+	WorkQueueSubsystem         = "workqueue"
+	DepthKey                   = "depth"
+	AddsKey                    = "adds_total"
+	QueueLatencyKey            = "queue_duration_seconds"
+	WorkDurationKey            = "work_duration_seconds"
+	UnfinishedWorkKey          = "unfinished_work_seconds"
+	LongestRunningProcessorKey = "longest_running_processor_seconds"
+	RetriesKey                 = "retries_total"
+)
+
+var (
+	depth = k8smetrics.NewGaugeVec(&k8smetrics.GaugeOpts{
+		Subsystem: WorkQueueSubsystem,
+		Name:      DepthKey,
+		Help:      "Current depth of workqueue",
+	}, []string{"name"})
+
+	adds = k8smetrics.NewCounterVec(&k8smetrics.CounterOpts{
+		Subsystem: WorkQueueSubsystem,
+		Name:      AddsKey,
+		Help:      "Total number of adds handled by workqueue",
+	}, []string{"name"})
+
+	latency = k8smetrics.NewHistogramVec(&k8smetrics.HistogramOpts{
+		Subsystem: WorkQueueSubsystem,
+		Name:      QueueLatencyKey,
+		Help:      "How long in seconds an item stays in workqueue before being requested.",
+		Buckets:   k8smetrics.ExponentialBuckets(10e-9, 10, 10),
+	}, []string{"name"})
+
+	workDuration = k8smetrics.NewHistogramVec(&k8smetrics.HistogramOpts{
+		Subsystem: WorkQueueSubsystem,
+		Name:      WorkDurationKey,
+		Help:      "How long in seconds processing an item from workqueue takes.",
+		Buckets:   k8smetrics.ExponentialBuckets(10e-9, 10, 10),
+	}, []string{"name"})
+
+	unfinished = k8smetrics.NewGaugeVec(&k8smetrics.GaugeOpts{
+		Subsystem: WorkQueueSubsystem,
+		Name:      UnfinishedWorkKey,
+		Help: "How many seconds of work has done that " +
+			"is in progress and hasn't been observed by work_duration. Large " +
+			"values indicate stuck threads. One can deduce the number of stuck " +
+			"threads by observing the rate at which this increases.",
+	}, []string{"name"})
+
+	longestRunningProcessor = k8smetrics.NewGaugeVec(&k8smetrics.GaugeOpts{
+		Subsystem: WorkQueueSubsystem,
+		Name:      LongestRunningProcessorKey,
+		Help: "How many seconds has the longest running " +
+			"processor for workqueue been running.",
+	}, []string{"name"})
+
+	retries = k8smetrics.NewCounterVec(&k8smetrics.CounterOpts{
+		Subsystem: WorkQueueSubsystem,
+		Name:      RetriesKey,
+		Help:      "Total number of retries handled by workqueue",
+	}, []string{"name"})
+
+	metrics = []k8smetrics.Registerable{
+		depth, adds, latency, workDuration, unfinished, longestRunningProcessor, retries,
+	}
+)
+
+type prometheusMetricsProvider struct {
+}
+
+func init() {
+	for _, m := range metrics {
+		legacyregistry.MustRegister(m)
+	}
+	workqueue.SetProvider(prometheusMetricsProvider{})
+}
+
+func (prometheusMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
+	return depth.WithLabelValues(name)
+}
+
+func (prometheusMetricsProvider) NewAddsMetric(name string) workqueue.CounterMetric {
+	return adds.WithLabelValues(name)
+}
+
+func (prometheusMetricsProvider) NewLatencyMetric(name string) workqueue.HistogramMetric {
+	return latency.WithLabelValues(name)
+}
+
+func (prometheusMetricsProvider) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
+	return workDuration.WithLabelValues(name)
+}
+
+func (prometheusMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return unfinished.WithLabelValues(name)
+}
+
+func (prometheusMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return longestRunningProcessor.WithLabelValues(name)
+}
+
+func (prometheusMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
+	return retries.WithLabelValues(name)
+}

--- a/vendor/k8s.io/component-base/metrics/testutil/metrics.go
+++ b/vendor/k8s.io/component-base/metrics/testutil/metrics.go
@@ -1,0 +1,368 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"reflect"
+	"sort"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+
+	"k8s.io/component-base/metrics"
+)
+
+var (
+	// MetricNameLabel is label under which model.Sample stores metric name
+	MetricNameLabel model.LabelName = model.MetricNameLabel
+	// QuantileLabel is label under which model.Sample stores latency quantile value
+	QuantileLabel model.LabelName = model.QuantileLabel
+)
+
+// Metrics is generic metrics for other specific metrics
+type Metrics map[string]model.Samples
+
+// Equal returns true if all metrics are the same as the arguments.
+func (m *Metrics) Equal(o Metrics) bool {
+	var leftKeySet []string
+	var rightKeySet []string
+	for k := range *m {
+		leftKeySet = append(leftKeySet, k)
+	}
+	for k := range o {
+		rightKeySet = append(rightKeySet, k)
+	}
+	if !reflect.DeepEqual(leftKeySet, rightKeySet) {
+		return false
+	}
+	for _, k := range leftKeySet {
+		if !(*m)[k].Equal(o[k]) {
+			return false
+		}
+	}
+	return true
+}
+
+// NewMetrics returns new metrics which are initialized.
+func NewMetrics() Metrics {
+	result := make(Metrics)
+	return result
+}
+
+// ParseMetrics parses Metrics from data returned from prometheus endpoint
+func ParseMetrics(data string, output *Metrics) error {
+	dec := expfmt.NewDecoder(strings.NewReader(data), expfmt.FmtText)
+	decoder := expfmt.SampleDecoder{
+		Dec:  dec,
+		Opts: &expfmt.DecodeOptions{},
+	}
+
+	for {
+		var v model.Vector
+		if err := decoder.Decode(&v); err != nil {
+			if err == io.EOF {
+				// Expected loop termination condition.
+				return nil
+			}
+			continue
+		}
+		for _, metric := range v {
+			name := string(metric.Metric[MetricNameLabel])
+			(*output)[name] = append((*output)[name], metric)
+		}
+	}
+}
+
+// TextToMetricFamilies reads 'in' as the simple and flat text-based exchange
+// format and creates MetricFamily proto messages. It returns the MetricFamily
+// proto messages in a map where the metric names are the keys, along with any
+// error encountered.
+func TextToMetricFamilies(in io.Reader) (map[string]*dto.MetricFamily, error) {
+	var textParser expfmt.TextParser
+	return textParser.TextToMetricFamilies(in)
+}
+
+// PrintSample returns formatted representation of metric Sample
+func PrintSample(sample *model.Sample) string {
+	buf := make([]string, 0)
+	// Id is a VERY special label. For 'normal' container it's useless, but it's necessary
+	// for 'system' containers (e.g. /docker-daemon, /kubelet, etc.). We know if that's the
+	// case by checking if there's a label "kubernetes_container_name" present. It's hacky
+	// but it works...
+	_, normalContainer := sample.Metric["kubernetes_container_name"]
+	for k, v := range sample.Metric {
+		if strings.HasPrefix(string(k), "__") {
+			continue
+		}
+
+		if string(k) == "id" && normalContainer {
+			continue
+		}
+		buf = append(buf, fmt.Sprintf("%v=%v", string(k), v))
+	}
+	return fmt.Sprintf("[%v] = %v", strings.Join(buf, ","), sample.Value)
+}
+
+// ComputeHistogramDelta computes the change in histogram metric for a selected label.
+// Results are stored in after samples
+func ComputeHistogramDelta(before, after model.Samples, label model.LabelName) {
+	beforeSamplesMap := make(map[string]*model.Sample)
+	for _, bSample := range before {
+		beforeSamplesMap[makeKey(bSample.Metric[label], bSample.Metric["le"])] = bSample
+	}
+	for _, aSample := range after {
+		if bSample, found := beforeSamplesMap[makeKey(aSample.Metric[label], aSample.Metric["le"])]; found {
+			aSample.Value = aSample.Value - bSample.Value
+		}
+	}
+}
+
+func makeKey(a, b model.LabelValue) string {
+	return string(a) + "___" + string(b)
+}
+
+// GetMetricValuesForLabel returns value of metric for a given dimension
+func GetMetricValuesForLabel(ms Metrics, metricName, label string) map[string]int64 {
+	samples, found := ms[metricName]
+	result := make(map[string]int64, len(samples))
+	if !found {
+		return result
+	}
+	for _, sample := range samples {
+		count := int64(sample.Value)
+		dimensionName := string(sample.Metric[model.LabelName(label)])
+		result[dimensionName] = count
+	}
+	return result
+}
+
+// ValidateMetrics verifies if every sample of metric has all expected labels
+func ValidateMetrics(metrics Metrics, metricName string, expectedLabels ...string) error {
+	samples, ok := metrics[metricName]
+	if !ok {
+		return fmt.Errorf("metric %q was not found in metrics", metricName)
+	}
+	for _, sample := range samples {
+		for _, l := range expectedLabels {
+			if _, ok := sample.Metric[model.LabelName(l)]; !ok {
+				return fmt.Errorf("metric %q is missing label %q, sample: %q", metricName, l, sample.String())
+			}
+		}
+	}
+	return nil
+}
+
+// Histogram wraps prometheus histogram DTO (data transfer object)
+type Histogram struct {
+	*dto.Histogram
+}
+
+// GetHistogramFromGatherer collects a metric from a gatherer implementing k8s.io/component-base/metrics.Gatherer interface.
+// Used only for testing purposes where we need to gather metrics directly from a running binary (without metrics endpoint).
+func GetHistogramFromGatherer(gatherer metrics.Gatherer, metricName string) (Histogram, error) {
+	var metricFamily *dto.MetricFamily
+	m, err := gatherer.Gather()
+	if err != nil {
+		return Histogram{}, err
+	}
+	for _, mFamily := range m {
+		if mFamily.GetName() == metricName {
+			metricFamily = mFamily
+			break
+		}
+	}
+
+	if metricFamily == nil {
+		return Histogram{}, fmt.Errorf("metric %q not found", metricName)
+	}
+
+	if metricFamily.GetMetric() == nil {
+		return Histogram{}, fmt.Errorf("metric %q is empty", metricName)
+	}
+
+	if len(metricFamily.GetMetric()) == 0 {
+		return Histogram{}, fmt.Errorf("metric %q is empty", metricName)
+	}
+
+	return Histogram{
+		// Histograms are stored under the first index (based on observation).
+		// Given there's only one histogram registered per each metric name, accessing
+		// the first index is sufficient.
+		metricFamily.GetMetric()[0].GetHistogram(),
+	}, nil
+}
+
+func uint64Ptr(u uint64) *uint64 {
+	return &u
+}
+
+// Bucket of a histogram
+type bucket struct {
+	upperBound float64
+	count      float64
+}
+
+func bucketQuantile(q float64, buckets []bucket) float64 {
+	if q < 0 {
+		return math.Inf(-1)
+	}
+	if q > 1 {
+		return math.Inf(+1)
+	}
+
+	if len(buckets) < 2 {
+		return math.NaN()
+	}
+
+	rank := q * buckets[len(buckets)-1].count
+	b := sort.Search(len(buckets)-1, func(i int) bool { return buckets[i].count >= rank })
+
+	if b == 0 {
+		return buckets[0].upperBound * (rank / buckets[0].count)
+	}
+
+	if b == len(buckets)-1 && math.IsInf(buckets[b].upperBound, 1) {
+		return buckets[len(buckets)-2].upperBound
+	}
+
+	// linear approximation of b-th bucket
+	brank := rank - buckets[b-1].count
+	bSize := buckets[b].upperBound - buckets[b-1].upperBound
+	bCount := buckets[b].count - buckets[b-1].count
+
+	return buckets[b-1].upperBound + bSize*(brank/bCount)
+}
+
+// Quantile computes q-th quantile of a cumulative histogram.
+// It's expected the histogram is valid (by calling Validate)
+func (hist *Histogram) Quantile(q float64) float64 {
+	var buckets []bucket
+
+	for _, bckt := range hist.Bucket {
+		buckets = append(buckets, bucket{
+			count:      float64(bckt.GetCumulativeCount()),
+			upperBound: bckt.GetUpperBound(),
+		})
+	}
+
+	if len(buckets) == 0 || buckets[len(buckets)-1].upperBound != math.Inf(+1) {
+		// The list of buckets in dto.Histogram doesn't include the final +Inf bucket, so we
+		// add it here for the reset of the samples.
+		buckets = append(buckets, bucket{
+			count:      float64(hist.GetSampleCount()),
+			upperBound: math.Inf(+1),
+		})
+	}
+
+	return bucketQuantile(q, buckets)
+}
+
+// Average computes histogram's average value
+func (hist *Histogram) Average() float64 {
+	return hist.GetSampleSum() / float64(hist.GetSampleCount())
+}
+
+// Clear clears all fields of the wrapped histogram
+func (hist *Histogram) Clear() {
+	if hist.SampleCount != nil {
+		*hist.SampleCount = 0
+	}
+	if hist.SampleSum != nil {
+		*hist.SampleSum = 0
+	}
+	for _, b := range hist.Bucket {
+		if b.CumulativeCount != nil {
+			*b.CumulativeCount = 0
+		}
+	}
+}
+
+// Validate makes sure the wrapped histogram has all necessary fields set and with valid values.
+func (hist *Histogram) Validate() error {
+	if hist.SampleCount == nil || hist.GetSampleCount() == 0 {
+		return fmt.Errorf("nil or empty histogram SampleCount")
+	}
+
+	if hist.SampleSum == nil || hist.GetSampleSum() == 0 {
+		return fmt.Errorf("nil or empty histogram SampleSum")
+	}
+
+	for _, bckt := range hist.Bucket {
+		if bckt == nil {
+			return fmt.Errorf("empty histogram bucket")
+		}
+		if bckt.UpperBound == nil || bckt.GetUpperBound() < 0 {
+			return fmt.Errorf("nil or negative histogram bucket UpperBound")
+		}
+	}
+
+	return nil
+}
+
+// GetGaugeMetricValue extract metric value from GaugeMetric
+func GetGaugeMetricValue(m metrics.GaugeMetric) (float64, error) {
+	metricProto := &dto.Metric{}
+	if err := m.Write(metricProto); err != nil {
+		return 0, fmt.Errorf("error writing m: %v", err)
+	}
+	return metricProto.Gauge.GetValue(), nil
+}
+
+// GetCounterMetricValue extract metric value from CounterMetric
+func GetCounterMetricValue(m metrics.CounterMetric) (float64, error) {
+	metricProto := &dto.Metric{}
+	if err := m.(metrics.Metric).Write(metricProto); err != nil {
+		return 0, fmt.Errorf("error writing m: %v", err)
+	}
+	return metricProto.Counter.GetValue(), nil
+}
+
+// GetHistogramMetricValue extract sum of all samples from ObserverMetric
+func GetHistogramMetricValue(m metrics.ObserverMetric) (float64, error) {
+	metricProto := &dto.Metric{}
+	if err := m.(metrics.Metric).Write(metricProto); err != nil {
+		return 0, fmt.Errorf("error writing m: %v", err)
+	}
+	return metricProto.Histogram.GetSampleSum(), nil
+}
+
+// LabelsMatch returns true if metric has all expected labels otherwise false
+func LabelsMatch(metric *dto.Metric, labelFilter map[string]string) bool {
+	metricLabels := map[string]string{}
+
+	for _, labelPair := range metric.Label {
+		metricLabels[labelPair.GetName()] = labelPair.GetValue()
+	}
+
+	// length comparison then match key to values in the maps
+	if len(labelFilter) > len(metricLabels) {
+		return false
+	}
+
+	for labelName, labelValue := range labelFilter {
+		if value, ok := metricLabels[labelName]; !ok || value != labelValue {
+			return false
+		}
+	}
+
+	return true
+}

--- a/vendor/k8s.io/component-base/metrics/testutil/promlint.go
+++ b/vendor/k8s.io/component-base/metrics/testutil/promlint.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
+)
+
+// exceptionMetrics is an exception list of metrics which violates promlint rules.
+//
+// The original entries come from the existing metrics when we introduce promlint.
+// We setup this list for allow and not fail on the current violations.
+// Generally speaking, you need to fix the problem for a new metric rather than add it into the list.
+var exceptionMetrics = []string{
+	// k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/egressselector
+	"apiserver_egress_dialer_dial_failure_count", // counter metrics should have "_total" suffix
+
+	// k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/server/healthz
+	"apiserver_request_total", // label names should be written in 'snake_case' not 'camelCase'
+
+	// k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/filters
+	"authenticated_user_requests", // counter metrics should have "_total" suffix
+	"authentication_attempts",     // counter metrics should have "_total" suffix
+
+	// kube-apiserver
+	"aggregator_openapi_v2_regeneration_count",
+	"apiserver_admission_step_admission_duration_seconds_summary",
+	"apiserver_current_inflight_requests",
+	"apiserver_longrunning_gauge",
+	"get_token_count",
+	"get_token_fail_count",
+	"ssh_tunnel_open_count",
+	"ssh_tunnel_open_fail_count",
+
+	// kube-controller-manager
+	"attachdetach_controller_forced_detaches",
+	"authenticated_user_requests",
+	"authentication_attempts",
+	"get_token_count",
+	"get_token_fail_count",
+	"node_collector_evictions_number",
+
+	// k8s.io/kubernetes/pkg/kubelet/server/stats
+	// The two metrics have been deprecated and will be removed in release v1.20+.
+	"container_cpu_usage_seconds_total", // non-counter metrics should not have "_total" suffix
+	"node_cpu_usage_seconds_total",      // non-counter metrics should not have "_total" suffix
+}
+
+// A Problem is an issue detected by a Linter.
+type Problem promlint.Problem
+
+func (p *Problem) String() string {
+	return fmt.Sprintf("%s:%s", p.Metric, p.Text)
+}
+
+// A Linter is a Prometheus metrics linter.  It identifies issues with metric
+// names, types, and metadata, and reports them to the caller.
+type Linter struct {
+	promLinter *promlint.Linter
+}
+
+// Lint performs a linting pass, returning a slice of Problems indicating any
+// issues found in the metrics stream.  The slice is sorted by metric name
+// and issue description.
+func (l *Linter) Lint() ([]Problem, error) {
+	promProblems, err := l.promLinter.Lint()
+	if err != nil {
+		return nil, err
+	}
+
+	// Ignore problems those in exception list
+	problems := make([]Problem, 0, len(promProblems))
+	for i := range promProblems {
+		if !l.shouldIgnore(promProblems[i].Metric) {
+			problems = append(problems, Problem(promProblems[i]))
+		}
+	}
+
+	return problems, nil
+}
+
+// shouldIgnore returns true if metric in the exception list, otherwise returns false.
+func (l *Linter) shouldIgnore(metricName string) bool {
+	for i := range exceptionMetrics {
+		if metricName == exceptionMetrics[i] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// NewPromLinter creates a new Linter that reads an input stream of Prometheus metrics.
+// Only the text exposition format is supported.
+func NewPromLinter(r io.Reader) *Linter {
+	return &Linter{
+		promLinter: promlint.New(r),
+	}
+}
+
+func mergeProblems(problems []Problem) string {
+	var problemsMsg []string
+
+	for index := range problems {
+		problemsMsg = append(problemsMsg, problems[index].String())
+	}
+
+	return strings.Join(problemsMsg, ",")
+}
+
+// shouldIgnore returns true if metric in the exception list, otherwise returns false.
+func shouldIgnore(metricName string) bool {
+	for i := range exceptionMetrics {
+		if metricName == exceptionMetrics[i] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getLintError will ignore the metrics in exception list and converts lint problem to error.
+func getLintError(problems []promlint.Problem) error {
+	var filteredProblems []Problem
+	for _, problem := range problems {
+		if shouldIgnore(problem.Metric) {
+			continue
+		}
+
+		filteredProblems = append(filteredProblems, Problem(problem))
+	}
+
+	if len(filteredProblems) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("lint error: %s", mergeProblems(filteredProblems))
+}

--- a/vendor/k8s.io/component-base/metrics/testutil/testutil.go
+++ b/vendor/k8s.io/component-base/metrics/testutil/testutil.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/component-base/metrics"
+)
+
+// CollectAndCompare registers the provided Collector with a newly created
+// pedantic Registry. It then does the same as GatherAndCompare, gathering the
+// metrics from the pedantic Registry.
+func CollectAndCompare(c metrics.Collector, expected io.Reader, metricNames ...string) error {
+	lintProblems, err := testutil.CollectAndLint(c, metricNames...)
+	if err != nil {
+		return err
+	}
+	if err := getLintError(lintProblems); err != nil {
+		return err
+	}
+
+	return testutil.CollectAndCompare(c, expected, metricNames...)
+}
+
+// GatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+func GatherAndCompare(g metrics.Gatherer, expected io.Reader, metricNames ...string) error {
+	lintProblems, err := testutil.GatherAndLint(g, metricNames...)
+	if err != nil {
+		return err
+	}
+	if err := getLintError(lintProblems); err != nil {
+		return err
+	}
+
+	return testutil.GatherAndCompare(g, expected, metricNames...)
+}
+
+// CustomCollectAndCompare registers the provided StableCollector with a newly created
+// registry. It then does the same as GatherAndCompare, gathering the
+// metrics from the pedantic Registry.
+func CustomCollectAndCompare(c metrics.StableCollector, expected io.Reader, metricNames ...string) error {
+	registry := metrics.NewKubeRegistry()
+	registry.CustomMustRegister(c)
+
+	return GatherAndCompare(registry, expected, metricNames...)
+}
+
+// NewFakeKubeRegistry creates a fake `KubeRegistry` that takes the input version as `build in version`.
+// It should only be used in testing scenario especially for the deprecated metrics.
+// The input version format should be `major.minor.patch`, e.g. '1.18.0'.
+func NewFakeKubeRegistry(ver string) metrics.KubeRegistry {
+	backup := metrics.BuildVersion
+	defer func() {
+		metrics.BuildVersion = backup
+	}()
+
+	metrics.BuildVersion = func() apimachineryversion.Info {
+		return apimachineryversion.Info{
+			GitVersion: fmt.Sprintf("v%s-alpha+1.12345", ver),
+		}
+	}
+
+	return metrics.NewKubeRegistry()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -575,6 +575,9 @@ k8s.io/component-base/cli/flag
 k8s.io/component-base/featuregate
 k8s.io/component-base/featuregate/testing
 k8s.io/component-base/metrics
+k8s.io/component-base/metrics/legacyregistry
+k8s.io/component-base/metrics/prometheus/clientgo/leaderelection
+k8s.io/component-base/metrics/prometheus/workqueue
 k8s.io/component-base/version
 # k8s.io/component-helpers v0.20.4 => k8s.io/component-helpers v0.20.0
 ## explicit

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -94,6 +94,8 @@ github.com/pkg/errors
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
+github.com/prometheus/client_golang/prometheus/testutil
+github.com/prometheus/client_golang/prometheus/testutil/promlint
 # github.com/prometheus/client_model v0.2.0
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.19.0
@@ -578,6 +580,7 @@ k8s.io/component-base/metrics
 k8s.io/component-base/metrics/legacyregistry
 k8s.io/component-base/metrics/prometheus/clientgo/leaderelection
 k8s.io/component-base/metrics/prometheus/workqueue
+k8s.io/component-base/metrics/testutil
 k8s.io/component-base/version
 # k8s.io/component-helpers v0.20.4 => k8s.io/component-helpers v0.20.0
 ## explicit


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

As pointed out in the KEP review for storage capacity tracking, admins need more insights into the operation of the sidecar than just the CSI calls. This PR adds new metrics gathering specifically for storage capacity tracking, but also enables the gather of metrices that already existed and just weren't reported (process and Go runtime, work queues, leaderelection).

**Note to reviewer**

The commit messages have examples of what the new data looks like. I'm not sure how we want to document this. IMHO we should first decide about central documentation (= https://github.com/kubernetes-csi/docs/issues/339), then add something to each repo as needed.

**Does this PR introduce a user-facing change?**:
```release-note
new metrics data (storage capacity tracking, process and Go runtime, work queues, leaderelection)
```
