### PR TITLE
Pass PVC annotations to req.Parameters when --extra-create-metadata is enabled

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1107,7 +1107,14 @@ func provisionTestcases() (int64, map[string]provisioningTestcase) {
 					},
 				},
 				PVName: "test-name",
-				PVC:    createFakePVC(requestedBytes),
+				PVC: createFakeNamedPVC(
+					requestedBytes,
+					"fake-pvc",
+					map[string]string{
+						"userAnnotation1": "value1",
+						"userAnnotation2": "value2",
+					},
+				),
 			},
 			withExtraMetadata: true,
 			expectedPVSpec: &pvSpec{
@@ -1128,10 +1135,11 @@ func provisionTestcases() (int64, map[string]provisioningTestcase) {
 			expectCreateVolDo: func(t *testing.T, ctx context.Context, req *csi.CreateVolumeRequest) {
 				pvc := createFakePVC(requestedBytes)
 				expectedParams := map[string]string{
-					pvcNameKey:      pvc.GetName(),
-					pvcNamespaceKey: pvc.GetNamespace(),
-					pvNameKey:       "test-testi",
-					"fstype":        "ext3",
+					pvcNameKey:                 pvc.GetName(),
+					pvcNamespaceKey:            pvc.GetNamespace(),
+					pvNameKey:                  "test-testi",
+					"fstype":                   "ext3",
+					pvcNamespaceAnnotationsKey: "userAnnotation1=value1,userAnnotation2=value2,volume.beta.kubernetes.io/storage-provisioner=test-driver",
 				}
 				if fmt.Sprintf("%v", req.Parameters) != fmt.Sprintf("%v", expectedParams) { // only pvc name/namespace left
 					t.Errorf("Unexpected parameters: %v", req.Parameters)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adding PVC's annotation to CreateVolumeRequest.Parameters when --extra-create-metadata is enabled, fix issue #86
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #86 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adding PVC's annotation to CreateVolumeRequest.Parameters when --extra-create-metadata is enabled
```
