### PR TITLE
Ensue the flag higher than env for kubeconfig

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -162,12 +162,14 @@ func main() {
 		addr = *httpEndpoint
 	}
 
-	// get the KUBECONFIG from env if specified (useful for local/debug cluster)
-	kubeconfigEnv := os.Getenv("KUBECONFIG")
+	if len(*kubeconfig) == 0 {
+		// get the KUBECONFIG from env if specified (useful for local/debug cluster)
+		kubeconfigEnv := os.Getenv("KUBECONFIG")
 
-	if kubeconfigEnv != "" {
-		klog.Infof("Found KUBECONFIG environment variable set, using that..")
-		kubeconfig = &kubeconfigEnv
+		if kubeconfigEnv != "" {
+			klog.Infof("Found KUBECONFIG environment variable set, using that..")
+			kubeconfig = &kubeconfigEnv
+		}
 	}
 
 	if *master != "" || *kubeconfig != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

As usually, the kubeconfig specified by cmd line should have the higher priority than got it from env,
but when I run the cmd "KUBECONFIG=/path/kubeconfig1 go run cmd/csi-provisioner/csi-provisioner.go --kubeconfig /path/kubeconfig2",  the "KUBECONFIG" will be used rather than "--kubeconfig". 
this PR to fix it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
