### PR TITLE
Group the rest of dependencies in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,9 +17,11 @@ updates:
         - "sigs.k8s.io*"
     github-dependencies:
       patterns:
-        - "github.com*"
+        - "*"
       exclude-patterns:
         - "github.com/golang*"
+        - "k8s.io*"
+        - "sigs.k8s.io*"
   labels:
     - "area/dependency"
     - "release-note-none"


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Group the rest of dependencies so it does not open a single dependency update similar to this PR https://github.com/kubernetes-csi/external-provisioner/pull/1007

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
