### PR TITLE
Support accepting GA annStorageProvisioner annotation

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -73,7 +73,7 @@ var (
 	volumeModeFileSystem = v1.PersistentVolumeFilesystem
 	volumeModeBlock      = v1.PersistentVolumeBlock
 
-	driverNameAnnotation = map[string]string{annStorageProvisioner: driverName}
+	driverNameAnnotation = map[string]string{annBetaStorageProvisioner: driverName}
 	translatedKey        = "translated"
 	defaultfsType        = "ext4"
 )
@@ -503,7 +503,7 @@ func provisionFromPVCCapabilities() (rpc.PluginCapabilitySet, rpc.ControllerCapa
 var fakeSCName = "fake-test-sc"
 
 func createFakeNamedPVC(requestBytes int64, name string, userAnnotations map[string]string) *v1.PersistentVolumeClaim {
-	annotations := map[string]string{annStorageProvisioner: driverName}
+	annotations := map[string]string{annBetaStorageProvisioner: driverName}
 	for k, v := range userAnnotations {
 		annotations[k] = v
 	}
@@ -4503,11 +4503,23 @@ func TestProvisionWithMigration(t *testing.T) {
 		{
 			name:              "provision with migration on",
 			scProvisioner:     inTreePluginName,
+			annotation:        map[string]string{annBetaStorageProvisioner: driverName},
+			expectTranslation: true,
+		},
+		{
+			name:              "provision with migration on with GA annStorageProvisioner annontation",
+			scProvisioner:     inTreePluginName,
 			annotation:        map[string]string{annStorageProvisioner: driverName},
 			expectTranslation: true,
 		},
 		{
 			name:              "provision without migration for native CSI",
+			scProvisioner:     driverName,
+			annotation:        map[string]string{annBetaStorageProvisioner: driverName},
+			expectTranslation: false,
+		},
+		{
+			name:              "provision without migration for native CSI with GA annStorageProvisioner annontation",
 			scProvisioner:     driverName,
 			annotation:        map[string]string{annStorageProvisioner: driverName},
 			expectTranslation: false,
@@ -4515,31 +4527,31 @@ func TestProvisionWithMigration(t *testing.T) {
 		{
 			name:              "provision with migration for migrated-to CSI",
 			scProvisioner:     inTreePluginName,
-			annotation:        map[string]string{annStorageProvisioner: inTreePluginName, annMigratedTo: driverName},
+			annotation:        map[string]string{annBetaStorageProvisioner: inTreePluginName, annMigratedTo: driverName},
 			expectTranslation: true,
 		},
 		{
 			name:          "provision with migration-to some random driver",
 			scProvisioner: inTreePluginName,
-			annotation:    map[string]string{annStorageProvisioner: inTreePluginName, annMigratedTo: "foo"},
+			annotation:    map[string]string{annBetaStorageProvisioner: inTreePluginName, annMigratedTo: "foo"},
 			expectErr:     true,
 		},
 		{
 			name:          "provision with migration-to some random driver with random storageProvisioner",
 			scProvisioner: inTreePluginName,
-			annotation:    map[string]string{annStorageProvisioner: "foo", annMigratedTo: "foo"},
+			annotation:    map[string]string{annBetaStorageProvisioner: "foo", annMigratedTo: "foo"},
 			expectErr:     true,
 		},
 		{
 			name:              "provision with migration for migrated-to CSI with CSI Provisioner",
 			scProvisioner:     inTreePluginName,
-			annotation:        map[string]string{annStorageProvisioner: driverName, annMigratedTo: driverName},
+			annotation:        map[string]string{annBetaStorageProvisioner: driverName, annMigratedTo: driverName},
 			expectTranslation: true,
 		},
 		{
 			name:          "ignore in-tree PVC when provisioned by in-tree",
 			scProvisioner: inTreePluginName,
-			annotation:    map[string]string{annStorageProvisioner: inTreePluginName},
+			annotation:    map[string]string{annBetaStorageProvisioner: inTreePluginName},
 			expectErr:     true,
 		},
 	}


### PR DESCRIPTION


**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Supports GA version annStorageProvisioner annotation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support GA version annStorageProvisioner
```

/cc @msau42 @jsafrane @gnufied 
related issue: https://github.com/kubernetes/kubernetes/issues/102357
A follow up is to update sig-storage-lib-external-provisioner which include this: https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/pull/110
