### PR TITLE
controller: handle cache.DeletedFinalStateUnknown

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -384,6 +384,9 @@ func NewCSIProvisioner(client kubernetes.Interface,
 		// Remove deleted PVCs from rate limiter.
 		claimHandler := cache.ResourceEventHandlerFuncs{
 			DeleteFunc: func(obj interface{}) {
+				if unknown, ok := obj.(cache.DeletedFinalStateUnknown); ok && unknown.Obj != nil {
+					obj = unknown.Obj
+				}
 				if claim, ok := obj.(*v1.PersistentVolumeClaim); ok {
 					provisioner.nodeDeployment.rateLimiter.Forget(claim.UID)
 				}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

The DeleteFunc callback may get called with a cache.DeletedFinalStateUnknown
object. This needs to be handled as in
https://github.com/kubernetes-csi/external-attacher/blob/v3.2.1/pkg/controller/controller.go#L171-L173


**Which issue(s) this PR fixes**:
Fixes #628

**Does this PR introduce a user-facing change?**:
```release-note
Certain informer delete events were not handled correctly.
```
