### PR TITLE
Enable dependabot raising PR by groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,19 @@ updates:
   - dependency-type: "all"
   schedule:
     interval: daily
+  groups:
+    golang-dependencies:
+      patterns:
+        - "github.com/golang*"
+    k8s-dependencies:
+      patterns:
+        - "k8s.io*"
+        - "sigs.k8s.io*"
+    github-dependencies:
+      patterns:
+        - "github.com*"
+      exclude-patterns:
+        - "github.com/golang*"
   labels:
     - "area/dependency"
     - "release-note-none"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,7 @@ updates:
   allow:
   - dependency-type: "all"
   schedule:
-    interval: daily
+    interval: weekly
   groups:
     golang-dependencies:
       patterns:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Discussed in the CSI meeting in this [doc](https://docs.google.com/document/d/1PFnr77YRkG6SyBAP2jWPdMGuinUDd2zJTqorpnJ5DQ0/edit#heading=h.zi7hqs68iml9), we want to enable dependabot raising PR by groups to reduce PR and email spam. We are using the [beta groups feature](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) of dependabot 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/assign @jsafrane 
/assign @msau42 
