### PR TITLE
feat: support PVC annotation template for provisioner secret

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -697,12 +697,7 @@ func (p *csiProvisioner) prepareProvision(ctx context.Context, claim *v1.Persist
 	}
 
 	// Resolve provision secret credentials.
-	provisionerSecretRef, err := getSecretReference(provisionerSecretParams, sc.Parameters, pvName, &v1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      claim.Name,
-			Namespace: claim.Namespace,
-		},
-	})
+	provisionerSecretRef, err := getSecretReference(provisionerSecretParams, sc.Parameters, pvName, claim)
 	if err != nil {
 		return nil, controller.ProvisioningNoChange, err
 	}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -722,6 +722,23 @@ func TestGetSecretReference(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		"template - valid PVC annotations for Provision and Delete": {
+			secretParams: provisionerSecretParams,
+			params: map[string]string{
+				prefixedProvisionerSecretNamespaceKey: "static-${pvc.namespace}",
+				prefixedProvisionerSecretNameKey:      "static-${pvc.name}-${pvc.annotations['akey']}",
+			},
+			pvName: "pvname",
+			pvc: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "name",
+					Namespace:   "pvcnamespace",
+					Annotations: map[string]string{"akey": "avalue"},
+				},
+			},
+			expectErr: false,
+			expectRef: &v1.SecretReference{Name: "static-name-avalue", Namespace: "static-pvcnamespace"},
+		},
 		"template - valid nodepublish secret ref": {
 			secretParams: nodePublishSecretParams,
 			params: map[string]string{


### PR DESCRIPTION
Provisioner can resolve templated per volume secret in storage class such as following example: `csi.storage.k8s.io/provisioner-secret-name: ${pvc.annotations['example.com/foo_secret']} `
The secret will be stored as metadata in annotations of PV, so it can find the secret OnDelete even the PVC was deleted


**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Inconsistent usage of per volume secrets in storage class with parameter like `csi.storage.k8s.io/provisioner-secret-name`
We can support syntax like other API does
`csi.storage.k8s.io/node-publish-secret-name: ${pvc.annotations['team.example.com/key']}`

**Which issue(s) this PR fixes**:
Fixes #1148

**Special notes for your reviewer**:
We can use original PVC object to resolve secret during provision and store  it to PV's metadata.
Parameters on existing SC are immutable so the provisioner should compatible with previous version.

**Does this PR introduce a user-facing change?**:
```release-note
Added support for PVC annotations in `csi.storage.k8s.io/provisioner-secret-name` StorageClass parameters. For example: `csi.storage.k8s.io/provisioner-secret-name: ${pvc.annotations['xyz']}`.
```
