### PR TITLE
Register metrics exposed by sig-storage-lib

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -54,6 +54,7 @@ import (
 	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v8/controller"
+	libmetrics "sigs.k8s.io/sig-storage-lib-external-provisioner/v8/controller/metrics"
 
 	"github.com/kubernetes-csi/csi-lib-utils/leaderelection"
 	"github.com/kubernetes-csi/csi-lib-utils/metrics"
@@ -551,6 +552,14 @@ func main() {
 		// To collect metrics data from the metric handler itself, we
 		// let it register itself and then collect from that registry.
 		reg := prometheus.NewRegistry()
+		reg.MustRegister([]prometheus.Collector{
+			libmetrics.PersistentVolumeClaimProvisionTotal,
+			libmetrics.PersistentVolumeClaimProvisionFailedTotal,
+			libmetrics.PersistentVolumeClaimProvisionDurationSeconds,
+			libmetrics.PersistentVolumeDeleteTotal,
+			libmetrics.PersistentVolumeDeleteFailedTotal,
+			libmetrics.PersistentVolumeDeleteDurationSeconds,
+		}...)
 		gatherers = append(gatherers, reg)
 
 		// This is similar to k8s.io/component-base/metrics HandlerWithReset


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

This PR registers metrics exposed by sig-storage-lib in the external provisioner. 
After this change, querying the http endpoint includes the following metrics:

1. Create an nginx pod in the cluster

2. Get the IP address of the Pod running csi-provisioner
```
% kubectl get pod -o wide
NAME                   READY   STATUS    RESTARTS   AGE     IP            NODE              NOMINATED NODE   READINESS GATES
csi-hostpath-socat-0   1/1     Running   0          31h     10.244.1.6    csi-prow-worker   <none>           <none>
csi-hostpathplugin-0   8/8     Running   0          5h47m   10.244.1.23   csi-prow-worker   <none>           <none>
nginx                  1/1     Running   0          9h      10.244.1.18   csi-prow-worker   <none>           <none>
```

3. Exec into the nginx pod and curl the metrics endpoint
```
% kubectl exec -it nginx -- sh
# curl 10.244.1.23:8080/metrics
# HELP controller_persistentvolume_delete_duration_seconds Latency in seconds to delete persistent volumes. Failed deletion attempts are ignored. Broken down by storage class name.
# TYPE controller_persistentvolume_delete_duration_seconds histogram
controller_persistentvolume_delete_duration_seconds_bucket{class="csi-hostpath-sc",le="0.005"} 0
controller_persistentvolume_delete_duration_seconds_bucket{class="csi-hostpath-sc",le="0.01"} 0
controller_persistentvolume_delete_duration_seconds_bucket{class="csi-hostpath-sc",le="0.025"} 1
controller_persistentvolume_delete_duration_seconds_bucket{class="csi-hostpath-sc",le="0.05"} 1
controller_persistentvolume_delete_duration_seconds_bucket{class="csi-hostpath-sc",le="0.1"} 1
controller_persistentvolume_delete_duration_seconds_bucket{class="csi-hostpath-sc",le="0.25"} 1
controller_persistentvolume_delete_duration_seconds_bucket{class="csi-hostpath-sc",le="0.5"} 1
controller_persistentvolume_delete_duration_seconds_bucket{class="csi-hostpath-sc",le="1"} 1
controller_persistentvolume_delete_duration_seconds_bucket{class="csi-hostpath-sc",le="2.5"} 1
controller_persistentvolume_delete_duration_seconds_bucket{class="csi-hostpath-sc",le="5"} 1
controller_persistentvolume_delete_duration_seconds_bucket{class="csi-hostpath-sc",le="10"} 1
controller_persistentvolume_delete_duration_seconds_bucket{class="csi-hostpath-sc",le="+Inf"} 1
controller_persistentvolume_delete_duration_seconds_sum{class="csi-hostpath-sc"} 0.011995
controller_persistentvolume_delete_duration_seconds_count{class="csi-hostpath-sc"} 1
# HELP controller_persistentvolume_delete_total Total number of persistent volumes deleted succesfully. Broken down by storage class name.
# TYPE controller_persistentvolume_delete_total counter
controller_persistentvolume_delete_total{class="csi-hostpath-sc"} 1
# HELP controller_persistentvolumeclaim_provision_duration_seconds Latency in seconds to provision persistent volumes. Failed provisioning attempts are ignored. Broken down by storage class name.
# TYPE controller_persistentvolumeclaim_provision_duration_seconds histogram
controller_persistentvolumeclaim_provision_duration_seconds_bucket{class="csi-hostpath-sc",le="0.005"} 0
controller_persistentvolumeclaim_provision_duration_seconds_bucket{class="csi-hostpath-sc",le="0.01"} 0
controller_persistentvolumeclaim_provision_duration_seconds_bucket{class="csi-hostpath-sc",le="0.025"} 0
controller_persistentvolumeclaim_provision_duration_seconds_bucket{class="csi-hostpath-sc",le="0.05"} 1
controller_persistentvolumeclaim_provision_duration_seconds_bucket{class="csi-hostpath-sc",le="0.1"} 1
controller_persistentvolumeclaim_provision_duration_seconds_bucket{class="csi-hostpath-sc",le="0.25"} 1
controller_persistentvolumeclaim_provision_duration_seconds_bucket{class="csi-hostpath-sc",le="0.5"} 1
controller_persistentvolumeclaim_provision_duration_seconds_bucket{class="csi-hostpath-sc",le="1"} 1
controller_persistentvolumeclaim_provision_duration_seconds_bucket{class="csi-hostpath-sc",le="2.5"} 1
controller_persistentvolumeclaim_provision_duration_seconds_bucket{class="csi-hostpath-sc",le="5"} 1
controller_persistentvolumeclaim_provision_duration_seconds_bucket{class="csi-hostpath-sc",le="10"} 1
controller_persistentvolumeclaim_provision_duration_seconds_bucket{class="csi-hostpath-sc",le="+Inf"} 1
controller_persistentvolumeclaim_provision_duration_seconds_sum{class="csi-hostpath-sc"} 0.032850625
controller_persistentvolumeclaim_provision_duration_seconds_count{class="csi-hostpath-sc"} 1
# HELP controller_persistentvolumeclaim_provision_total Total number of persistent volumes provisioned succesfully. Broken down by storage class name.
# TYPE controller_persistentvolumeclaim_provision_total counter
controller_persistentvolumeclaim_provision_total{class="csi-hostpath-sc"} 1
...
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Register metrics exposed by sig-storage-lib
```
