### PR TITLE
use registry.k8s.io instead of k8s.gcr.io registry.

### DIFF
--- a/deploy/kubernetes/storage-capacity.yaml
+++ b/deploy/kubernetes/storage-capacity.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccount: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.0.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v2.0.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"


### PR DESCRIPTION
Refer# https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


> /kind cleanup

-->
```release-note
NONE
```
