### PR TITLE
release-2.2: update release-tools

### DIFF
--- a/release-tools/README.md
+++ b/release-tools/README.md
@@ -42,7 +42,7 @@ images. Building from master creates the main `canary` image.
 Sharing and updating
 --------------------
 
-[`git subtree`](https://github.com/git/git/blob/master/contrib/subtree/git-subtree.txt)
+[`git subtree`](https://github.com/git/git/blob/HEAD/contrib/subtree/git-subtree.txt)
 is the recommended way of maintaining a copy of the rules inside the
 `release-tools` directory of a project. This way, it is possible to make
 changes also locally, test them and then push them back to the shared
@@ -89,7 +89,7 @@ main
 
 All Kubernetes-CSI repos are expected to switch to Prow. For details
 on what is enabled in Prow, see
-https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-csi
+https://github.com/kubernetes/test-infra/tree/HEAD/config/jobs/kubernetes-csi
 
 Test results for periodic jobs are visible in
 https://testgrid.k8s.io/sig-storage-csi-ci

--- a/release-tools/SECURITY_CONTACTS
+++ b/release-tools/SECURITY_CONTACTS
@@ -4,7 +4,7 @@
 # to for triaging and handling of incoming issues.
 #
 # The below names agree to abide by the
-# [Embargo Policy](https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#embargo-policy)
+# [Embargo Policy](https://github.com/kubernetes/sig-release/blob/HEAD/security-release-process-documentation/security-release-process.md#embargo-policy)
 # and will be removed and replaced if they violate that agreement.
 #
 # DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE

--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -9,13 +9,8 @@ The release manager must:
 * Be a member of the kubernetes-csi organization. Open an
   [issue](https://github.com/kubernetes/org/issues/new?assignees=&labels=area%2Fgithub-membership&template=membership.md&title=REQUEST%3A+New+membership+for+%3Cyour-GH-handle%3E) in
   kubernetes/org to request membership
-* Be a top level approver for the repository. To become a top level approver,
-  the candidate must demonstrate ownership and deep knowledge of the repository
-  through active maintenance, responding to and fixing issues, reviewing PRs,
-  test triage.
-* Be part of the maintainers or admin group for the repository. admin is a
-  superset of maintainers, only maintainers level is required for cutting a
-  release.  Membership can be requested by submitting a PR to kubernetes/org.
+* Be part of the maintainers group for the repository.
+  Membership can be requested by submitting a PR to kubernetes/org.
   [Example](https://github.com/kubernetes/org/pull/1467)
 
 ## Updating CI Jobs
@@ -31,16 +26,16 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 1. "-on-master" jobs are the closest reflection to the new Kubernetes version.
 1. Fixes to our prow.sh CI script can be tested in the [CSI hostpath
    repo](https://github.com/kubernetes-csi/csi-driver-host-path) by modifying
-   [prow.sh](https://github.com/kubernetes-csi/csi-driver-host-path/blob/master/release-tools/prow.sh)
+   [prow.sh](https://github.com/kubernetes-csi/csi-driver-host-path/blob/HEAD/release-tools/prow.sh)
    along with any overrides in
-   [.prow.sh](https://github.com/kubernetes-csi/csi-driver-host-path/blob/master/.prow.sh)
+   [.prow.sh](https://github.com/kubernetes-csi/csi-driver-host-path/blob/HEAD/.prow.sh)
    to mirror the failing environment. Once e2e tests are passing (verify-unit tests
    will fail), then the prow.sh changes can be submitted to [csi-release-tools](https://github.com/kubernetes-csi/csi-release-tools).
 1. Changes can then be updated in all the sidecar repos and hostpath driver repo
    by following the [update
-   instructions](https://github.com/kubernetes-csi/csi-release-tools/blob/master/README.md#sharing-and-updating).
+   instructions](https://github.com/kubernetes-csi/csi-release-tools/blob/HEAD/README.md#sharing-and-updating).
 1. New pull and CI jobs are configured by adding new K8s versions to the top of
-   [gen-jobs.sh](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-csi/gen-jobs.sh).
+   [gen-jobs.sh](https://github.com/kubernetes/test-infra/blob/HEAD/config/jobs/kubernetes-csi/gen-jobs.sh).
    New pull jobs that have been unverified should be initially made optional by
    setting the new K8s version as
    [experimental](https://github.com/kubernetes/test-infra/blob/a1858f46d6014480b130789df58b230a49203a64/config/jobs/kubernetes-csi/gen-jobs.sh#L40).
@@ -52,7 +47,7 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 1. Identify all issues and ongoing PRs that should go into the release, and
   drive them to resolution.
 1. Download v2.8+ [K8s release notes
-  generator](https://github.com/kubernetes/release/tree/master/cmd/release-notes)
+  generator](https://github.com/kubernetes/release/tree/HEAD/cmd/release-notes)
 1. Generate release notes for the release. Replace arguments with the relevant
   information.
     * Clean up old cached information (also needed if you are generating release
@@ -95,15 +90,15 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 1. Check [image build status](https://k8s-testgrid.appspot.com/sig-storage-image-build).
 1. Promote images from k8s-staging-sig-storage to k8s.gcr.io/sig-storage. From
    the [k8s image
-   repo](https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io/images/k8s-staging-sig-storage),
+   repo](https://github.com/kubernetes/k8s.io/tree/HEAD/k8s.gcr.io/images/k8s-staging-sig-storage),
    run `./generate.sh > images.yaml`, and send a PR with the updated images.
    Once merged, the image promoter will copy the images from staging to prod.
 1. Update [kubernetes-csi/docs](https://github.com/kubernetes-csi/docs) sidecar
    and feature pages with the new released version.
 1. After all the sidecars have been released, update
-   CSI hostpath driver with the new sidecars in the [CSI repo](https://github.com/kubernetes-csi/csi-driver-host-path/tree/master/deploy)
+   CSI hostpath driver with the new sidecars in the [CSI repo](https://github.com/kubernetes-csi/csi-driver-host-path/tree/HEAD/deploy)
    and [k/k
-   in-tree](https://github.com/kubernetes/kubernetes/tree/master/test/e2e/testing-manifests/storage-csi/hostpath/hostpath)
+   in-tree](https://github.com/kubernetes/kubernetes/tree/HEAD/test/e2e/testing-manifests/storage-csi/hostpath/hostpath)
 
 ## Adding support for a new Kubernetes release
 
@@ -134,7 +129,7 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 1. Once all sidecars for the new Kubernetes release are released,
    either bump the version number of the images in the existing
    [csi-driver-host-path
-   deployments](https://github.com/kubernetes-csi/csi-driver-host-path/tree/master/deploy)
+   deployments](https://github.com/kubernetes-csi/csi-driver-host-path/tree/HEAD/deploy)
    and/or create a new deployment, depending on what Kubernetes
    release an updated sidecar is compatible with. If no new deployment
    is needed, then add a symlink to document that there intentionally

--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -10,10 +10,10 @@
 #   because binaries will get built for different architectures and then
 #   get copied from the built host into the container image
 #
-# See https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md
+# See https://github.com/kubernetes/test-infra/blob/HEAD/config/jobs/image-pushing/README.md
 # for more details on image pushing process in Kubernetes.
 #
-# To promote release images, see https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io/images/k8s-staging-sig-storage.
+# To promote release images, see https://github.com/kubernetes/k8s.io/tree/HEAD/k8s.gcr.io/images/k8s-staging-sig-storage.
 
 # This must be specified in seconds. If omitted, defaults to 600s (10 mins).
 # Building three images in external-snapshotter takes roughly half an hour,
@@ -27,7 +27,7 @@ steps:
   # The image must contain bash and curl. Ideally it should also contain
   # the desired version of Go (currently defined in release-tools/prow.sh),
   # but that just speeds up the build and is not required.
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20210331-c732583'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20210917-12df099d55'
     entrypoint: ./.cloudbuild.sh
     env:
     - GIT_TAG=${_GIT_TAG}


### PR DESCRIPTION
Squashed 'release-tools/' changes from c0a4fb1dd..5b9a1e067

[5b9a1e067](https://github.com/kubernetes-csi/csi-release-tools/commit/5b9a1e067) Merge [pull request #175](https://github.com/kubernetes-csi/csi-release-tools/pull/175) from jimdaga/patch-1
[5eeb60299](https://github.com/kubernetes-csi/csi-release-tools/commit/5eeb60299) images: use k8s-staging-test-infra/gcb-docker-gcloud
[5489de6e7](https://github.com/kubernetes-csi/csi-release-tools/commit/5489de6e7) Merge [pull request #174](https://github.com/kubernetes-csi/csi-release-tools/pull/174) from mauriciopoppe/bump-kind-version
[0c675d4c0](https://github.com/kubernetes-csi/csi-release-tools/commit/0c675d4c0) Bump kind version to v0.11.1
[ef69a88d7](https://github.com/kubernetes-csi/csi-release-tools/commit/ef69a88d7) Merge [pull request #173](https://github.com/kubernetes-csi/csi-release-tools/pull/173) from nick5616/add-ws2022
[44c710c5b](https://github.com/kubernetes-csi/csi-release-tools/commit/44c710c5b) added WS2022 to build platforms
[0883be4fa](https://github.com/kubernetes-csi/csi-release-tools/commit/0883be4fa) Merge [pull request #171](https://github.com/kubernetes-csi/csi-release-tools/pull/171) from pohly/example-commands
[02cda510c](https://github.com/kubernetes-csi/csi-release-tools/commit/02cda510c) build.make: support binaries outside of cmd, with optional go.mod
[65922ea24](https://github.com/kubernetes-csi/csi-release-tools/commit/65922ea24) Merge [pull request #170](https://github.com/kubernetes-csi/csi-release-tools/pull/170) from pohly/canary-snapshot-controller
[c0bdfb3ab](https://github.com/kubernetes-csi/csi-release-tools/commit/c0bdfb3ab) prow.sh: deploy canary snapshot-controller in canary jobs
[0438f15a3](https://github.com/kubernetes-csi/csi-release-tools/commit/0438f15a3) Merge [pull request #167](https://github.com/kubernetes-csi/csi-release-tools/pull/167) from c0va23/feature/release-armv7-image
[4786f4d02](https://github.com/kubernetes-csi/csi-release-tools/commit/4786f4d02) Merge [pull request #168](https://github.com/kubernetes-csi/csi-release-tools/pull/168) from msau42/update-release-prereq
[6a2dc64a1](https://github.com/kubernetes-csi/csi-release-tools/commit/6a2dc64a1) Remove requirement to be top-level approver. Only maintainers membership is required to do a release
[30a4f7bb3](https://github.com/kubernetes-csi/csi-release-tools/commit/30a4f7bb3) Release armv7 image
[ac8108f12](https://github.com/kubernetes-csi/csi-release-tools/commit/ac8108f12) Merge [pull request #165](https://github.com/kubernetes-csi/csi-release-tools/pull/165) from consideRatio/pr/update-github-links-ref-to-master-to-HEAD
[999b483d6](https://github.com/kubernetes-csi/csi-release-tools/commit/999b483d6) docs: make github links reference HEAD instead of main
[fd6706935](https://github.com/kubernetes-csi/csi-release-tools/commit/fd6706935) docs: make github links reference HEAD instead of master

git-subtree-dir: release-tools
git-subtree-split: 5b9a1e06794ddb137ff7e2d565416cc6934ec380

```release-note
NONE
```