### PR TITLE
WIP: remove protection finalizer correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -191,3 +191,5 @@ replace k8s.io/mount-utils => k8s.io/mount-utils v0.30.0
 replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.30.0
 
 replace k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.30.0
+
+replace sigs.k8s.io/sig-storage-lib-external-provisioner/v10 => github.com/jsafrane/sig-storage-lib-external-provisioner/v10 v10.0.0-20240729124546-527f63708d4d

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9q
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jsafrane/sig-storage-lib-external-provisioner/v10 v10.0.0-20240729124546-527f63708d4d h1:+wVBX0EMKljd61qe+CyMq/dzJIMoygUt4ZfiNtL5Fuc=
+github.com/jsafrane/sig-storage-lib-external-provisioner/v10 v10.0.0-20240729124546-527f63708d4d/go.mod h1:mfQ2enu5yAHUhpNWsce9NmkqkRQsk70zQT+7KjZ+JMo=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -346,8 +348,6 @@ sigs.k8s.io/gateway-api v1.1.0 h1:DsLDXCi6jR+Xz8/xd0Z1PYl2Pn0TyaFMOPPZIj4inDM=
 sigs.k8s.io/gateway-api v1.1.0/go.mod h1:ZH4lHrL2sDi0FHZ9jjneb8kKnGzFWyrTya35sWUTrRs=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/sig-storage-lib-external-provisioner/v10 v10.0.0 h1:+OhFU21hL9Gq/sHKHfYxbc7M6RWV3UqTpnk5/wF9cP4=
-sigs.k8s.io/sig-storage-lib-external-provisioner/v10 v10.0.0/go.mod h1:mfQ2enu5yAHUhpNWsce9NmkqkRQsk70zQT+7KjZ+JMo=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1 h1:150L+0vs/8DA78h1u02ooW1/fFq/Lwr+sGiqlzvrtq4=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.1/go.mod h1:N8hJocpFajUSSeSJ9bOZ77VzejKZaXsTtZo4/u7Io08=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1495,7 +1495,7 @@ sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1beta1
 ## explicit; go 1.18
 sigs.k8s.io/json
 sigs.k8s.io/json/internal/golang/encoding/json
-# sigs.k8s.io/sig-storage-lib-external-provisioner/v10 v10.0.0
+# sigs.k8s.io/sig-storage-lib-external-provisioner/v10 v10.0.0 => github.com/jsafrane/sig-storage-lib-external-provisioner/v10 v10.0.0-20240729124546-527f63708d4d
 ## explicit; go 1.22.0
 sigs.k8s.io/sig-storage-lib-external-provisioner/v10/controller
 sigs.k8s.io/sig-storage-lib-external-provisioner/v10/controller/metrics
@@ -1539,3 +1539,4 @@ sigs.k8s.io/yaml/goyaml.v2
 # k8s.io/mount-utils => k8s.io/mount-utils v0.30.0
 # k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.30.0
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.30.0
+# sigs.k8s.io/sig-storage-lib-external-provisioner/v10 => github.com/jsafrane/sig-storage-lib-external-provisioner/v10 v10.0.0-20240729124546-527f63708d4d


### PR DESCRIPTION
Bump sig-storage-lib-external-provisioner to remove PV protection finalizer correctly.

WIP: waiting for https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/pull/174 to be merged firs & v10.0.1 tagged.

A testing image is available as quay.io/jsafrane/external-provisioner:test1245 (amd64 only)

```release-note
Fixed removal of PV protection finalizer. PVs are no longer Terminating forever after PVC deletion.
```
