### PR TITLE
Release 2.2 backport

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -222,7 +222,10 @@ func main() {
 		klog.V(2).Infof("Supports migration from in-tree plugin: %s", supportsMigrationFromInTreePluginName)
 
 		// Create a new connection with the metrics manager with migrated label
-		metricsManager = metrics.NewCSIMetricsManagerWithOptions(provisionerName, metrics.WithMigration())
+		metricsManager = metrics.NewCSIMetricsManagerWithOptions(provisionerName,
+			// Will be provided via default gatherer.
+			metrics.WithProcessStartTime(false),
+			metrics.WithMigration())
 		migratedGrpcClient, err := ctrl.Connect(*csiEndpoint, metricsManager)
 		if err != nil {
 			klog.Error(err.Error())

--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -441,6 +441,7 @@ func main() {
 			klog.Infof("producing CSIStorageCapacity objects with fixed topology segment %s", segment)
 			topologyInformer = topology.NewFixedNodeTopology(&segment)
 		}
+		go topologyInformer.RunWorker(context.Background())
 
 		managedByID := "external-provisioner"
 		if *enableNodeDeployment {

--- a/pkg/capacity/topology/mock.go
+++ b/pkg/capacity/topology/mock.go
@@ -51,7 +51,7 @@ func (mt *Mock) List() []*Segment {
 	return mt.segments
 }
 
-func (mt *Mock) Run(ctx context.Context) {
+func (mt *Mock) RunWorker(ctx context.Context) {
 }
 
 func (mt *Mock) HasSynced() bool {

--- a/pkg/capacity/topology/nodes.go
+++ b/pkg/capacity/topology/nodes.go
@@ -201,14 +201,12 @@ func (nt *nodeTopology) List() []*Segment {
 	return segments
 }
 
-func (nt *nodeTopology) Run(ctx context.Context) {
-	go nt.nodeInformer.Informer().Run(ctx.Done())
-	go nt.csiNodeInformer.Informer().Run(ctx.Done())
+func (nt *nodeTopology) RunWorker(ctx context.Context) {
 	go nt.runWorker(ctx)
 
-	klog.Info("Started node topology informer")
+	klog.Info("Started node topology worker")
 	<-ctx.Done()
-	klog.Info("Shutting node topology informer")
+	klog.Info("Shutting node topology worker")
 }
 
 func (nt *nodeTopology) HasSynced() bool {

--- a/pkg/capacity/topology/topology.go
+++ b/pkg/capacity/topology/topology.go
@@ -127,11 +127,11 @@ type Informer interface {
 	// List returns all known segments, in no particular order.
 	List() []*Segment
 
-	// Run starts watching for changes.
-	Run(ctx context.Context)
-
 	// HasSynced returns true once all segments have been found.
 	HasSynced() bool
+
+	// RunWorker starts a worker to process queue.
+	RunWorker(ctx context.Context)
 }
 
 type Callback func(added []*Segment, removed []*Segment)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Two bug fixes that should go into 2.2.1.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
- gathered metric family process_start_time_seconds has help "[ALPHA] Start time of the process since unix epoch in seconds." but should have "Start time of the process since unix epoch in seconds."
- Fix capacity information updates when topology changes. Only affected central deployment and network attached storage, not deployment on each node. This broke in v2.2.0 as part of a bug fix for capacity informer handling.
```
