### PR TITLE
Fix data race in cloning protection controller (v2.2)

### DIFF
--- a/pkg/controller/clone_controller.go
+++ b/pkg/controller/clone_controller.go
@@ -79,8 +79,6 @@ func (p *CloningProtectionController) Run(ctx context.Context, threadiness int) 
 		}, time.Second, ctx.Done())
 	}
 
-	go p.claimInformer.Run(ctx.Done())
-
 	klog.Infof("Started CloningProtection controller")
 	<-ctx.Done()
 	klog.Info("Shutting down CloningProtection controller")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

cherry-pick https://github.com/kubernetes-csi/external-provisioner/pull/651 to v2.

Fixes https://github.com/kubernetes-csi/external-provisioner/issues/595

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
cherry-pick #651: Fix a data race in cloning protection controller
```


