### PR TITLE
controller: pass sc information to downstream csi

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -140,6 +140,10 @@ const (
 	snapshotNotBound = "snapshot %s not bound"
 
 	pvcCloneFinalizer = "provisioner.storage.kubernetes.io/cloning-protection"
+
+	// The kv that needs to be automatically inserted into CreateVolumeRequest.Parameters
+	parameterPrefix = "X-K8S-PROVISIONER-"
+	ParameterScName = parameterPrefix + "SC-NAME"
 )
 
 var (
@@ -613,6 +617,10 @@ func (p *csiProvisioner) prepareProvision(ctx context.Context, claim *v1.Persist
 			RequiredBytes: int64(volSizeBytes),
 		},
 	}
+	if req.Parameters == nil {
+		req.Parameters = make(map[string]string)
+	}
+	req.Parameters[ParameterScName] = sc.Name
 
 	if claim.Spec.DataSource != nil && (rc.clone || rc.snapshot) {
 		volumeContentSource, err := p.getVolumeContentSource(ctx, claim, sc)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:

When developing localpv, it is necessary to record some meta information, such as the last used disk, so that the disk allocation strategy can be based on the meta information, which may be a rotation training strategy, but users may create different scs based on the same csi, and csi cannot Distinguish the sc corresponding to pv, so the strategy is problematic.

**Which issue(s) this PR fixes**:


NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE

```release-note
external-privisioner As a controller, it should pass some information to the csi information, so that the csi can be refined for the user.
```
