### PR TITLE
CreateVolume Metadata:  Provide StorageClass name

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -113,6 +113,7 @@ const (
 	pvcNameKey      = "csi.storage.k8s.io/pvc/name"
 	pvcNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
 	pvNameKey       = "csi.storage.k8s.io/pv/name"
+	scNameKey       = "csi.storage.k8s.io/sc/name"
 
 	// Defines parameters for ExponentialBackoff used for executing
 	// CSI CreateVolume API call, it gives approx 4 minutes for the CSI
@@ -681,6 +682,7 @@ func (p *csiProvisioner) prepareProvision(ctx context.Context, claim *v1.Persist
 		req.Parameters[pvcNameKey] = claim.GetName()
 		req.Parameters[pvcNamespaceKey] = claim.GetNamespace()
 		req.Parameters[pvNameKey] = pvName
+		req.Parameters[scNameKey] = sc.GetName()
 	}
 
 	return &prepareProvisionResult{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Injects the `StorageClass` name into the metadata provided to `CreateVolume` if metadata passing is enabled with `--extra-create-metadata`.

This allows a single CSI driver to handle multiple storage classes.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

`CreateVolume` requests to the CSI driver now contain an additional parameter specifying the name of the storage class.
The parameter key is `csi.storage.k8s.io/sc/name`.

Only applicable if the metadata feature is enabled with `--extra-create-metadata`.
```
