### PR TITLE
use registry.k8s.io image name for deployment

### DIFF
--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccount: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: gcr.io/k8s-staging-sig-storage/csi-provisioner:canary
+          image: registry.k8s.io/k8s-staging-sig-storage/csi-provisioner:canary
           args:
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"


### PR DESCRIPTION
What type of PR is this?
/kind feature deprecation

What this PR does / why we need it:

Related to:
  [PR 687 of external snapshotter](https://github.com/kubernetes-csi/external-snapshotter/pull/687)
Switch to the new endpoint for container images. See: https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Special notes for your reviewer:
registry.k8s.io is currently a redirect to k8s.gcr.io. The change should be transparent to any pulling from k8s.gcr.io.

Does this PR introduce a user-facing change?:

NONE