### PR TITLE
capacity test: rebind loop variable to avoid race

### DIFF
--- a/pkg/capacity/capacity_test.go
+++ b/pkg/capacity/capacity_test.go
@@ -1089,6 +1089,7 @@ func TestCapacityController(t *testing.T) {
 	}
 
 	for name, tc := range testcases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			// Running in parallel is possible because only logging uses a global instance.
 			t.Parallel()
@@ -1766,6 +1767,7 @@ func TestTermToSegment(t *testing.T) {
 	}
 
 	for name, tc := range testcases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1920,6 +1922,7 @@ func TestRefresh(t *testing.T) {
 	}
 
 	for name, tc := range testcases {
+		tc := tc
 		t.Run(name, func(t *testing.T) {
 			// Running in parallel is possible because only logging uses a global instance.
 			t.Parallel()


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

When introducing parallel testing, it was overlooked that now the "tc"
loop variables get modified before the tests actually run. That caused
random test failures, depending on timing.

**Which issue(s) this PR fixes**:
Fixes #609 

**Special notes for your reviewer**:

This bug wasn't in any previous release, therefore this fix doesn't need to be mentioned in the release notes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
