### PR TITLE
[WIP] fix: properly shutdown topology informer on context cancellation

### DIFF
--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -242,6 +242,7 @@ var _ metrics.StableCollector = &Controller{}
 func (c *Controller) Run(ctx context.Context, threadiness int) {
 	klog.Info("Starting Capacity Controller")
 	defer c.queue.ShutDown()
+	defer c.topologyInformer.ShutDown()
 
 	c.prepare(ctx)
 	for i := 0; i < threadiness; i++ {

--- a/pkg/capacity/topology/mock.go
+++ b/pkg/capacity/topology/mock.go
@@ -42,6 +42,8 @@ type Mock struct {
 	callbacks []Callback
 }
 
+func (mt *Mock) ShutDown() {}
+
 func (mt *Mock) AddCallback(cb Callback) {
 	mt.callbacks = append(mt.callbacks, cb)
 	cb(mt.segments, nil)

--- a/pkg/capacity/topology/nodes.go
+++ b/pkg/capacity/topology/nodes.go
@@ -168,6 +168,10 @@ type nodeTopology struct {
 	callbacks []Callback
 }
 
+func (nt *nodeTopology) ShutDown() {
+	nt.queue.ShutDown()
+}
+
 // driverTopologyKeys returns nil if the driver is not running
 // on the node, otherwise at least an empty slice of topology keys.
 func (nt *nodeTopology) driverTopologyKeys(csiNode *storagev1.CSINode) []string {

--- a/pkg/capacity/topology/topology.go
+++ b/pkg/capacity/topology/topology.go
@@ -132,6 +132,9 @@ type Informer interface {
 
 	// RunWorker starts a worker to process queue.
 	RunWorker(ctx context.Context)
+
+	// ShutDown stops all workers.
+	ShutDown()
 }
 
 type Callback func(added []*Segment, removed []*Segment)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Makes context cancellation clear and resolves the topology informer never shutting down correctly when cancelling its context. Includes shutdown logs to verify this.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1151

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
external-provisioner now includes shutdown logs for controllers started.
If consumed as a go dependency, external-provisioner now shuts down the context correctly when stopping the context used for the informers.
```
