### PR TITLE
Add SupportsBlock method to provisionWrapper for being able to use block device

### DIFF
--- a/pkg/capacity/provision.go
+++ b/pkg/capacity/provision.go
@@ -30,6 +30,7 @@ type provisionWrapper struct {
 
 var _ controller.Provisioner = &provisionWrapper{}
 var _ controller.BlockProvisioner = &provisionWrapper{}
+var _ controller.Qualifier = &provisionWrapper{}
 
 func NewProvisionWrapper(p controller.Provisioner, c *Controller) controller.Provisioner {
 	return &provisionWrapper{
@@ -90,6 +91,13 @@ func (p *provisionWrapper) Delete(ctx context.Context, pv *v1.PersistentVolume) 
 func (p *provisionWrapper) SupportsBlock(ctx context.Context) bool {
 	if blockProvisioner, ok := p.Provisioner.(controller.BlockProvisioner); ok {
 		return blockProvisioner.SupportsBlock(ctx)
+	}
+	return false
+}
+
+func (p *provisionWrapper) ShouldProvision(ctx context.Context, claim *v1.PersistentVolumeClaim) bool {
+	if qualifier, ok := p.Provisioner.(controller.Qualifier); ok {
+		return qualifier.ShouldProvision(ctx, claim)
 	}
 	return false
 }

--- a/pkg/capacity/provision.go
+++ b/pkg/capacity/provision.go
@@ -29,6 +29,7 @@ type provisionWrapper struct {
 }
 
 var _ controller.Provisioner = &provisionWrapper{}
+var _ controller.BlockProvisioner = &provisionWrapper{}
 
 func NewProvisionWrapper(p controller.Provisioner, c *Controller) controller.Provisioner {
 	return &provisionWrapper{
@@ -84,4 +85,11 @@ func (p *provisionWrapper) Delete(ctx context.Context, pv *v1.PersistentVolume) 
 		p.c.refreshTopology(*pv.Spec.NodeAffinity)
 	}
 	return
+}
+
+func (p *provisionWrapper) SupportsBlock(ctx context.Context) bool {
+	if blockProvisioner, ok := p.Provisioner.(controller.BlockProvisioner); ok {
+		return blockProvisioner.SupportsBlock(ctx)
+	}
+	return false
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
-->
/kind bug

**What this PR does / why we need it**:

Add SupportsBlock method to provisionWrapper for being able to use block device.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #631

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug that not being able to use block device mode when enable a storage capacity tracking mode.
```
