### PR TITLE
Enable or Enhance Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,27 +10,31 @@ updates:
   groups:
     golang-dependencies:
       patterns:
-        - "github.com/golang*"
+      - "github.com/golang*"
     k8s-dependencies:
       patterns:
-        - "k8s.io*"
-        - "sigs.k8s.io*"
+      - "k8s.io*"
+      - "sigs.k8s.io*"
     github-dependencies:
       patterns:
-        - "github.com*"
+      - "github.com*"
       exclude-patterns:
-        - "github.com/golang*"
+      - "github.com/golang*"
   labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
+  - "area/dependency"
+  - "release-note-none"
+  - "ok-to-test"
   open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-      interval: "daily"
+    interval: "daily"
   labels:
-    - "area/dependency"
-    - "release-note-none"
-    - "ok-to-test"
+  - "area/dependency"
+  - "release-note-none"
+  - "ok-to-test"
   open-pull-requests-limit: 10
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily


### PR DESCRIPTION

Enable Dependabot for Docker and GoMod if not already so.
Keeping K8s dependencies up-to-date. 

Signed-off-by: zhuxiaow@google.com
