### PR TITLE
controller: add pv secret annotation support to forget SC

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1217,7 +1217,7 @@ func (p *csiProvisioner) handleSecretsForDeletion(ctx context.Context, volume *v
 			}
 			req.Secrets = credentials
 		} else if annDeletionSecretName == "" && annDeletionSecretNamespace == "" {
-			klog.V(2).Infof("volumes without secrets detected.. continue deleting the volumes")
+			klog.V(2).Infof("volume %s does not need any deletion secrets", volume.Name)
 		}
 	} else {
 		err := p.getSecretsFromSC(ctx, volume, migratedVolume, req)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -132,6 +132,11 @@ const (
 	annStorageProvisioner     = "volume.kubernetes.io/storage-provisioner"
 	annSelectedNode           = "volume.kubernetes.io/selected-node"
 
+	// Annotation for secret name and namespace will be added to the pv object
+	// and used at pvc deletion time.
+	annDeletionProvisionerSecretRefName      = "volume.kubernetes.io/provisioner-deletion-secret-name"
+	annDeletionProvisionerSecretRefNamespace = "volume.kubernetes.io/provisioner-deletion-secret-namespace"
+
 	snapshotNotBound = "snapshot %s not bound"
 
 	pvcCloneFinalizer = "provisioner.storage.kubernetes.io/cloning-protection"
@@ -497,11 +502,17 @@ func (p *csiProvisioner) getVolumeCapabilities(
 	return volumeCaps, nil
 }
 
+type deletionSecretParams struct {
+	name      string
+	namespace string
+}
+
 type prepareProvisionResult struct {
-	fsType         string
-	migratedVolume bool
-	req            *csi.CreateVolumeRequest
-	csiPVSource    *v1.CSIPersistentVolumeSource
+	fsType              string
+	migratedVolume      bool
+	req                 *csi.CreateVolumeRequest
+	csiPVSource         *v1.CSIPersistentVolumeSource
+	provDeletionSecrets *deletionSecretParams
 }
 
 // prepareProvision does non-destructive parameter checking and preparations for provisioning a volume.
@@ -689,13 +700,21 @@ func (p *csiProvisioner) prepareProvision(ctx context.Context, claim *v1.Persist
 		req.Parameters[pvcNamespaceKey] = claim.GetNamespace()
 		req.Parameters[pvNameKey] = pvName
 	}
+	deletionAnnSecrets := new(deletionSecretParams)
+
+	if provisionerSecretRef != nil {
+		deletionAnnSecrets.name = provisionerSecretRef.Name
+		deletionAnnSecrets.namespace = provisionerSecretRef.Namespace
+	}
 
 	return &prepareProvisionResult{
-		fsType:         fsType,
-		migratedVolume: migratedVolume,
-		req:            &req,
-		csiPVSource:    csiPVSource,
+		fsType:              fsType,
+		migratedVolume:      migratedVolume,
+		req:                 &req,
+		csiPVSource:         csiPVSource,
+		provDeletionSecrets: deletionAnnSecrets,
 	}, controller.ProvisioningNoChange, nil
+
 }
 
 func (p *csiProvisioner) Provision(ctx context.Context, options controller.ProvisionOptions) (*v1.PersistentVolume, controller.ProvisioningState, error) {
@@ -836,6 +855,16 @@ func (p *csiProvisioner) Provision(ctx context.Context, options controller.Provi
 				CSI: result.csiPVSource,
 			},
 		},
+	}
+
+	// Set annDeletionSecretRefName and namespace in PV object.
+	if result.provDeletionSecrets != nil {
+		klog.V(5).Infof("createVolumeOperation: set annotation [%s/%s] on pv [%s].", annDeletionProvisionerSecretRefNamespace, annDeletionProvisionerSecretRefName, pv.Name)
+		metav1.SetMetaDataAnnotation(&pv.ObjectMeta, annDeletionProvisionerSecretRefName, result.provDeletionSecrets.name)
+		metav1.SetMetaDataAnnotation(&pv.ObjectMeta, annDeletionProvisionerSecretRefNamespace, result.provDeletionSecrets.namespace)
+	} else {
+		metav1.SetMetaDataAnnotation(&pv.ObjectMeta, annDeletionProvisionerSecretRefName, "")
+		metav1.SetMetaDataAnnotation(&pv.ObjectMeta, annDeletionProvisionerSecretRefNamespace, "")
 	}
 
 	if options.StorageClass.ReclaimPolicy != nil {
@@ -1154,6 +1183,52 @@ func (p *csiProvisioner) Delete(ctx context.Context, volume *v1.PersistentVolume
 	req := csi.DeleteVolumeRequest{
 		VolumeId: volumeId,
 	}
+
+	err = p.handleSecretsForDeletion(ctx, volume, &req, migratedVolume)
+	if err != nil {
+		return err
+	}
+	deleteCtx := markAsMigrated(ctx, migratedVolume)
+	deleteCtx, cancel := context.WithTimeout(deleteCtx, p.timeout)
+	defer cancel()
+
+	if err := p.canDeleteVolume(volume); err != nil {
+		return err
+	}
+
+	_, err = p.csiClient.DeleteVolume(deleteCtx, &req)
+
+	return err
+}
+
+func (p *csiProvisioner) handleSecretsForDeletion(ctx context.Context, volume *v1.PersistentVolume, req *csi.DeleteVolumeRequest, migratedVolume bool) error {
+	var err error
+	if metav1.HasAnnotation(volume.ObjectMeta, annDeletionProvisionerSecretRefName) && metav1.HasAnnotation(volume.ObjectMeta, annDeletionProvisionerSecretRefNamespace) {
+		annDeletionSecretName := volume.Annotations[annDeletionProvisionerSecretRefName]
+		annDeletionSecretNamespace := volume.Annotations[annDeletionProvisionerSecretRefNamespace]
+		if annDeletionSecretName != "" && annDeletionSecretNamespace != "" {
+			provisionerSecretRef := &v1.SecretReference{}
+			provisionerSecretRef.Name = annDeletionSecretName
+			provisionerSecretRef.Namespace = annDeletionSecretNamespace
+			credentials, err := getCredentials(ctx, p.client, provisionerSecretRef)
+			if err != nil {
+				// Continue with deletion, as the secret may have already been deleted.
+				klog.Errorf("failed to get credentials for volume %s: %s", volume.Name, err.Error())
+			}
+			req.Secrets = credentials
+		} else if annDeletionSecretName == "" && annDeletionSecretNamespace == "" {
+			klog.V(2).Infof("volumes without secrets detected.. continue deleting the volumes")
+		}
+	} else {
+		err := p.getSecretsFromSC(ctx, volume, migratedVolume, req)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+func (p *csiProvisioner) getSecretsFromSC(ctx context.Context, volume *v1.PersistentVolume, migratedVolume bool, req *csi.DeleteVolumeRequest) error {
 	// get secrets if StorageClass specifies it
 	storageClassName := util.GetPersistentVolumeClass(volume)
 	if len(storageClassName) != 0 {
@@ -1187,17 +1262,7 @@ func (p *csiProvisioner) Delete(ctx context.Context, volume *v1.PersistentVolume
 			klog.Warningf("failed to get storageclass: %s, proceeding to delete without secrets. %v", storageClassName, err)
 		}
 	}
-	deleteCtx := markAsMigrated(ctx, migratedVolume)
-	deleteCtx, cancel := context.WithTimeout(deleteCtx, p.timeout)
-	defer cancel()
-
-	if err := p.canDeleteVolume(volume); err != nil {
-		return err
-	}
-
-	_, err = p.csiClient.DeleteVolume(deleteCtx, &req)
-
-	return err
+	return nil
 }
 
 func (p *csiProvisioner) canDeleteVolume(volume *v1.PersistentVolume) error {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1072,8 +1072,8 @@ func provisionTestcases() (int64, map[string]provisioningTestcase) {
 			expectedPVSpec: &pvSpec{
 				Name: "test-testi",
 				Annotations: map[string]string{
-					AnnDeletionProvisionerSecretRefName:      "",
-					AnnDeletionProvisionerSecretRefNamespace: "",
+					annDeletionProvisionerSecretRefName:      "",
+					annDeletionProvisionerSecretRefNamespace: "",
 				},
 				ReclaimPolicy: v1.PersistentVolumeReclaimDelete,
 				Capacity: v1.ResourceList{
@@ -1568,8 +1568,8 @@ func provisionTestcases() (int64, map[string]provisioningTestcase) {
 			expectedPVSpec: &pvSpec{
 				Name: "test-testi",
 				Annotations: map[string]string{
-					AnnDeletionProvisionerSecretRefName:      "provisionersecret",
-					AnnDeletionProvisionerSecretRefNamespace: defaultSecretNsName,
+					annDeletionProvisionerSecretRefName:      "provisionersecret",
+					annDeletionProvisionerSecretRefNamespace: defaultSecretNsName,
 				},
 				Capacity: v1.ResourceList{
 					v1.ResourceName(v1.ResourceStorage): bytesToQuantity(requestedBytes),
@@ -1623,8 +1623,8 @@ func provisionTestcases() (int64, map[string]provisioningTestcase) {
 			expectedPVSpec: &pvSpec{
 				Name: "test-testi",
 				Annotations: map[string]string{
-					AnnDeletionProvisionerSecretRefName:      "default-secret",
-					AnnDeletionProvisionerSecretRefNamespace: "default-ns",
+					annDeletionProvisionerSecretRefName:      "default-secret",
+					annDeletionProvisionerSecretRefNamespace: "default-ns",
 				},
 				Capacity: v1.ResourceList{
 					v1.ResourceName(v1.ResourceStorage): bytesToQuantity(requestedBytes),
@@ -1678,8 +1678,8 @@ func provisionTestcases() (int64, map[string]provisioningTestcase) {
 			expectedPVSpec: &pvSpec{
 				Name: "test-testi",
 				Annotations: map[string]string{
-					AnnDeletionProvisionerSecretRefName:      "my-pvc",
-					AnnDeletionProvisionerSecretRefNamespace: "default-ns",
+					annDeletionProvisionerSecretRefName:      "my-pvc",
+					annDeletionProvisionerSecretRefNamespace: "default-ns",
 				},
 				Capacity: v1.ResourceList{
 					v1.ResourceName(v1.ResourceStorage): bytesToQuantity(requestedBytes),
@@ -3930,8 +3930,8 @@ func TestDelete(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pv",
 					Annotations: map[string]string{
-						AnnDeletionProvisionerSecretRefName:      "",
-						AnnDeletionProvisionerSecretRefNamespace: "",
+						annDeletionProvisionerSecretRefName:      "",
+						annDeletionProvisionerSecretRefNamespace: "",
 					},
 				},
 				Spec: v1.PersistentVolumeSpec{
@@ -3957,8 +3957,8 @@ func TestDelete(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pv",
 					Annotations: map[string]string{
-						AnnDeletionProvisionerSecretRefName:      "",
-						AnnDeletionProvisionerSecretRefNamespace: "",
+						annDeletionProvisionerSecretRefName:      "",
+						annDeletionProvisionerSecretRefNamespace: "",
 					},
 				},
 				Spec: v1.PersistentVolumeSpec{
@@ -3978,8 +3978,8 @@ func TestDelete(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pv",
 					Annotations: map[string]string{
-						AnnDeletionProvisionerSecretRefName:      "provisionersecret",
-						AnnDeletionProvisionerSecretRefNamespace: defaultSecretNsName,
+						annDeletionProvisionerSecretRefName:      "provisionersecret",
+						annDeletionProvisionerSecretRefNamespace: defaultSecretNsName,
 					},
 				},
 				Spec: v1.PersistentVolumeSpec{
@@ -4012,8 +4012,8 @@ func TestDelete(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pv",
 					Annotations: map[string]string{
-						AnnDeletionProvisionerSecretRefName:      "provisionersecret",
-						AnnDeletionProvisionerSecretRefNamespace: defaultSecretNsName,
+						annDeletionProvisionerSecretRefName:      "provisionersecret",
+						annDeletionProvisionerSecretRefNamespace: defaultSecretNsName,
 					},
 				},
 				Spec: v1.PersistentVolumeSpec{
@@ -4037,8 +4037,8 @@ func TestDelete(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pv",
 					Annotations: map[string]string{
-						AnnDeletionProvisionerSecretRefName:      "provisionersecret",
-						AnnDeletionProvisionerSecretRefNamespace: defaultSecretNsName,
+						annDeletionProvisionerSecretRefName:      "provisionersecret",
+						annDeletionProvisionerSecretRefNamespace: defaultSecretNsName,
 					},
 				},
 				Spec: v1.PersistentVolumeSpec{
@@ -4071,8 +4071,8 @@ func TestDelete(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pv",
 					Annotations: map[string]string{
-						AnnDeletionProvisionerSecretRefName:      "non-existent-provisionersecret",
-						AnnDeletionProvisionerSecretRefNamespace: defaultSecretNsName,
+						annDeletionProvisionerSecretRefName:      "non-existent-provisionersecret",
+						annDeletionProvisionerSecretRefNamespace: defaultSecretNsName,
 					},
 				},
 				Spec: v1.PersistentVolumeSpec{


### PR DESCRIPTION
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


> /kind feature
Fixes #330 

**Special notes for your reviewer**:



-->
```release-note
Previous to this release, if the SC does not exist at time of PVC deletion where provisioner need credentials to delete volume which was passed as SC parameter at creation time, the PV deletion will fail as it can not fetch credentials by reading the SC from the API server. However this workflow is improved from this release which allows the PV deletion to succeed even if SC was deleted or does not exist at time of PV deletion. 
```
