### PR TITLE
Change annotation name to allow volume mode change

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -144,7 +144,7 @@ const (
 
 	pvcCloneFinalizer = "provisioner.storage.kubernetes.io/cloning-protection"
 
-	annAllowVolumeModeChange = "snapshot.storage.kubernetes.io/allowVolumeModeChange"
+	annAllowVolumeModeChange = "snapshot.storage.kubernetes.io/allow-volume-mode-change"
 )
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR updates the annotation that needs to be applies to `VolumeSnapshotContents` from `snapshot.storage.kubernetes.io/allowVolumeModeChange` to `snapshot.storage.kubernetes.io/allow-volume-mode-change`. 
The feature is still in the Alpha stage. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update the annotation that needs to be applies to VolumeSnapshotContents from snapshot.storage.kubernetes.io/allowVolumeModeChange to snapshot.storage.kubernetes.io/allow-volume-mode-change
```
