### PR TITLE
Seed random generator before creating provisioner identity

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -280,6 +280,7 @@ func main() {
 
 	// Generate a unique ID for this provisioner
 	timeStamp := time.Now().UnixNano() / int64(time.Millisecond)
+	rand.Seed(timeStamp)
 	identity := strconv.FormatInt(timeStamp, 10) + "-" + strconv.Itoa(rand.Intn(10000)) + "-" + provisionerName
 	if *enableNodeDeployment {
 		identity = identity + "-" + node


### PR DESCRIPTION
The Go math/random package needs to be seeded otherwise it will generate the same sequence over and over.

Without seeding, all provisioners will have `8081` as part of their random ID, as that is the first number generated by the default sequence.

Use the millisecond timeStamp created just above as seed. This still links the random number to the time stamp, but that's probably good enough for its purpose.

/kind bug

Fixes #845

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
