### PR TITLE
relax same storageclass restriction

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -963,11 +963,6 @@ func (p *csiProvisioner) getPVCSource(ctx context.Context, claim *v1.PersistentV
 		return nil, fmt.Errorf("the requested PVC (%s) storageclass cannot be empty", claim.Name)
 	}
 
-	if *sourcePVC.Spec.StorageClassName != *claim.Spec.StorageClassName {
-		return nil, fmt.Errorf("the source PVC and destination PVCs must be in the same storage class for cloning.  Source is in %v, but new PVC is in %v",
-			*sourcePVC.Spec.StorageClassName, *claim.Spec.StorageClassName)
-	}
-
 	capacity := claim.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	requestedSize := capacity.Value()
 	srcCapacity := sourcePVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -4148,9 +4148,10 @@ func TestProvisionFromPVC(t *testing.T) {
 			expectErr:        true,
 		},
 		"provision with pvc data source different storage classes": {
-			clonePVName: pvName,
-			volOpts:     generatePVCForProvisionFromPVC(srcNamespace, srcName, fakeSc2, requestedBytes, ""),
-			expectErr:   true,
+			clonePVName:      pvName,
+			volOpts:          generatePVCForProvisionFromPVC(srcNamespace, srcName, fakeSc2, requestedBytes, ""),
+			expectFinalizers: true,
+			expectErr:        false,
 		},
 		"provision with pvc data source destination too small": {
 			clonePVName:          pvName,


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
The restriction that cloning is only supported within the same Storage Class, restricts PVC cloning in some cases. For example, if you want to clone from a zonal volume --> regional volume, the replication-type for these two volumes must be different, so they require different Storage Classes. Currently snapshot allows for restoring from a snapshot with a different StorageClass, and it leaves the validation up to the CSI Drivers. No validation is done in the external provisioner to make sure the Storage Classes are compatible. For PVC cloning, validation will also be up to the CSI Drivers.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-csi/docs/issues/490

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users will be able to clone a volume with a different Storage Class. The destination volume no longer has to be the same storage class as the source. 
```