### PR TITLE
Promote VolumeAttributesClass to Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Following table reflects the head of this branch.
 | CSINodeExpandSecret | GA | On | [CSI Node expansion secret](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/3107-csi-nodeexpandsecret)                                  | No |
 | HonorPVReclaimPolicy| Beta | On | [Honor the PV reclaim policy](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/2644-honor-pv-reclaim-policy)                                  | No |
 | PreventVolumeModeConversion | Beta |On | [Prevent unauthorized conversion of source volume mode](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/3141-prevent-volume-mode-conversion) | `--prevent-volume-mode-conversion` (No in-tree feature gate) |
+| VolumeAttributesClass | Beta | Off | [Pass VolumeAttributesClass parameters during CreateVolume](https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/3751-volume-attributes-class/README.md) | `--feature-gates=VolumeAttributesClass=true` |
 | CrossNamespaceVolumeDataSource | Alpha |Off | [Cross-namespace volume data source](https://github.com/kubernetes/enhancements/tree/master/keps/sig-storage/3294-provision-volumes-from-cross-namespace-snapshots) | `--feature-gates=CrossNamespaceVolumeDataSource=true` |
 
 All other external-provisioner features and the external-provisioner itself is considered GA and fully supported.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -757,7 +757,7 @@ func (p *csiProvisioner) prepareProvision(ctx context.Context, claim *v1.Persist
 	}
 
 	if vacName != "" {
-		vac, err := p.client.StorageV1alpha1().VolumeAttributesClasses().Get(ctx, vacName, metav1.GetOptions{})
+		vac, err := p.client.StorageV1beta1().VolumeAttributesClasses().Get(ctx, vacName, metav1.GetOptions{})
 		if err != nil {
 			return nil, controller.ProvisioningNoChange, err
 		}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -33,7 +33,7 @@ import (
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	storagev1alpha1 "k8s.io/api/storage/v1alpha1"
+	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -2326,7 +2326,7 @@ func provisionTestcases() (int64, map[string]provisioningTestcase) {
 				features.VolumeAttributesClass: true,
 			},
 			pluginCapabilities: provisionWithVACCapabilities,
-			clientSetObjects: []runtime.Object{&storagev1alpha1.VolumeAttributesClass{
+			clientSetObjects: []runtime.Object{&storagev1beta1.VolumeAttributesClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: vacName,
 				},
@@ -2379,7 +2379,7 @@ func provisionTestcases() (int64, map[string]provisioningTestcase) {
 				features.VolumeAttributesClass: false,
 			},
 			pluginCapabilities: provisionWithVACCapabilities,
-			clientSetObjects: []runtime.Object{&storagev1alpha1.VolumeAttributesClass{
+			clientSetObjects: []runtime.Object{&storagev1beta1.VolumeAttributesClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: vacName,
 				},
@@ -2448,7 +2448,7 @@ func provisionTestcases() (int64, map[string]provisioningTestcase) {
 				features.VolumeAttributesClass: true,
 			},
 			pluginCapabilities: provisionWithVACCapabilities,
-			clientSetObjects: []runtime.Object{&storagev1alpha1.VolumeAttributesClass{
+			clientSetObjects: []runtime.Object{&storagev1beta1.VolumeAttributesClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: vacName,
 				},
@@ -2475,7 +2475,7 @@ func provisionTestcases() (int64, map[string]provisioningTestcase) {
 				features.VolumeAttributesClass: true,
 			},
 			pluginCapabilities: provisionWithVACCapabilities,
-			clientSetObjects: []runtime.Object{&storagev1alpha1.VolumeAttributesClass{
+			clientSetObjects: []runtime.Object{&storagev1beta1.VolumeAttributesClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: vacName,
 				},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -46,6 +46,7 @@ const (
 	// owner: @sunnylovestiramisu @ConnorJC3
 	// kep: https://kep.k8s.io/3751
 	// alpha: v1.29
+	// beta: v1.31
 	//
 	// Pass VolumeAttributesClass parameters to supporting CSI drivers during CreateVolume
 	VolumeAttributesClass featuregate.Feature = "VolumeAttributesClass"
@@ -61,5 +62,5 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	Topology:                       {Default: true, PreRelease: featuregate.GA},
 	HonorPVReclaimPolicy:           {Default: true, PreRelease: featuregate.Beta},
 	CrossNamespaceVolumeDataSource: {Default: false, PreRelease: featuregate.Alpha},
-	VolumeAttributesClass:          {Default: false, PreRelease: featuregate.Alpha},
+	VolumeAttributesClass:          {Default: false, PreRelease: featuregate.Beta},
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design

/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Promote VolumeAttributesClass feature gate to Beta to match [promotion of upstream KEP #3751](https://github.com/kubernetes/enhancements/issues/3751) in Kubernetes v1.31.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Promote VolumeAttributesClass feature gate to beta. If VolumeAttributesClass feature gate gate is enabled, this sidecar may only be used with Kubernetes v1.31 due to objects and listers having been upgraded to v1beta1.
```
