### PR TITLE
fix: add finalizer to prevent volume leakage

### DIFF
--- a/pkg/controller/provisioning_controller.go
+++ b/pkg/controller/provisioning_controller.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v9/controller"
+)
+
+type ProvisioningProtectionController struct {
+	client        kubernetes.Interface
+	claimLister   corelisters.PersistentVolumeClaimLister
+	claimInformer cache.SharedInformer
+	claimQueue    workqueue.RateLimitingInterface
+}
+
+// NewProvisioningProtectionController creates new controller for additional CSI claim protection capabilities
+func NewProvisioningProtectionController(
+	client kubernetes.Interface,
+	claimLister corelisters.PersistentVolumeClaimLister,
+	claimInformer cache.SharedInformer,
+	claimQueue workqueue.RateLimitingInterface,
+) *ProvisioningProtectionController {
+	controller := &ProvisioningProtectionController{
+		client:        client,
+		claimLister:   claimLister,
+		claimInformer: claimInformer,
+		claimQueue:    claimQueue,
+	}
+	return controller
+}
+
+// Run is a main ProvisioningProtectionController handler
+func (p *ProvisioningProtectionController) Run(ctx context.Context, threadiness int) {
+	klog.Info("Starting ProvisioningProtection controller")
+	defer utilruntime.HandleCrash()
+	defer p.claimQueue.ShutDown()
+
+	claimHandler := cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { p.enqueueClaimUpdate(obj) },
+		UpdateFunc: func(_ interface{}, newObj interface{}) { p.enqueueClaimUpdate(newObj) },
+	}
+	p.claimInformer.AddEventHandlerWithResyncPeriod(claimHandler, controller.DefaultResyncPeriod)
+
+	for i := 0; i < threadiness; i++ {
+		go wait.Until(func() {
+			p.runClaimWorker(ctx)
+		}, time.Second, ctx.Done())
+	}
+
+	klog.Infof("Started ProvisioningProtection controller")
+	<-ctx.Done()
+	klog.Info("Shutting down ProvisioningProtection controller")
+}
+
+func (p *ProvisioningProtectionController) runClaimWorker(ctx context.Context) {
+	for p.processNextClaimWorkItem(ctx) {
+	}
+}
+
+// processNextClaimWorkItem processes items from claimQueue
+func (p *ProvisioningProtectionController) processNextClaimWorkItem(ctx context.Context) bool {
+	obj, shutdown := p.claimQueue.Get()
+	if shutdown {
+		return false
+	}
+
+	err := func(obj interface{}) error {
+		defer p.claimQueue.Done(obj)
+		var key string
+		var ok bool
+		if key, ok = obj.(string); !ok {
+			p.claimQueue.Forget(obj)
+			return fmt.Errorf("expected string in workqueue but got %#v", obj)
+		}
+
+		if err := p.syncClaimHandler(ctx, key); err != nil {
+			klog.Warningf("Retrying syncing claim %q after %v failures", key, p.claimQueue.NumRequeues(obj))
+			p.claimQueue.AddRateLimited(obj)
+		} else {
+			p.claimQueue.Forget(obj)
+		}
+
+		return nil
+	}(obj)
+
+	if err != nil {
+		utilruntime.HandleError(err)
+		return true
+	}
+
+	return true
+}
+
+// enqueueClaimUpdate takes a PVC obj and stores it into the claim work queue.
+func (p *ProvisioningProtectionController) enqueueClaimUpdate(obj interface{}) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	p.claimQueue.Add(key)
+}
+
+// syncClaimHandler gets the claim from informer's cache then calls syncClaim
+func (p *ProvisioningProtectionController) syncClaimHandler(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		return nil
+	}
+
+	claim, err := p.claimLister.PersistentVolumeClaims(namespace).Get(name)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			utilruntime.HandleError(fmt.Errorf("item '%s' in work queue no longer exists", key))
+			return nil
+		}
+
+		return err
+	}
+
+	return p.syncClaim(ctx, claim)
+}
+
+// syncClaim removes finalizers from a PVC, when provision is finished
+func (p *ProvisioningProtectionController) syncClaim(ctx context.Context, claim *v1.PersistentVolumeClaim) error {
+	if !checkFinalizer(claim, pvcProvisioningFinalizer) || claim.Spec.VolumeName == "" {
+		return nil
+	}
+
+	// Remove provision finalizer
+	finalizers := make([]string, 0)
+	for _, finalizer := range claim.ObjectMeta.Finalizers {
+		if finalizer != pvcProvisioningFinalizer {
+			finalizers = append(finalizers, finalizer)
+		}
+	}
+
+	clone := claim.DeepCopy()
+	clone.Finalizers = finalizers
+	if _, err := p.client.CoreV1().PersistentVolumeClaims(clone.Namespace).Update(ctx, clone, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/controller/provisioning_controller_test.go
+++ b/pkg/controller/provisioning_controller_test.go
@@ -1,0 +1,97 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/informers"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/util/workqueue"
+)
+
+func provisioningBaseClaim(pvName string) *v1.PersistentVolumeClaim {
+	return fakeClaim("test", "test", "fake-claim-uid", 1000, pvName, v1.ClaimBound, &fakeSc1, "").DeepCopy()
+}
+
+func TestProvisioningFinalizerRemoval(t *testing.T) {
+	testcases := map[string]struct {
+		claim           runtime.Object
+		expectFinalizer bool
+		expectError     error
+	}{
+		"provisioning pvc without volumeName": {
+			claim:           pvcFinalizers(provisioningBaseClaim(""), pvcProvisioningFinalizer),
+			expectFinalizer: true,
+		},
+		"pvc without provisioning finalizer": {
+			claim:           baseClaim(),
+			expectFinalizer: false,
+		},
+		"provisioning pvc with volumeName": {
+			claim:           pvcFinalizers(provisioningBaseClaim("test"), pvcProvisioningFinalizer),
+			expectFinalizer: false,
+		},
+	}
+
+	for k, tc := range testcases {
+		tc := tc
+		t.Run(k, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			clientSet := fakeclientset.NewSimpleClientset(tc.claim)
+			provisioningProtector := fakeProvisioningProtector(clientSet, tc.claim)
+
+			claim := tc.claim.(*v1.PersistentVolumeClaim)
+			err := provisioningProtector.syncClaim(ctx, claim)
+
+			// Get updated claim after reconcile finish
+			claim, _ = clientSet.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(ctx, claim.Name, metav1.GetOptions{})
+
+			// Check finalizers removal
+			if tc.expectFinalizer && !checkFinalizer(claim, pvcProvisioningFinalizer) {
+				t.Errorf("Claim finalizer was expected to be found on: %s", claim.Name)
+			} else if !tc.expectFinalizer && checkFinalizer(claim, pvcProvisioningFinalizer) {
+				t.Errorf("Claim finalizer was not expected to be found on: %s", claim.Name)
+			}
+
+			if tc.expectError == nil && err != nil {
+				t.Errorf("Caught an unexpected error during 'syncClaim' run: %s", err)
+			} else if tc.expectError != nil && err == nil {
+				t.Errorf("Expected error during 'syncClaim' run, got nil: %s", tc.expectError)
+			} else if tc.expectError != nil && err != nil && tc.expectError.Error() != err.Error() {
+				t.Errorf("Unexpected error during 'syncClaim' run:\n\t%s\nExpected:\n\t%s", err, tc.expectError)
+			}
+		})
+	}
+
+}
+
+func fakeProvisioningProtector(client *fakeclientset.Clientset, objects ...runtime.Object) *ProvisioningProtectionController {
+	utilruntime.ReallyCrash = false
+
+	informerFactory := informers.NewSharedInformerFactory(client, 1*time.Second)
+	claimInformer := informerFactory.Core().V1().PersistentVolumeClaims().Informer()
+	claimLister := informerFactory.Core().V1().PersistentVolumeClaims().Lister()
+	rateLimiter := workqueue.NewItemExponentialFailureRateLimiter(time.Second, 2*time.Second)
+	claimQueue := workqueue.NewNamedRateLimitingQueue(rateLimiter, "provisioning-protection")
+
+	for _, claim := range objects {
+		claimInformer.GetStore().Add(claim)
+	}
+
+	informerFactory.WaitForCacheSync(context.TODO().Done())
+	go informerFactory.Start(context.TODO().Done())
+
+	return NewProvisioningProtectionController(
+		client,
+		claimLister,
+		claimInformer,
+		claimQueue,
+	)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug

**What this PR does / why we need it**:

Add a annotation volume.kubernetes.io/provisioning-consistency to pvc. When the annotation is set to enable, use a finalizer to ensure that the lifecycle of the PVC is consistent with the associated volume, preventing volume leakage.

The finalizer is removed under two conditions:

1.When the annotation volume.kubernetes.io/provisioning-consistency is set to disable on the PVC, or

2.When the associated PV has been provisioned successfully.

Removing the finalizer allows the PVC to be deleted safely without causing the volume to leak.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #486

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

When the annotation volume.kubernetes.io/provisioning-consistency is added to a PVC with the value enable, a provisioning protection finalizer will be added before creating the volume and removed after setting pvc.spec.volumeName.

If the PVC is being deleted and volume.kubernetes.io/provisioning-consistency is set to disable, the finalizer will be removed, abandoning the provisioning process. A CSI driver may be provisioning the volume and this volume may leak.

```
