### PR TITLE
Optimize for topology term

### DIFF
--- a/pkg/controller/topology_test.go
+++ b/pkg/controller/topology_test.go
@@ -1484,22 +1484,12 @@ func BenchmarkDedupAndSortHost(b *testing.B) {
 }
 
 func benchmarkDedupAndSort(b *testing.B, terms []topologyTerm) {
-	b.Run("slices.Sort", func(b *testing.B) {
-		for range b.N {
-			terms := slices.Clone(terms)
-			terms = deduplicate(terms)
-			slices.SortFunc(terms, topologyTerm.compare)
-			toCSITopology(terms)
-		}
-	})
-	b.Run("slices.Compact", func(b *testing.B) {
-		for range b.N {
-			terms := slices.Clone(terms)
-			slices.SortFunc(terms, topologyTerm.compare)
-			terms = slices.CompactFunc(terms, slices.Equal)
-			toCSITopology(terms)
-		}
-	})
+	for range b.N {
+		terms := slices.Clone(terms)
+		slices.SortFunc(terms, topologyTerm.compare)
+		terms = slices.CompactFunc(terms, slices.Equal)
+		toCSITopology(terms)
+	}
 }
 
 func buildNodes(nodeLabels []map[string]string) *v1.NodeList {

--- a/pkg/controller/topology_test.go
+++ b/pkg/controller/topology_test.go
@@ -18,10 +18,12 @@ package controller
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/testing/protocmp"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -1454,6 +1456,52 @@ func TestPreferredTopologies(t *testing.T) {
 	}
 }
 
