### PR TITLE
Fix clone controller shallow copy bug

### DIFF
--- a/pkg/controller/clone_controller.go
+++ b/pkg/controller/clone_controller.go
@@ -199,9 +199,10 @@ func (p *CloningProtectionController) syncClaim(ctx context.Context, claim *v1.P
 			finalizers = append(finalizers, finalizer)
 		}
 	}
-	claim.ObjectMeta.Finalizers = finalizers
 
-	if _, err = p.client.CoreV1().PersistentVolumeClaims(claim.Namespace).Update(ctx, claim, metav1.UpdateOptions{}); err != nil {
+	clone := claim.DeepCopy()
+	clone.Finalizers = finalizers
+	if _, err = p.client.CoreV1().PersistentVolumeClaims(clone.Namespace).Update(ctx, clone, metav1.UpdateOptions{}); err != nil {
 		if !apierrs.IsNotFound(err) {
 			// Couldn't remove finalizer and the object still exists, the controller may
 			// try to remove the finalizer again on the next update

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -983,9 +983,10 @@ func (p *csiProvisioner) setCloneFinalizer(ctx context.Context, pvc *v1.Persiste
 		return err
 	}
 
-	if !checkFinalizer(claim, pvcCloneFinalizer) {
-		claim.Finalizers = append(claim.Finalizers, pvcCloneFinalizer)
-		_, err := p.client.CoreV1().PersistentVolumeClaims(claim.Namespace).Update(ctx, claim, metav1.UpdateOptions{})
+	clone := claim.DeepCopy()
+	if !checkFinalizer(clone, pvcCloneFinalizer) {
+		clone.Finalizers = append(clone.Finalizers, pvcCloneFinalizer)
+		_, err := p.client.CoreV1().PersistentVolumeClaims(clone.Namespace).Update(ctx, clone, metav1.UpdateOptions{})
 		return err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

If the cloner controller directly updates the PVC reference without using a deep copy and then calls the Update() method, it can lead to a situation where the cached PVC is updated (removing the finalizer), while the actual PVC remains unmodified in case the Update() operation fails.

**Which issue(s) this PR fixes**:

Fixes #1188 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

Fix clone controller shallow copy bug

```
