### PR TITLE
Replace templates in SC parameter with PVC annotations

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -121,10 +121,10 @@ const (
 	snapshotAPIGroup = snapapi.GroupName       // "snapshot.storage.k8s.io"
 	pvcKind          = "PersistentVolumeClaim" // Native types don't require an API group
 
-	tokenPVNameKey                 = "pv.name"
-	tokenPVCNameKey                = "pvc.name"
-	tokenPVCNameSpaceKey           = "pvc.namespace"
-	tokenPVAnnoationTemplatePrefix = "pvc.annotations"
+	tokenPVNameKey                  = "pv.name"
+	tokenPVCNameKey                 = "pvc.name"
+	tokenPVCNameSpaceKey            = "pvc.namespace"
+	tokenPVCAnnoationTemplatePrefix = "pvc.annotations"
 
 	ResyncPeriodOfCsiNodeInformer = 1 * time.Hour
 
@@ -598,14 +598,14 @@ func (p *csiProvisioner) prepareProvision(ctx context.Context, claim *v1.Persist
 
 	pvcAnnotationsForSCParam := map[string]string{}
 	for k, v := range claim.GetAnnotations() {
-		pvcAnnotationsForSCParam[tokenPVAnnoationTemplatePrefix+"['"+k+"']"] = v
+		pvcAnnotationsForSCParam[tokenPVCAnnoationTemplatePrefix+"['"+k+"']"] = v
 	}
 
 	fsTypesFound := 0
 	fsType := ""
 	for k, v := range sc.Parameters {
 		// Replace SC parameters with PVC annoations
-		if strings.Contains(v, tokenPVAnnoationTemplatePrefix) {
+		if strings.Contains(v, tokenPVCAnnoationTemplatePrefix) {
 			resolvedName, err := resolveTemplate(v, pvcAnnotationsForSCParam)
 
 			if err != nil {
@@ -1765,7 +1765,7 @@ func getSecretReference(secretParams secretParamsMap, storageClassParams map[str
 			nameParams[tokenPVCNameKey] = pvc.Name
 			nameParams[tokenPVCNameSpaceKey] = pvc.Namespace
 			for k, v := range pvc.Annotations {
-				nameParams[tokenPVAnnoationTemplatePrefix+"['"+k+"']"] = v
+				nameParams[tokenPVCAnnoationTemplatePrefix+"['"+k+"']"] = v
 			}
 		}
 		resolvedName, err := resolveTemplate(nameTemplate, nameParams)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Replace templates in SC parameter with PVC annotations, this fixes issue 428 in csi-driver-smb repo: https://github.com/kubernetes-csi/csi-driver-smb/issues/428

This change has been tested manually with SMB CSI Driver which uses SC parameter subDir in SMB mount path, code example as below

> Storage Class
```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: smb
provisioner: smb.csi.k8s.io
parameters:
  subDir: ${pvc.annotations['subDirInPVC']}
```

> PVC
```
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: pvc-smb
  annotations:
    subDirInPVC: "dir1"
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Replace SC parameter template with PVC annotations
```
