### PR TITLE
Fix string pointer comparison for source volume mode conversion

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1149,7 +1149,7 @@ func (p *csiProvisioner) getSnapshotSource(ctx context.Context, claim *v1.Persis
 	}
 
 	if p.preventVolumeModeConversion {
-		if snapContentObj.Spec.SourceVolumeMode != nil && claim.Spec.VolumeMode != nil && snapContentObj.Spec.SourceVolumeMode != claim.Spec.VolumeMode {
+		if snapContentObj.Spec.SourceVolumeMode != nil && claim.Spec.VolumeMode != nil && *snapContentObj.Spec.SourceVolumeMode != *claim.Spec.VolumeMode {
 			// Attempt to modify volume mode during volume creation.
 			// Verify if this volume is allowed to alter its mode.
 			allowVolumeModeChange, ok := snapContentObj.Annotations[annAllowVolumeModeChange]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR fixes a bug where string addresses were being compared for equality instead of the actual string values. 
Due to this bug, even if the source volume mode is unchanged, the VolumeSnapshotContent object needed the `allowVolumeModeChange` annotation to be set to true for PVC creation to succeed. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix string pointer comparison for source volume mode conversion
```
