### PR TITLE
node topology worker should run

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -438,6 +438,7 @@ func main() {
 			klog.Infof("producing CSIStorageCapacity objects with fixed topology segment %s", segment)
 			topologyInformer = topology.NewFixedNodeTopology(&segment)
 		}
+		go topologyInformer.RunWorker(context.Background())
 
 		managedByID := "external-provisioner"
 		if *enableNodeDeployment {

--- a/pkg/capacity/topology/mock.go
+++ b/pkg/capacity/topology/mock.go
@@ -51,7 +51,7 @@ func (mt *Mock) List() []*Segment {
 	return mt.segments
 }
 
-func (mt *Mock) Run(ctx context.Context) {
+func (mt *Mock) RunWorker(ctx context.Context) {
 }
 
 func (mt *Mock) HasSynced() bool {

--- a/pkg/capacity/topology/nodes.go
+++ b/pkg/capacity/topology/nodes.go
@@ -201,14 +201,12 @@ func (nt *nodeTopology) List() []*Segment {
 	return segments
 }
 
-func (nt *nodeTopology) Run(ctx context.Context) {
-	go nt.nodeInformer.Informer().Run(ctx.Done())
-	go nt.csiNodeInformer.Informer().Run(ctx.Done())
+func (nt *nodeTopology) RunWorker(ctx context.Context) {
 	go nt.runWorker(ctx)
 
-	klog.Info("Started node topology informer")
+	klog.Info("Started node topology worker")
 	<-ctx.Done()
-	klog.Info("Shutting node topology informer")
+	klog.Info("Shutting node topology worker")
 }
 
 func (nt *nodeTopology) HasSynced() bool {

--- a/pkg/capacity/topology/topology.go
+++ b/pkg/capacity/topology/topology.go
@@ -127,11 +127,11 @@ type Informer interface {
 	// List returns all known segments, in no particular order.
 	List() []*Segment
 
-	// Run starts watching for changes.
-	Run(ctx context.Context)
-
 	// HasSynced returns true once all segments have been found.
 	HasSynced() bool
+
+	// RunWorker starts a worker to process queue.
+	RunWorker(ctx context.Context)
 }
 
 type Callback func(added []*Segment, removed []*Segment)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug


**What this PR does / why we need it**:
bugfix for commit before, if we directly remove topology informer run, the topology worker will not run and do not sync. fix this PR https://github.com/kubernetes-csi/external-provisioner/pull/590
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix capacity information updates when topology changes. Only affected central deployment and network attached storage, not deployment on each node. This broke in v2.2.0 as part of a bug fix for capacity informer handling.
```
