### PR TITLE
release 2.2 backport

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -93,7 +93,7 @@ var (
 	enableCapacity           = flag.Bool("enable-capacity", false, "This enables producing CSIStorageCapacity objects with capacity information from the driver's GetCapacity call.")
 	capacityImmediateBinding = flag.Bool("capacity-for-immediate-binding", false, "Enables producing capacity information for storage classes with immediate binding. Not needed for the Kubernetes scheduler, maybe useful for other consumers or for debugging.")
 	capacityPollInterval     = flag.Duration("capacity-poll-interval", time.Minute, "How long the external-provisioner waits before checking for storage capacity changes.")
-	capacityOwnerrefLevel    = flag.Int("capacity-ownerref-level", 1, "The level indicates the number of objects that need to be traversed starting from the pod identified by the POD_NAME and POD_NAMESPACE environment variables to reach the owning object for CSIStorageCapacity objects: -1 for no owner, 0 for the pod itself, 1 for a StatefulSet or DaemonSet, 2 for a Deployment, etc.")
+	capacityOwnerrefLevel    = flag.Int("capacity-ownerref-level", 1, "The level indicates the number of objects that need to be traversed starting from the pod identified by the POD_NAME and NAMESPACE environment variables to reach the owning object for CSIStorageCapacity objects: -1 for no owner, 0 for the pod itself, 1 for a StatefulSet or DaemonSet, 2 for a Deployment, etc.")
 
 	enableNodeDeployment           = flag.Bool("node-deployment", false, "Enables deploying the external-provisioner together with a CSI driver on nodes to manage node-local volumes.")
 	nodeDeploymentImmediateBinding = flag.Bool("node-deployment-immediate-binding", true, "Determines whether immediate binding is supported when deployed on each node.")

--- a/pkg/capacity/provision.go
+++ b/pkg/capacity/provision.go
@@ -30,6 +30,7 @@ type provisionWrapper struct {
 
 var _ controller.Provisioner = &provisionWrapper{}
 var _ controller.BlockProvisioner = &provisionWrapper{}
+var _ controller.Qualifier = &provisionWrapper{}
 
 func NewProvisionWrapper(p controller.Provisioner, c *Controller) controller.Provisioner {
 	return &provisionWrapper{
@@ -90,6 +91,13 @@ func (p *provisionWrapper) Delete(ctx context.Context, pv *v1.PersistentVolume) 
 func (p *provisionWrapper) SupportsBlock(ctx context.Context) bool {
 	if blockProvisioner, ok := p.Provisioner.(controller.BlockProvisioner); ok {
 		return blockProvisioner.SupportsBlock(ctx)
+	}
+	return false
+}
+
+func (p *provisionWrapper) ShouldProvision(ctx context.Context, claim *v1.PersistentVolumeClaim) bool {
+	if qualifier, ok := p.Provisioner.(controller.Qualifier); ok {
+		return qualifier.ShouldProvision(ctx, claim)
 	}
 	return false
 }

--- a/pkg/capacity/provision.go
+++ b/pkg/capacity/provision.go
@@ -29,6 +29,7 @@ type provisionWrapper struct {
 }
 
 var _ controller.Provisioner = &provisionWrapper{}
+var _ controller.BlockProvisioner = &provisionWrapper{}
 
 func NewProvisionWrapper(p controller.Provisioner, c *Controller) controller.Provisioner {
 	return &provisionWrapper{
@@ -84,4 +85,11 @@ func (p *provisionWrapper) Delete(ctx context.Context, pv *v1.PersistentVolume) 
 		p.c.refreshTopology(*pv.Spec.NodeAffinity)
 	}
 	return
+}
+
+func (p *provisionWrapper) SupportsBlock(ctx context.Context) bool {
+	if blockProvisioner, ok := p.Provisioner.(controller.BlockProvisioner); ok {
+		return blockProvisioner.SupportsBlock(ctx)
+	}
+	return false
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

We should do a v2.2.2 with fixes that have accumulated on the master branch.

**Special notes for your reviewer**:

One of the backported commits (571be5a9e5b1dcddcfc1895048ef3aa17bab5aea) is still pending in https://github.com/kubernetes-csi/external-provisioner/pull/640. While not strictly a bug fix, it addresses a test flake that also could occur on the release branch and thus worth backporting.

**Does this PR introduce a user-facing change?**:
```release-note
- Fix env name from POD_NAMESPACE to NAMESPACE for capacity-ownerref-level option. https://github.com/kubernetes-csi/external-provisioner/pull/636, @bells17
- Fix a bug that not being able to use block device mode when enable a storage capacity tracking mode. https://github.com/kubernetes-csi/external-provisioner/pull/635, @bells17  
```
