### PR TITLE
Enable dependabot for all dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,6 +2,8 @@ version: 2
 updates:
 - package-ecosystem: gomod
   directory: "/"
+  allow:
+  - dependency-type: "all"
   schedule:
     interval: daily
   labels:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Let dependabot update all dependencies, not only the direct ones. For example, golang.org/x/net should be updated because it had a recent CVE.

This is an experiment, we'll see what it does in external-provisioner before applying it to all other repos.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
