### PR TITLE
capacity: add benchmark for CSIStorageCapacity update

### DIFF
--- a/pkg/capacity/README.md
+++ b/pkg/capacity/README.md
@@ -1,0 +1,9 @@
+To benchmark the CSIStorageCapacity update code, use:
+
+```
+KUBECONFIG=<some config file> go test -bench=. -run=xxx .
+```
+
+Running repeatedly with `-count=5` and filtering the output with
+[benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) is recommended
+to determine how stable the results are.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

It may be possible to optimize updating capacity by using patching. Before
trying that we need a benchmark.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #467

**Special notes for your reviewer**:

This benchmark acts as a client with basically unlimited local rate
limits. When run long enough, the results are stable:

```
$ go test -run=xxx -bench=. -count=5 -benchtime=1m . | tee /tmp/log
...
$ $GOPATH/bin/benchstat /tmp/log
name               time/op
CapacityUpdate-36  3.93ms ± 1%
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
