### PR TITLE
set Topology feature gate default to true

### DIFF
--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -58,7 +58,7 @@ func init() {
 // defaultKubernetesFeatureGates consists of all known feature keys specific to external-provisioner.
 // To add a new feature, define a key for it above and add it here.
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	Topology:                       {Default: false, PreRelease: featuregate.GA},
+	Topology:                       {Default: true, PreRelease: featuregate.GA},
 	HonorPVReclaimPolicy:           {Default: true, PreRelease: featuregate.Beta},
 	CrossNamespaceVolumeDataSource: {Default: false, PreRelease: featuregate.Alpha},
 	VolumeAttributesClass:          {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This feature gate has already existed for 5 years. And should be safe to enable by default.

Besides, because this feature gate has been marked as GA, it will show warnings: `Setting GA feature gate Topology=true. It will be removed in a future release.`. So I went ahead and removed this feature gate from command line. Then something breaks, which is very confusing. I would expect a GA feature gate to default to true.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Action required: Feature gate Topology is enabled by default. This feature gate is already GA and will be removed in a future release. CSI drivers are required to report capability `VOLUME_ACCESSIBILITY_CONSTRAINTS` correctly: when a CSI drivers reports the capability, topology is enabled in the external-provisioner. When the driver does not report it, external-provisioner disables topology support. 
```
