### PR TITLE
[WIP] Add finalizer before CreateVolume and remove it after PV is provisioned

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -267,6 +267,7 @@ func main() {
 	// Listers
 	// Create informer to prevent hit the API server for all resource request
 	scLister := factory.Storage().V1().StorageClasses().Lister()
+	pvLister := factory.Core().V1().PersistentVolumes().Lister()
 	claimLister := factory.Core().V1().PersistentVolumeClaims().Lister()
 
 	var vaLister storagelistersv1.VolumeAttachmentLister
@@ -486,6 +487,7 @@ func main() {
 
 	csiClaimController := ctrl.NewCloningProtectionController(
 		clientset,
+		pvLister,
 		claimLister,
 		claimInformer,
 		claimQueue,


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

This patch adds a finalizer to the PVC before _CreateVolume_ is called and remove it _after_ the volume has been provisioned by the CSI driver.

**Which issue(s) this PR fixes**:

Fixes #486

**Special notes for your reviewer**:

This is **not** ready for review yet.

**Does this PR introduce a user-facing change?**:
```release-note
Prevent leaking volumes by avoiding the PVC deletion before the volume is provisioned by the CSI driver.
```
