### PR TITLE
Fix data race in cloning protection controller

### DIFF
--- a/pkg/controller/clone_controller.go
+++ b/pkg/controller/clone_controller.go
@@ -79,8 +79,6 @@ func (p *CloningProtectionController) Run(ctx context.Context, threadiness int) 
 		}, time.Second, ctx.Done())
 	}
 
-	go p.claimInformer.Run(ctx.Done())
-
 	klog.Infof("Started CloningProtection controller")
 	<-ctx.Done()
 	klog.Info("Shutting down CloningProtection controller")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As mentioned in #590, informers will [automatically start](https://github.com/kubernetes/client-go/blob/v0.21.0/informers/factory.go#L132-L137) when [factory.Start is called](https://github.com/kubernetes-csi/external-provisioner/blob/v2.2.2/cmd/csi-provisioner/csi-provisioner.go#L528). Since calling the extra claimInformer.Run [causes a data race](https://github.com/kubernetes-csi/external-provisioner/issues/595#issuecomment-880420284), it should not be called in CloningProtectionController. I think this PR along with #590 will fix #582.



**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #595

**Special notes for your reviewer**:

https://github.com/kubernetes-csi/external-provisioner/issues/595#issuecomment-879678124 is my reproduction code to produce a similar panic to #582 by calling `informer.Run()` twice.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a data race in cloning protection controller
```