+func BenchmarkDedupAndSortZone(b *testing.B) {
+	terms := make([]topologyTerm, 0, 3000)
+	for range 1000 {
+		for _, zone := range [...]string{"zone1", "zone2", "zone3"} {
+			terms = append(terms, topologyTerm{
+				{"topology.kubernetes.io/region", "some-region"},
+				{"topology.kubernetes.io/zone", zone},
+			})
+		}
+	}
+	benchmarkDedupAndSort(b, terms)
+}
+
+func BenchmarkDedupAndSortHost(b *testing.B) {
+	terms := make([]topologyTerm, 0, 3000)
+	for i := range 1000 {
+		for j, zone := range [...]string{"zone1", "zone2", "zone3"} {
+			terms = append(terms, topologyTerm{
+				{"example.com/instance-id", fmt.Sprintf("i-%05d", i+j*10000)},
+				{"topology.kubernetes.io/region", "some-region"},
+				{"topology.kubernetes.io/zone", zone},
+			})
+		}
+	}
+	benchmarkDedupAndSort(b, terms)
+}
+
+func benchmarkDedupAndSort(b *testing.B, terms []topologyTerm) {
+	b.Run("slices.Sort", func(b *testing.B) {
+		for range b.N {
+			terms := slices.Clone(terms)
+			terms = deduplicate(terms)
+			slices.SortFunc(terms, topologyTerm.compare)
+			toCSITopology(terms)
+		}
+	})
+	b.Run("slices.Compact", func(b *testing.B) {
+		for range b.N {
+			terms := slices.Clone(terms)
+			slices.SortFunc(terms, topologyTerm.compare)
+			terms = slices.CompactFunc(terms, slices.Equal)
+			toCSITopology(terms)
+		}
+	})
+}
+
 func buildNodes(nodeLabels []map[string]string) *v1.NodeList {
 	list := &v1.NodeList{}
 	i := 0
@@ -1635,4 +1683,161 @@ func listers(kubeClient *fakeclientset.Clientset) (
 	factory.Start(stopChan)
 	factory.WaitForCacheSync(stopChan)
 	return scLister, csiNodeLister, nodeLister, claimLister, vaLister, stopChan
+}
+
+func TestTopologyTermSort(t *testing.T) {
+	testCases := []struct {
+		name            string
+		terms, expected topologyTerm
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name: "single-key",
+			terms: topologyTerm{
+				{"zone", "us-east-1a"},
+			},
+			expected: topologyTerm{
+				{"zone", "us-east-1a"},
+			},
+		},
+		{
+			name: "multiple-keys",
+			terms: topologyTerm{
+				{"zone", "us-east-1a"},
+				{"instance", "i-123"},
+			},
+			expected: topologyTerm{
+				{"instance", "i-123"},
+				{"zone", "us-east-1a"},
+			},
+		},
+		{
+			name: "multiple-values", // should not happen currently
+			terms: topologyTerm{
+				{"zone", "us-east-1b"},
+				{"zone", "us-east-1a"},
+			},
+			expected: topologyTerm{
+				{"zone", "us-east-1a"},
+				{"zone", "us-east-1b"},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.terms.sort()
+			assert.Equal(t, tc.expected, tc.terms)
+		})
+	}
+}
+
+func TestTopologyTermCompare(t *testing.T) {
+	testCases := []struct {
+		name          string
+		first, second topologyTerm
+	}{
+		{
+			name:  "shorter",
+			first: topologyTerm{},
+			second: topologyTerm{
+				{"zone", "us-east-1a"},
+			},
+		},
+		{
+			name: "key-smaller",
+			first: topologyTerm{
+				{"instance", "i-123"},
+			},
+			second: topologyTerm{
+				{"zone", "us-east-1a"},
+			},
+		},
+		{
+			name: "value-smaller",
+			first: topologyTerm{
+				{"instance", "i-123"},
+				{"zone", "us-east-1a"},
+			},
+			second: topologyTerm{
+				{"instance", "i-123"},
+				{"zone", "us-east-1b"},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Less(t, tc.first.compare(tc.second), 0)
+			assert.Greater(t, tc.second.compare(tc.first), 0)
+			assert.Equal(t, 0, tc.first.compare(tc.first))
+			assert.Equal(t, 0, tc.second.compare(tc.second))
+		})
+	}
+}
+
+func TestTopologyTermSubset(t *testing.T) {
+	testCases := []struct {
+		name         string
+		terms, other topologyTerm
+		subset       bool
+	}{
+		{
+			name:   "empty",
+			subset: true,
+		},
+		{
+			name:   "shorter",
+			terms:  topologyTerm{},
+			other:  topologyTerm{{"zone", "us-east-1a"}},
+			subset: true,
+		},
+		{
+			name:   "longer",
+			terms:  topologyTerm{{"zone", "us-east-1a"}},
+			other:  topologyTerm{},
+			subset: false,
+		},
+		{
+			name:   "same",
+			terms:  topologyTerm{{"zone", "us-east-1a"}},
+			other:  topologyTerm{{"zone", "us-east-1a"}},
+			subset: true,
+		},
+		{
+			name:   "shorter-2",
+			terms:  topologyTerm{{"instance", "i-123"}},
+			other:  topologyTerm{{"instance", "i-123"}, {"zone", "us-east-1a"}},
+			subset: true,
+		},
+		{
+			name:   "longer-2",
+			terms:  topologyTerm{{"instance", "i-123"}, {"zone", "us-east-1a"}},
+			other:  topologyTerm{{"instance", "i-123"}},
+			subset: false,
+		},
+		{
+			name:   "shorter-3",
+			terms:  topologyTerm{{"zone", "us-east-1a"}},
+			other:  topologyTerm{{"instance", "i-123"}, {"zone", "us-east-1a"}},
+			subset: true,
+		},
+		{
+			name:   "longer-3",
+			terms:  topologyTerm{{"instance", "i-123"}, {"zone", "us-east-1a"}},
+			other:  topologyTerm{{"zone", "us-east-1a"}},
+			subset: false,
+		},
+		{
+			name:   "unrelated",
+			terms:  topologyTerm{{"instance", "i-123"}},
+			other:  topologyTerm{{"zone", "us-east-1a"}},
+			subset: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.subset, tc.terms.subset(tc.other))
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Greatly reduce the CPU and memory usage, especially for drivers assign different topology to each host. Benchmark shows 30x CPU reduction and 21x memory allocation size reduction.

We were performing a stress test recently, and found the bottleneck to be the CPU usage of external-provisioner. From profiling, `topologyTerm.hash` takes almost all the CPU time (apart from logGRPC).
![image](https://github.com/user-attachments/assets/919c01f6-2cb4-4dfa-b3bc-db7dfd4dfabf)
Our setup is a 3k node cluster, each node has a distinct topology. It took about 50s for provisioning 3k immediate binding volumes, despite that we have raised the CPU limit to 10. external-provisioner also took ~3GiB memory, which is far higher than expected.

[This](https://github.com/huww98/external-provisioner/commit/4998f1d35d2f7091fa044508a6fb7abe9dd32f9a) is my initial attempt (not included in this PR) to optimize this. I re-implemented the compare function for sort to avoid hash() and added some benchmarks. The benchmark result is:
```
goos: darwin
goarch: arm64
pkg: github.com/kubernetes-csi/external-provisioner/v5/pkg/controller
cpu: Apple M2 Pro
BenchmarkDedupAndSortZone/baseline-12               1641            643224 ns/op          697858 B/op      15032 allocs/op
BenchmarkDedupAndSortZone/compare-12                1812            642864 ns/op          697004 B/op      15012 allocs/op
BenchmarkDedupAndSortZone/slices.Sort-12            1795            644037 ns/op          696948 B/op      15010 allocs/op
BenchmarkDedupAndSortZone/slices.Compact-12          906           1309465 ns/op          540267 B/op       8060 allocs/op
BenchmarkDedupAndSortHost/baseline-12                 50          22663181 ns/op        27017105 B/op     530151 allocs/op
BenchmarkDedupAndSortHost/compare-12                 156           7625107 ns/op         5039063 B/op      60242 allocs/op
BenchmarkDedupAndSortHost/slices.Sort-12             156           7646612 ns/op         5040749 B/op      60260 allocs/op
BenchmarkDedupAndSortHost/slices.Compact-12          193           6147562 ns/op         3457850 B/op      37009 allocs/op
```
By comparing `compare` and `baseline` for `BenchmarkDedupAndSortHost`, re-implementing compare already gives 3x speedup and 5x memory allocation size reduction. But when I try to replace the hash() func completely by `slices.Compact`, the host case is faster, but the zone case becomes slower.

While I'm trying to find more opportunity to optimize, I do another profile for `Host/slices.Sort` case:
![image](https://github.com/user-attachments/assets/c44cffd1-b403-414b-8daa-98eae263b102)
Making slice, accessing map, and sorting keys can all be avoid if we define topologyTerm as a sorted slice instead of map (the first commit of this PR). The benchmark result from the first commit is:
```
BenchmarkDedupAndSortZone/slices.Sort-12                    1975            527407 ns/op          747079 B/op      15014 allocs/op
BenchmarkDedupAndSortZone/slices.Compact-12                10000            114418 ns/op           74904 B/op         11 allocs/op
BenchmarkDedupAndSortHost/slices.Sort-12                     652           1847723 ns/op         2948386 B/op      30078 allocs/op
BenchmarkDedupAndSortHost/slices.Compact-12                 1597            739441 ns/op         1250314 B/op       9002 allocs/op
```
`Host/slices.Sort` case is speedup several times again, the `Zone/slices.Sort` case is also improved because of the more efficient hash(). With the very cheap compare(), using `slices.Compact` to deduplicate becomes beneficial for both case!
So, with the second commit, the hash() is removed completely.

Note that for fair comparation, the benchmark also includes `toCSITopology` invocation, because if topologyTerm is a slice, we need to convert it back to map for GRPC. Actually, after this refactor, most of the time is spent on `toCSITopology()`. If I remove it, the result is:
```
BenchmarkDedupAndSortZone-12               10725            111114 ns/op           73753 B/op          1 allocs/op
BenchmarkDedupAndSortHost-12                4029            287086 ns/op           73830 B/op          3 allocs/op
```
This is ~78x speedup compared to the baseline, with zero allocation in deduplication and sort step!


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
