### PR TITLE
Fix migration metric registration

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -222,7 +222,10 @@ func main() {
 		klog.V(2).Infof("Supports migration from in-tree plugin: %s", supportsMigrationFromInTreePluginName)
 
 		// Create a new connection with the metrics manager with migrated label
-		metricsManager = metrics.NewCSIMetricsManagerWithOptions(provisionerName, metrics.WithMigration())
+		metricsManager = metrics.NewCSIMetricsManagerWithOptions(provisionerName,
+			// Will be provided via default gatherer.
+			metrics.WithProcessStartTime(false),
+			metrics.WithMigration())
 		migratedGrpcClient, err := ctrl.Connect(*csiEndpoint, metricsManager)
 		if err != nil {
 			klog.Error(err.Error())


### PR DESCRIPTION
/kind bug
**What this PR does / why we need it**:
Don't register `process_start_time_seconds metric` in migration metrics manager to prevent double registration, resulting in this error:

```
gathered metric family process_start_time_seconds has help "[ALPHA] Start time of the process since unix epoch in seconds." but should have "Start time of the process since unix epoch in seconds."
```

This happens only when a migratable CSI driver is used. With a regular hostpath CSI driver, the metrics work without any issues.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #619

**Special notes for your reviewer**:
cc @pohly @Jiawei0227 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed reporting of metrics when a migratable CSI driver is used.
```
