### PR TITLE
Add functionality to set pv gid annotation via driver volumecontext

### DIFF
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1802,8 +1802,10 @@ sigs.k8s.io/json
 sigs.k8s.io/json/internal/golang/encoding/json
 # sigs.k8s.io/sig-storage-lib-external-provisioner/v11 v11.0.1
 ## explicit; go 1.22.0
+sigs.k8s.io/sig-storage-lib-external-provisioner/v11/allocator
 sigs.k8s.io/sig-storage-lib-external-provisioner/v11/controller
 sigs.k8s.io/sig-storage-lib-external-provisioner/v11/controller/metrics
+sigs.k8s.io/sig-storage-lib-external-provisioner/v11/gidallocator
 sigs.k8s.io/sig-storage-lib-external-provisioner/v11/util
 # sigs.k8s.io/structured-merge-diff/v4 v4.5.0
 ## explicit; go 1.13

--- a/vendor/sigs.k8s.io/sig-storage-lib-external-provisioner/v11/allocator/doc.go
+++ b/vendor/sigs.k8s.io/sig-storage-lib-external-provisioner/v11/allocator/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator // import "sigs.k8s.io/sig-storage-lib-external-provisioner/v11/allocator"

--- a/vendor/sigs.k8s.io/sig-storage-lib-external-provisioner/v11/allocator/minmax.go
+++ b/vendor/sigs.k8s.io/sig-storage-lib-external-provisioner/v11/allocator/minmax.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//
+// This implementation is space-efficient for a sparse
+// allocation over a big range. Could be optimized
+// for high absolute allocation number with a bitmap.
+//
+
+package allocator
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	//ErrConflict returned when value is already in use.
+	ErrConflict = errors.New("number already allocated")
+
+	//ErrInvalidRange returned invalid range, for eg# min > max
+	ErrInvalidRange = errors.New("invalid range")
+
+	//ErrOutOfRange returned when value is not in pool range.
+	ErrOutOfRange = errors.New("out of range")
+
+	//ErrRangeFull returned when no more free values in the pool.
+	ErrRangeFull = errors.New("range full")
+
+	//ErrInternal returned when no free item found, but a.free != 0.
+	ErrInternal = errors.New("internal error")
+)
+
+// MinMaxAllocator defines allocator struct.
+type MinMaxAllocator struct {
+	lock sync.Mutex
+	min  int
+	max  int
+	free int
+	used map[int]bool
+}
+
+var _ Rangeable = &MinMaxAllocator{}
+
+// Rangeable is an Interface that can adjust its min/max range.
+// Rangeable should be threadsafe
+type Rangeable interface {
+	Allocate(int) (bool, error)
+	AllocateNext() (int, bool, error)
+	Release(int) error
+	Has(int) bool
+	Free() int
+	SetRange(min, max int) error
+}
+
+// NewMinMaxAllocator return a new allocator or error based on provided min/max value.
+func NewMinMaxAllocator(min, max int) (*MinMaxAllocator, error) {
+	if min > max {
+		return nil, ErrInvalidRange
+	}
+	return &MinMaxAllocator{
+		min:  min,
+		max:  max,
+		free: 1 + max - min,
+		used: map[int]bool{},
+	}, nil
+}
+
+// SetRange defines the range/pool with provided min and max values.
+func (a *MinMaxAllocator) SetRange(min, max int) error {
+	if min > max {
+		return ErrInvalidRange
+	}
+
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	// Check if we need to change
+	if a.min == min && a.max == max {
+		return nil
+	}
+
+	a.min = min
+	a.max = max
+
+	// Recompute how many free we have in the range
+	numUsed := 0
+	for i := range a.used {
+		if a.inRange(i) {
+			numUsed++
+		}
+	}
+	a.free = 1 + max - min - numUsed
+
+	return nil
+}
+
+// Allocate allocates provided value in the allocator and mark it as used.
+func (a *MinMaxAllocator) Allocate(i int) (bool, error) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	if !a.inRange(i) {
+		return false, ErrOutOfRange
+	}
+
+	if a.has(i) {
+		return false, ErrConflict
+	}
+
+	a.used[i] = true
+	a.free--
+
+	return true, nil
+}
+
+// AllocateNext allocates next value from the allocator.
+func (a *MinMaxAllocator) AllocateNext() (int, bool, error) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	// Fast check if we're out of items
+	if a.free <= 0 {
+		return 0, false, ErrRangeFull
+	}
+
+	// Scan from the minimum until we find a free item
+	for i := a.min; i <= a.max; i++ {
+		if !a.has(i) {
+			a.used[i] = true
+			a.free--
+			return i, true, nil
+		}
+	}
+
+	// no free item found, but a.free != 0
+	return 0, false, ErrInternal
+}
+
+// Release free/delete provided value from the allocator.
+func (a *MinMaxAllocator) Release(i int) error {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	if !a.has(i) {
+		return nil
+	}
+
+	delete(a.used, i)
+
+	if a.inRange(i) {
+		a.free++
+	}
+
+	return nil
+}
+
+func (a *MinMaxAllocator) has(i int) bool {
+	_, ok := a.used[i]
+	return ok
+}
+
+// Has check whether the provided value is used in the allocator
+func (a *MinMaxAllocator) Has(i int) bool {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	return a.has(i)
+}
+
+// Free returns the number of free values in the allocator.
+func (a *MinMaxAllocator) Free() int {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	return a.free
+}
+
+func (a *MinMaxAllocator) inRange(i int) bool {
+	return a.min <= i && i <= a.max
+}

