### PR TITLE
remove duplicate informer.run

### DIFF
--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -187,8 +187,6 @@ func NewCentralCapacityController(
 func (c *Controller) Run(ctx context.Context, threadiness int) {
 	klog.Info("Starting Capacity Controller")
 	defer c.queue.ShutDown()
-	go c.scInformer.Informer().Run(ctx.Done())
-	go c.topologyInformer.Run(ctx)
 
 	c.prepare(ctx)
 	for i := 0; i < threadiness; i++ {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug


**What this PR does / why we need it**:
When csi-provisoner start, it will call factory.Start(ctx.Done()). StorageClass Informer and topology Informer is created from factory. It will automatically run when calling factory.Start. Duplication of calling informer.run may cause some problems
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
