### PR TITLE
fix: don't pass confusing value to GetCapacityRequest.VolumeCapabilities

### DIFF
--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -591,17 +591,8 @@ func (c *Controller) syncCapacity(ctx context.Context, item workItem) error {
 
 	req := &csi.GetCapacityRequest{
 		Parameters: sc.Parameters,
-		// The assumption is that the capacity is independent of the
-		// capabilities. The standard makes it mandatory to pass something,
-		// therefore we pick something rather arbitrarily.
-		VolumeCapabilities: []*csi.VolumeCapability{
-			{
-				AccessType: &csi.VolumeCapability_Mount{},
-				AccessMode: &csi.VolumeCapability_AccessMode{
-					Mode: csi.VolumeCapability_AccessMode_UNKNOWN,
-				},
-			},
-		},
+		// The assumption is that the capacity is independent of the capabilities.
+		VolumeCapabilities: nil,
 	}
 	if item.segment != nil {
 		req.AccessibleTopology = &csi.Topology{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

`external-provisioner` calls `GetCapacity()` with "faked" VolumeCapabilities, but it is confusing for CSI driver implementations to validate the capabilities. For example, the access mode is always `VolumeCapability_AccessMode_UNKNOWN`, but it's unclear for an implementation how to handle an "UNKNOWN" mode. And the access type is always `mount`, it also confuses block-oriented CSI drivers.

The comment says "The standard makes it mandatory to pass something, therefore we pick something rather arbitrarily.", but according to the latest CSI spec, the field is optional. So I think we can simply set an empty value to that field.

https://github.com/container-storage-interface/spec/blob/2696773158b970c65107610d8f3ef4302546eca0/csi.proto#L1050-L1056

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`GetCapacityRequest.VolumeCapabilities` is now set to `nil` instead of some ambiguous default value when invoking `GetCapacity()`.
```
