### PR TITLE
Update release tools

### DIFF
--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -26,7 +26,7 @@ steps:
   # The image must contain bash and curl. Ideally it should also contain
   # the desired version of Go (currently defined in release-tools/prow.sh),
   # but that just speeds up the build and is not required.
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20230623-56e06d7c18'
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20240718-5ef92b5c36'
     entrypoint: ./.cloudbuild.sh
     env:
     - GIT_TAG=${_GIT_TAG}

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -243,7 +243,7 @@ configvar CSI_PROW_SIDECAR_E2E_PATH "${CSI_PROW_SIDECAR_E2E_IMPORT_PATH}" "CSI S
 # of the cluster. The alternative would have been to (cross-)compile csi-sanity
 # and install it inside the cluster, which is not necessarily easier.
 configvar CSI_PROW_SANITY_REPO https://github.com/kubernetes-csi/csi-test "csi-test repo"
-configvar CSI_PROW_SANITY_VERSION v5.2.0 "csi-test version"
+configvar CSI_PROW_SANITY_VERSION v5.3.1 "csi-test version"
 configvar CSI_PROW_SANITY_PACKAGE_PATH github.com/kubernetes-csi/csi-test "csi-test package"
 configvar CSI_PROW_SANITY_SERVICE "hostpath-service" "Kubernetes TCP service name that exposes csi.sock"
 configvar CSI_PROW_SANITY_POD "csi-hostpathplugin-0" "Kubernetes pod with CSI driver"


### PR DESCRIPTION
/kind cleanup

Squashed 'release-tools/' changes from 406a79acf..049659326

049659326 Merge pull request #268 from huww98/cloudbuild
119aee1ff Merge pull request #266 from jsafrane/bump-sanity-5.3.1
0ae5e52d9 Update cloudbuild image with go 1.21+
43bde065f Bump csi-sanity to 5.3.1

git-subtree-dir: release-tools
git-subtree-split: 04965932661b6e62709dcdbb9c25da528bac2605

```release-note
NONE
```