--- a/vendor/sigs.k8s.io/sig-storage-lib-external-provisioner/v11/gidallocator/doc.go
+++ b/vendor/sigs.k8s.io/sig-storage-lib-external-provisioner/v11/gidallocator/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gidallocator // import "sigs.k8s.io/sig-storage-lib-external-provisioner/v11/gidallocator"

--- a/vendor/sigs.k8s.io/sig-storage-lib-external-provisioner/v11/gidallocator/gidallocator.go
+++ b/vendor/sigs.k8s.io/sig-storage-lib-external-provisioner/v11/gidallocator/gidallocator.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gidallocator
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	klog "k8s.io/klog/v2"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v11/allocator"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v11/controller"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v11/util"
+)
+
+const (
+	// VolumeGidAnnotationKey is the key of the annotation on the PersistentVolume
+	// object that specifies a supplemental GID.
+	VolumeGidAnnotationKey = "pv.beta.kubernetes.io/gid"
+
+	defaultGidMin = 2000
+	defaultGidMax = math.MaxInt32
+	// absoluteGidMin/Max are currently the same as the
+	// default values, but they play a different role and
+	// could take a different value. Only thing we need is:
+	// absGidMin <= defGidMin <= defGidMax <= absGidMax
+	absoluteGidMin = 2000
+	absoluteGidMax = math.MaxInt32
+)
+
+// Allocator allocates GIDs to PVs. It allocates from per-SC ranges and ensures
+// that no two PVs of the same SC get the same GID.
+type Allocator struct {
+	client       kubernetes.Interface
+	gidTable     map[string]*allocator.MinMaxAllocator
+	gidTableLock sync.Mutex
+}
+
+// New creates a new GID Allocator
+func New(client kubernetes.Interface) Allocator {
+	return Allocator{
+		client:   client,
+		gidTable: make(map[string]*allocator.MinMaxAllocator),
+	}
+}
+
+// AllocateNext allocates the next available GID for the given ProvisionOptions
+// (claim's options for a volume it wants) from the appropriate GID table.
+func (a *Allocator) AllocateNext(logger klog.Logger, options controller.ProvisionOptions) (int, error) {
+	class := util.GetPersistentVolumeClaimClass(options.PVC)
+	gidMin, gidMax, err := parseClassParameters(options.StorageClass.Parameters)
+	if err != nil {
+		return 0, err
+	}
+
+	gidTable, err := a.getGidTable(logger, class, gidMin, gidMax)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get gidTable: %v", err)
+	}
+
+	gid, _, err := gidTable.AllocateNext()
+	if err != nil {
+		return 0, fmt.Errorf("failed to reserve gid from table: %v", err)
+	}
+
+	return gid, nil
+}
+
+// Release releases the given volume's allocated GID from the appropriate GID
+// table.
+func (a *Allocator) Release(logger klog.Logger, volume *v1.PersistentVolume) error {
+	class, err := a.client.StorageV1().StorageClasses().Get(context.Background(), util.GetPersistentVolumeClass(volume), metav1.GetOptions{})
+	gidMin, gidMax, err := parseClassParameters(class.Parameters)
+	if err != nil {
+		return err
+	}
+
+	gid, exists, err := getGid(volume)
+	if err != nil {
+		logger.Error(err, "Failed to get gid from volume")
+	} else if exists {
+		gidTable, err := a.getGidTable(logger, class.Name, gidMin, gidMax)
+		if err != nil {
+			return fmt.Errorf("failed to get gidTable: %v", err)
+		}
+
+		err = gidTable.Release(gid)
+		if err != nil {
+			return fmt.Errorf("failed to release gid %v: %v", gid, err)
+		}
+	}
+
+	return nil
+}
+
+// Return the gid table for a storage class.
+//   - If this is the first time, fill it with all the gids
+//     used in PVs of this storage class by traversing the PVs.
+//   - Adapt the range of the table to the current range of the SC.
+func (a *Allocator) getGidTable(logger klog.Logger, className string, min int, max int) (*allocator.MinMaxAllocator, error) {
+	var err error
+	a.gidTableLock.Lock()
+	gidTable, ok := a.gidTable[className]
+	a.gidTableLock.Unlock()
+
+	if ok {
+		err = gidTable.SetRange(min, max)
+		if err != nil {
+			return nil, err
+		}
+
+		return gidTable, nil
+	}
+
+	// create a new table and fill it
+	newGidTable, err := allocator.NewMinMaxAllocator(0, absoluteGidMax)
+	if err != nil {
+		return nil, err
+	}
+
+	// collect gids with the full range
+	err = a.collectGids(logger, className, newGidTable)
+	if err != nil {
+		return nil, err
+	}
+
+	// and only reduce the range afterwards
+	err = newGidTable.SetRange(min, max)
+	if err != nil {
+		return nil, err
+	}
+
+	// if in the meantime a table appeared, use it
+
+	a.gidTableLock.Lock()
+	defer a.gidTableLock.Unlock()
+
+	gidTable, ok = a.gidTable[className]
+	if ok {
+		err = gidTable.SetRange(min, max)
+		if err != nil {
+			return nil, err
+		}
+
+		return gidTable, nil
+	}
+
+	a.gidTable[className] = newGidTable
+
+	return newGidTable, nil
+}
+
+// Traverse the PVs, fetching all the GIDs from those
+// in a given storage class, and mark them in the table.
+func (a *Allocator) collectGids(logger klog.Logger, className string, gidTable *allocator.MinMaxAllocator) error {
+	pvList, err := a.client.CoreV1().PersistentVolumes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		logger.Error(err, "Failed to get existing persistent volumes")
+		return err
+	}
+
+	for _, pv := range pvList.Items {
+		if util.GetPersistentVolumeClass(&pv) != className {
+			continue
+		}
+
+		pvName := pv.ObjectMeta.Name
+
+		gidStr, ok := pv.Annotations[VolumeGidAnnotationKey]
+
+		if !ok {
+			logger.Info("No gid found", "pv", pvName)
+			continue
+		}
+
+		gid, err := convertGid(gidStr)
+		if err != nil {
+			logger.Error(err, "Failed to convert gid", "pv", pvName)
+			continue
+		}
+
+		_, err = gidTable.Allocate(gid)
+		if err == allocator.ErrConflict {
+			logger.Info("gid was already allocated", "gid", gid, "pv", pvName)
+		} else if err != nil {
+			logger.Error(err, "Failed to store gid", "gid", gid, "pv", pvName)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func parseClassParameters(params map[string]string) (int, int, error) {
+	gidMin := defaultGidMin
+	gidMax := defaultGidMax
+
+	for k, v := range params {
+		switch strings.ToLower(k) {
+		case "gidmin":
+			parseGidMin, err := convertGid(v)
+			if err != nil {
+				return 0, 0, fmt.Errorf("invalid value %s for parameter %s: %v", v, k, err)
+			}
+			if parseGidMin < absoluteGidMin {
+				return 0, 0, fmt.Errorf("gidMin must be >= %v", absoluteGidMin)
+			}
+			if parseGidMin > absoluteGidMax {
+				return 0, 0, fmt.Errorf("gidMin must be <= %v", absoluteGidMax)
+			}
+			gidMin = parseGidMin
+		case "gidmax":
+			parseGidMax, err := convertGid(v)
+			if err != nil {
+				return 0, 0, fmt.Errorf("invalid value %s for parameter %s: %v", v, k, err)
+			}
+			if parseGidMax < absoluteGidMin {
+				return 0, 0, fmt.Errorf("gidMax must be >= %v", absoluteGidMin)
+			}
+			if parseGidMax > absoluteGidMax {
+				return 0, 0, fmt.Errorf("gidMax must be <= %v", absoluteGidMax)
+			}
+			gidMax = parseGidMax
+		}
+	}
+
+	if gidMin > gidMax {
+		return 0, 0, fmt.Errorf("gidMax %v is not >= gidMin %v", gidMax, gidMin)
+	}
+
+	return gidMin, gidMax, nil
+}
+
+func getGid(volume *v1.PersistentVolume) (int, bool, error) {
+	gidStr, ok := volume.Annotations[VolumeGidAnnotationKey]
+
+	if !ok {
+		return 0, false, nil
+	}
+
+	gid, err := convertGid(gidStr)
+
+	return gid, true, err
+}
+
+func convertGid(gidString string) (int, error) {
+	gid64, err := strconv.ParseInt(gidString, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse gid %v ", gidString)
+	}
+
+	if gid64 < 0 {
+		return 0, fmt.Errorf("negative GIDs are not allowed: %v", gidString)
+	}
+
+	// ParseInt returns a int64, but since we parsed only
+	// for 32 bit, we can cast to int without loss:
+	gid := int(gid64)
+	return gid, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
We would like to add functionality to a CSI driver to be able set stricter permissions on provisioned directories, and still have this be accessible to whatever pod uses this provisioned dir. To do this, we would like to be able to dynamically assign a random gid to a provisioned dir, and add this gid as a supplemental group to any pod using this volume. We need to set the `pv.beta.kubernetes.io/gid` annotation in the PV metadata:  https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#access-control, however this is not exposed in the CreateVolume response of CSI driver.

Therefore, we are requesting this feature of the external-provisioner that will parse `VolumeContext` for a gid key and apply this to the PV metadata if returned from CSI driver. 
notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Set PV gid metadata annotation in provision workflow if gid key is returned in volume context from CSI driver
```
