### PR TITLE
Add chrishenzie to reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,6 +5,7 @@ approvers:
 - saad-ali
 - xing-yang
 reviewers:
+- chrishenzie
 - davidz627
 - jsafrane
 - lpabon


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds @chrishenzie to reviewers for this repo.

Originally was going to also add to approvers but going to be added to maintainers instead (required for performing release).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @msau42 
