### PR TITLE
rbac: remove unwaned rbac for the leader election

### DIFF
--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -85,9 +85,6 @@ metadata:
 rules:
 # Only one of the following rules for endpoints or leases is required based on
 # what is set for `--leader-election-type`. Endpoints are deprecated in favor of Leases.
-- apiGroups: [""]
-  resources: ["endpoints"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   verbs: ["get", "watch", "list", "delete", "update", "create"]


### PR DESCRIPTION
Considering we have removed leader election based on endpoints.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

> /kind cleanup

-->
```release-note
NONE
```
