### PR TITLE
fix: changed the csistoragecapacity check namespace

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -493,7 +493,7 @@ func main() {
 				Name: "#%123-invalid-name",
 			},
 		}
-		createdCapacity, err := clientset.StorageV1().CSIStorageCapacities("default").Create(ctx, invalidCapacity, metav1.CreateOptions{})
+		createdCapacity, err := clientset.StorageV1().CSIStorageCapacities(namespace).Create(ctx, invalidCapacity, metav1.CreateOptions{})
 		switch {
 		case err == nil:
 			klog.Fatalf("creating an invalid v1.CSIStorageCapacity didn't fail as expected, got: %s", createdCapacity)


### PR DESCRIPTION
The CSIStorageCapacity v1 check was attempting to create an invalid
object in the default namespace. This would fail if the pod did not
have permissions to the namespace. This will now use the namespace
specified in the NAMESPACE env variable.

Signed-off-by: N Balachandran <nibalach@redhat.com>



**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The CSIStorageCapacity version check attempts to create an invalid resource in the default namespace. If the pod does not have permissions on "default" , this check returns with a fatal error.

**Which issue(s) this PR fixes**:
Fixes #752 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
The CSIStorageCapacity version check will now use the namespace specified in the NAMESPACE env variable. This avoids a fatal unexpected error when checking for the V1 CSIStorageCapacity API error during startup.
```
