### PR TITLE
Fix the managed-by-label getting populated with invalid value.

### DIFF
--- a/cmd/csi-provisioner/util.go
+++ b/cmd/csi-provisioner/util.go
@@ -36,7 +36,7 @@ func getNameWithMaxLength(base, suffix string, maxLength int) string {
 	baseLength := maxLength - 10 /*length of -hash-*/ - len(suffix)
 
 	// if the suffix is too long, ignore it
-	if baseLength < 0 {
+	if baseLength <= 0 {
 		prefix := base[0:min(len(base), max(0, maxLength-9))]
 		// Calculate hash on initial base-suffix string
 		shortName := fmt.Sprintf("%s-%s", prefix, hash(name))

--- a/cmd/csi-provisioner/util_test.go
+++ b/cmd/csi-provisioner/util_test.go
@@ -45,6 +45,10 @@ func TestGetNameWithMaxLength(t *testing.T) {
 			nodeName: fmt.Sprintf("node%s", strings.Repeat("a", 39)),
 		},
 		"very long, ignore suffix": {
+			expected: fmt.Sprintf("%s-%s", externalProvisioner, "a3607ff1"),
+			nodeName: fmt.Sprintf("node%s", strings.Repeat("a", 49)),
+		},
+		"very very long, ignore suffix": {
 			expected: fmt.Sprintf("%s-%s", externalProvisioner, "df38e37f"),
 			nodeName: fmt.Sprintf("node%s", strings.Repeat("a", 63)),
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

 /kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
There will be a case when the length of the node name is equals to 53 and base length becomes zero. This will make the prefix value to be empty and the label will be generated starting with '-' which is invalid label.
Ex: nodename is 
worker1.ocp-virt2-s390x.s390g.lab.eng.rdu2.redhat.com
generated label name:
-53f40b57-worker1.ocp-virt1-s390x.s390g.lab.eng.rdu2.redhat.com

This is causing the issue for the hostpath provisioner while generating csistoragecapacity objects.
`W0116 09:21:22.515275       1 reflector.go:547] k8s.io/client-go/informers/factory.go:160: failed to list *v1.CSIStorageCapacity: unable to parse requirement: values[0][csi.storage.k8s.io/managed-by]: Invalid value: "-53f40b57-worker1.ocp-virt1-s390x.s390g.lab.eng.rdu2.redhat.com": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-csi/external-provisioner/issues/1333

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
storage capacity: managed-by label getting invalid label  with a long node name and enableNodeDeployment set to true
```
