### PR TITLE
Clean up .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-release-tools/travis.yml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/kubernetes-csi/external-provisioner.svg?branch=master)](https://travis-ci.org/kubernetes-csi/external-provisioner)
-
 # CSI provisioner
 
 The external-provisioner is a sidecar container that dynamically provisions volumes by calling `CreateVolume` and `DeleteVolume` functions of CSI drivers. It is necessary because internal persistent volume controller running in Kubernetes controller-manager does not have any direct interfaces to CSI drivers.


### PR DESCRIPTION
/kind cleanup


```
$ ls -la $(readlink -f .travis.yml)
ls: cannot access '/go/src/github.com/kubernetes-csi/external-provisioner/release-tools/travis.yml': No such file or directory
```

Similar to https://github.com/kubernetes-csi/external-resizer/pull/146

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
