### PR TITLE
Automated cherry pick of #753: fix: changed the csistoragecapacity check namespace

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -493,7 +493,7 @@ func main() {
 				Name: "#%123-invalid-name",
 			},
 		}
-		createdCapacity, err := clientset.StorageV1().CSIStorageCapacities("default").Create(ctx, invalidCapacity, metav1.CreateOptions{})
+		createdCapacity, err := clientset.StorageV1().CSIStorageCapacities(namespace).Create(ctx, invalidCapacity, metav1.CreateOptions{})
 		switch {
 		case err == nil:
 			klog.Fatalf("creating an invalid v1.CSIStorageCapacity didn't fail as expected, got: %s", createdCapacity)


### PR DESCRIPTION
Cherry pick of #753 on release-3.2.

#753: fix: changed the csistoragecapacity check namespace

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```