### PR TITLE
Update release tools - go version

### DIFF
--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -564,7 +564,15 @@ go_version_for_kubernetes () (
     local version="$2"
     local go_version
 
-    # We use the minimal Go version specified for each K8S release (= minimum_go_version in hack/lib/golang.sh).
+    # Try to get the version for .go-version
+    go_version="$( cat "$path/.go-version" )"
+    if [ "$go_version" ]; then
+        echo "$go_version"
+        return
+    fi
+
+    # Fall back to hack/lib/golang.sh parsing.
+    # This is necessary in v1.26.0 and older Kubernetes releases that do not have .go-version.
     # More recent versions might also work, but we don't want to count on that.
     go_version="$(grep minimum_go_version= "$path/hack/lib/golang.sh" | sed -e 's/.*=go//')"
     if ! [ "$go_version" ]; then


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Squashed 'release-tools/' changes from b54c1ba49..dc4d0ae20
dc4d0ae20 Merge pull request https://github.com/kubernetes-csi/external-provisioner/pull/249 from jsafrane/use-go-version
e681b170e Use .go-version to get Kubernetes go version

git-subtree-dir: release-tools
git-subtree-split: dc4d0ae20a3dcce17fbfc745fb1f1e3b10cd9644

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
