### PR TITLE
Pass source VS/PVC metadata to plugin by request parameters

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -119,6 +119,9 @@ const (
 	pvcNameKey      = "csi.storage.k8s.io/pvc/name"
 	pvcNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
 	pvNameKey       = "csi.storage.k8s.io/pv/name"
+	// VolumeContentSource(VolumeSnatshot/PersistentVolumeClaim) metadata
+	vcsNameKey      = "csi.storage.k8s.io/vsc/name"
+	vcsNamespaceKey = "csi.storage.k8s.io/vsc/namespace"
 
 	snapshotKind     = "VolumeSnapshot"
 	snapshotAPIGroup = snapapi.GroupName       // "snapshot.storage.k8s.io"
@@ -734,6 +737,12 @@ func (p *csiProvisioner) prepareProvision(ctx context.Context, claim *v1.Persist
 		req.Parameters[pvcNameKey] = claim.GetName()
 		req.Parameters[pvcNamespaceKey] = claim.GetNamespace()
 		req.Parameters[pvNameKey] = pvName
+		if dataSource != nil {
+			req.Parameters[vcsNameKey] = dataSource.Name
+			if utilfeature.DefaultFeatureGate.Enabled(features.CrossNamespaceVolumeDataSource) {
+				req.Parameters[vcsNamespaceKey] = dataSource.Namespace
+			}
+		}
 	}
 	deletionAnnSecrets := new(deletionSecretParams)
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2759,11 +2759,12 @@ func TestProvisionFromSnapshot(t *testing.T) {
 			},
 			withExtraMetadata: true,
 			expectCreateVolDo: func(t *testing.T, ctx context.Context, req *csi.CreateVolumeRequest) {
-				if req.Parameters[vcsNameKey] != snapName {
-					t.Errorf("Expected VolumeSnapshot name: %s, got: %s", snapName, req.Parameters[vcsNameKey])
+				if req.Parameters[sourceVsNameKey] != snapName {
+					t.Errorf("Expected VolumeSnapshot name: %s, got: %s", snapName, req.Parameters[sourceVsNameKey])
 				}
-				if req.Parameters[vcsNamespaceKey] != "" {
-					t.Errorf("Expected cannot get VolumeSnapshot namespace, but got: %s", req.Parameters[vcsNameKey])
+				// crossNamespace not enable, source VolumeSnapshot namespace not passed
+				if req.Parameters[sourceVsNamespaceKey] != "" {
+					t.Errorf("Expected cannot get VolumeSnapshot namespace, but got: %s", req.Parameters[sourceVsNamespaceKey])
 				}
 			},
 			expectCSICall: true,
@@ -3427,11 +3428,12 @@ func TestProvisionFromSnapshot(t *testing.T) {
 			},
 			withExtraMetadata: true,
 			expectCreateVolDo: func(t *testing.T, ctx context.Context, req *csi.CreateVolumeRequest) {
-				if req.Parameters[vcsNameKey] != snapName {
-					t.Errorf("Expected VolumeSnapshot name: %s, got: %s", snapName, req.Parameters[vcsNameKey])
+				if req.Parameters[sourceVsNameKey] != snapName {
+					t.Errorf("Expected VolumeSnapshot name: %s, got: %s", snapName, req.Parameters[sourceVsNameKey])
 				}
-				if req.Parameters[vcsNamespaceKey] != dataSourceNamespace {
-					t.Errorf("Expected VolumeSnapshot namespace: %s, got: %s", dataSourceNamespace, req.Parameters[vcsNamespaceKey])
+				// crossNamespace enabled, expect source VolumeSnapshot namespace passed
+				if req.Parameters[sourceVsNamespaceKey] != dataSourceNamespace {
+					t.Errorf("Expected VolumeSnapshot namespace: %s, got: %s", dataSourceNamespace, req.Parameters[sourceVsNamespaceKey])
 				}
 			},
 			expectCSICall:        true,
@@ -5565,11 +5567,12 @@ func TestProvisionFromPVC(t *testing.T) {
 			},
 			withExtraMetadata: true,
 			expectCreateVolDo: func(t *testing.T, ctx context.Context, req *csi.CreateVolumeRequest) {
-				if req.Parameters[vcsNameKey] != srcName {
-					t.Errorf("Expected PersistentVolumeClain name: %s, got: %s", srcName, req.Parameters[vcsNameKey])
+				if req.Parameters[sourcePvcNameKey] != srcName {
+					t.Errorf("Expected PersistentVolumeClain name: %s, got: %s", srcName, req.Parameters[sourcePvcNameKey])
 				}
-				if req.Parameters[vcsNamespaceKey] != "" {
-					t.Errorf("Expcted cannot get PersistentVolumeClain namespace, got: %s", req.Parameters[vcsNamespaceKey])
+				// crossNamespace not enable, source PersistentVolumeClaim namespace not passed
+				if req.Parameters[sourcePvcNamespaceKey] != "" {
+					t.Errorf("Expcted cannot get PersistentVolumeClain namespace, got: %s", req.Parameters[sourcePvcNamespaceKey])
 				}
 			},
 		},
@@ -5722,11 +5725,12 @@ func TestProvisionFromPVC(t *testing.T) {
 			xnsEnabled:        true,
 			withExtraMetadata: true,
 			expectCreateVolDo: func(t *testing.T, ctx context.Context, req *csi.CreateVolumeRequest) {
-				if req.Parameters[vcsNameKey] != srcName {
-					t.Errorf("Expected PersistentVolumeClaim name: %s, got: %s", srcName, req.Parameters[vcsNameKey])
+				if req.Parameters[sourcePvcNameKey] != srcName {
+					t.Errorf("Expected PersistentVolumeClaim name: %s, got: %s", srcName, req.Parameters[sourcePvcNameKey])
 				}
-				if req.Parameters[vcsNamespaceKey] != srcNamespace {
-					t.Errorf("Expected PersistentVolumeClain namespace: %s, got:  %s", srcNamespace, req.Parameters[vcsNamespaceKey])
+				// crossNamespace enabled, expect source VolumeSnapshot namespace passed
+				if req.Parameters[sourcePvcNamespaceKey] != srcNamespace {
+					t.Errorf("Expected PersistentVolumeClain namespace: %s, got:  %s", srcNamespace, req.Parameters[sourcePvcNamespaceKey])
 				}
 			},
 			expectedPVSpec: &pvSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

When flag `--extra-create-metadata` set, inject the name and namespace of VolumeContentSource(VS or PVC) into CreateVolumeRequest parameters if user create PVC base on the VS/PVC. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1069

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Expose name and namespace of VolumeContentSource(VS/PVC) to plugin
```
