### PR TITLE
release-3.1: update release-tools

### DIFF
--- a/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
+++ b/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
@@ -31,15 +31,7 @@ aliases:
 
 # This documents who previously contributed to Kubernetes-CSI
 # as approver.
-emeritus_approver:
+emeritus_approvers:
 - lpabon
-- sbezverk
-- vladimirvivien
-
-# This documents who previously contributed to Kubernetes-CSI
-# as reviewer.
-emeritus_reviewer:
-- lpabon
-- saad-ali
 - sbezverk
 - vladimirvivien

--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -46,10 +46,13 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 ## Release Process
 1. Identify all issues and ongoing PRs that should go into the release, and
   drive them to resolution.
-1. Download v2.8+ [K8s release notes
-  generator](https://github.com/kubernetes/release/tree/HEAD/cmd/release-notes)
+1. Download the latest version of the
+   [K8s release notes generator](https://github.com/kubernetes/release/tree/HEAD/cmd/release-notes)
+1. Create a
+   [Github personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+   with `repo:public_repo` access
 1. Generate release notes for the release. Replace arguments with the relevant
-  information.
+   information.
     * Clean up old cached information (also needed if you are generating release
       notes for multiple repos)
       ```bash
@@ -57,15 +60,24 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
       ```
     * For new minor releases on master:
         ```bash
-        GITHUB_TOKEN=<token> release-notes --discover=mergebase-to-latest
-        --github-org=kubernetes-csi --github-repo=external-provisioner
-        --required-author="" --output out.md
+        GITHUB_TOKEN=<token> release-notes \
+          --discover=mergebase-to-latest \
+          --org=kubernetes-csi \
+          --repo=external-provisioner \
+          --required-author="" \
+          --markdown-links \
+          --output out.md
         ```
     * For new patch releases on a release branch:
         ```bash
-        GITHUB_TOKEN=<token> release-notes --discover=patch-to-latest --branch=release-1.1
-        --github-org=kubernetes-csi --github-repo=external-provisioner
-        --required-author="" --output out.md
+        GITHUB_TOKEN=<token> release-notes \
+          --discover=patch-to-latest \
+          --branch=release-1.1 \
+          --org=kubernetes-csi \
+          --repo=external-provisioner \
+          --required-author="" \
+          --markdown-links \
+          --output out.md
         ```
 1. Compare the generated output to the new commits for the release to check if
    any notable change missed a release note.
@@ -99,6 +111,29 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
    CSI hostpath driver with the new sidecars in the [CSI repo](https://github.com/kubernetes-csi/csi-driver-host-path/tree/HEAD/deploy)
    and [k/k
    in-tree](https://github.com/kubernetes/kubernetes/tree/HEAD/test/e2e/testing-manifests/storage-csi/hostpath/hostpath)
+
+### Troubleshooting
+
+#### Image build jobs
+
+The following jobs are triggered after tagging to produce the corresponding
+image(s):
+https://k8s-testgrid.appspot.com/sig-storage-image-build
+
+Clicking on a failed build job opens that job in https://prow.k8s.io. Next to
+the job title is a rerun icon (circle with arrow). Clicking it opens a popup
+with a "rerun" button that maintainers with enough permissions can use. If in
+doubt, ask someone on #sig-release to rerun the job.
+
+Another way to rerun a job is to search for it in https://prow.k8s.io and click
+the rerun icon in the resulting job list:
+https://prow.k8s.io/?job=canary-csi-test-push-images
+
+#### Verify images
+
+Canary and staged images can be viewed at https://console.cloud.google.com/gcr/images/k8s-staging-sig-storage
+
+Promoted images can be viewed at https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/sig-storage
 
 ## Adding support for a new Kubernetes release
 

--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -16,9 +16,8 @@
 # To promote release images, see https://github.com/kubernetes/k8s.io/tree/HEAD/k8s.gcr.io/images/k8s-staging-sig-storage.
 
 # This must be specified in seconds. If omitted, defaults to 600s (10 mins).
-# Building three images in external-snapshotter takes roughly half an hour,
-# sometimes more.
-timeout: 3600s
+# Building three images in external-snapshotter takes more than an hour.
+timeout: 7200s
 # This prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:

--- a/release-tools/go-get-kubernetes.sh
+++ b/release-tools/go-get-kubernetes.sh
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 # This script can be used while converting a repo from "dep" to "go mod"
 # by calling it after "go mod init" or to update the Kubernetes packages
 # in a repo that has already been converted. Only packages that are

--- a/release-tools/verify-spelling.sh
+++ b/release-tools/verify-spelling.sh
@@ -41,7 +41,7 @@ if [[ -z "$(command -v misspell)" ]]; then
   # perform go get in a temp dir as we are not tracking this version in a go module
   # if we do the go get in the repo, it will create / update a go.mod and go.sum
   cd "${TMP_DIR}"
-  GO111MODULE=on GOBIN="${TMP_DIR}" go get "github.com/client9/misspell/cmd/misspell@${TOOL_VERSION}"
+  GO111MODULE=on GOBIN="${TMP_DIR}" go install "github.com/client9/misspell/cmd/misspell@${TOOL_VERSION}"
   export PATH="${TMP_DIR}:${PATH}"
 fi
 


### PR DESCRIPTION
Squashed 'release-tools/' changes from a6a1a7979..d29a2e754

[d29a2e754](https://github.com/kubernetes-csi/csi-release-tools/commit/d29a2e754) Merge [pull request #198](https://github.com/kubernetes-csi/csi-release-tools/pull/198) from pohly/csi-test-5.0.0
[41cb70d38](https://github.com/kubernetes-csi/csi-release-tools/commit/41cb70d38) prow.sh: sanity testing with csi-test v5.0.0
[c85a63fbf](https://github.com/kubernetes-csi/csi-release-tools/commit/c85a63fbf) Merge [pull request #197](https://github.com/kubernetes-csi/csi-release-tools/pull/197) from pohly/fix-alpha-testing
[b86d8e942](https://github.com/kubernetes-csi/csi-release-tools/commit/b86d8e942) support Kubernetes 1.25 + Ginkgo v2
[ab0b0a3d4](https://github.com/kubernetes-csi/csi-release-tools/commit/ab0b0a3d4) Merge [pull request #192](https://github.com/kubernetes-csi/csi-release-tools/pull/192) from andyzhangx/patch-1
[7bbab24e4](https://github.com/kubernetes-csi/csi-release-tools/commit/7bbab24e4) Merge [pull request #196](https://github.com/kubernetes-csi/csi-release-tools/pull/196) from humblec/non-alpha
[e51ff2cc0](https://github.com/kubernetes-csi/csi-release-tools/commit/e51ff2cc0) introduce control variable for non alpha feature gate configuration
[ca19ef521](https://github.com/kubernetes-csi/csi-release-tools/commit/ca19ef521) Merge [pull request #195](https://github.com/kubernetes-csi/csi-release-tools/pull/195) from pohly/fix-alpha-testing
[3948331e2](https://github.com/kubernetes-csi/csi-release-tools/commit/3948331e2) fix testing with latest Kubernetes
[e4dab7ff5](https://github.com/kubernetes-csi/csi-release-tools/commit/e4dab7ff5) Merge [pull request #194](https://github.com/kubernetes-csi/csi-release-tools/pull/194) from yselkowitz/registry-k8s-io
[84a4d5a1d](https://github.com/kubernetes-csi/csi-release-tools/commit/84a4d5a1d) Move from k8s.gcr.io to registry.k8s.io
[9a0260c55](https://github.com/kubernetes-csi/csi-release-tools/commit/9a0260c55) fix boilerplate header
[37d110492](https://github.com/kubernetes-csi/csi-release-tools/commit/37d110492) Merge [pull request #191](https://github.com/kubernetes-csi/csi-release-tools/pull/191) from pohly/go-1.18
[db917f5c1](https://github.com/kubernetes-csi/csi-release-tools/commit/db917f5c1) update to Go 1.18
[335339f05](https://github.com/kubernetes-csi/csi-release-tools/commit/335339f05) Merge [pull request #187](https://github.com/kubernetes-csi/csi-release-tools/pull/187) from mauriciopoppe/remove-eol-windows-versions
[890b87a28](https://github.com/kubernetes-csi/csi-release-tools/commit/890b87a28) Merge [pull request #188](https://github.com/kubernetes-csi/csi-release-tools/pull/188) from pwschuurman/update-release-notes-docs
[274bc9ba4](https://github.com/kubernetes-csi/csi-release-tools/commit/274bc9ba4) Update Sidecar Release Process documentation to reference latest syntax for release-notes tool
[87b6c3724](https://github.com/kubernetes-csi/csi-release-tools/commit/87b6c3724) Merge [pull request #185](https://github.com/kubernetes-csi/csi-release-tools/pull/185) from Garima-Negi/fix-OWNERS-files
[f1de2c66b](https://github.com/kubernetes-csi/csi-release-tools/commit/f1de2c66b) Fix OWNERS file - squashed commits
[59ae38b7b](https://github.com/kubernetes-csi/csi-release-tools/commit/59ae38b7b) Remove EOL windows versions from BUILD_PLATFORMS
[5d664712a](https://github.com/kubernetes-csi/csi-release-tools/commit/5d664712a) Merge [pull request #186](https://github.com/kubernetes-csi/csi-release-tools/pull/186) from humblec/sp
[d066f1ba6](https://github.com/kubernetes-csi/csi-release-tools/commit/d066f1ba6) Correct prow.sh typo and make codespell linter pass
[762e22d09](https://github.com/kubernetes-csi/csi-release-tools/commit/762e22d09) Merge [pull request #184](https://github.com/kubernetes-csi/csi-release-tools/pull/184) from pohly/image-publishing-troubleshooting
[81e26c3f8](https://github.com/kubernetes-csi/csi-release-tools/commit/81e26c3f8) SIDECAR_RELEASE_PROCESS.md: add troubleshooting for image publishing
[31aa44d1d](https://github.com/kubernetes-csi/csi-release-tools/commit/31aa44d1d) Merge [pull request #182](https://github.com/kubernetes-csi/csi-release-tools/pull/182) from chrishenzie/csi-sanity-version
[f49e141ce](https://github.com/kubernetes-csi/csi-release-tools/commit/f49e141ce) Update csi-sanity test suite to v4.3.0
[d9815c284](https://github.com/kubernetes-csi/csi-release-tools/commit/d9815c284) Merge [pull request #181](https://github.com/kubernetes-csi/csi-release-tools/pull/181) from mauriciopoppe/armv7-support
[05c18012f](https://github.com/kubernetes-csi/csi-release-tools/commit/05c18012f) Add support to build arm/v7 images
[4aedf357c](https://github.com/kubernetes-csi/csi-release-tools/commit/4aedf357c) Merge [pull request #178](https://github.com/kubernetes-csi/csi-release-tools/pull/178) from xing-yang/timeout
[2b9897eb6](https://github.com/kubernetes-csi/csi-release-tools/commit/2b9897eb6) Increase build timeout
[51d370295](https://github.com/kubernetes-csi/csi-release-tools/commit/51d370295) Merge [pull request #177](https://github.com/kubernetes-csi/csi-release-tools/pull/177) from mauriciopoppe/kind-image-1.23
[a30efeac8](https://github.com/kubernetes-csi/csi-release-tools/commit/a30efeac8) Add kind image for 1.23

git-subtree-dir: release-tools
git-subtree-split: d29a2e7547822371ebf3e61f7d2249c244879f85

```release-note
NONE
```