### PR TITLE
Disable VolumeAttributesClass Feature Gate If V1 API Not Present

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -207,6 +207,16 @@ func main() {
 		klog.Fatalf("Failed to create client: %v", err)
 	}
 
+	volumeAttributesClassV1Enabled, err := features.IsVolumeAttributesClassV1Enabled(clientset.Discovery())
+	if err == nil && !volumeAttributesClassV1Enabled {
+		if utilfeature.DefaultMutableFeatureGate.Enabled(features.VolumeAttributesClass) {
+			klog.InfoS("Disabling VolumeAttributesClass feature gate because the VolumeAttributesClass v1 API is not available")
+			if err := utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=false", features.VolumeAttributesClass)); err != nil {
+				klog.Fatalf("Failed to disable VolumeAttributesClass feature gate: %v", err)
+			}
+		}
+	}
+
 	// snapclientset.NewForConfig creates a new Clientset for  VolumesnapshotV1Client
 	snapClient, err := snapclientset.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This is to handle emulated versions for VAC. Changing the feature gate value in utilfeature.DefaultMutableFeatureGate will also impact utilfeature.DefaultFeatureGate. They both point to the same underlying feature gate object.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Tested end to end the following cases:

#### 1.33 with VAC **V1 API disabled**

KUBE_FEATURE_GATES="VolumeAttributesClass=**true**" kubetest --up 

```
I1010 21:38:51.324331       1 csi-provisioner.go:211] ======= volumeAttributesClassV1Enabled is false =======

I1010 21:39:51.792853       1 controller.go:617] ======= utilfeature.DefaultFeatureGate.Enabled value is false in prepareProvision =======
I1010 21:39:51.792866       1 controller.go:618] ======= utilfeature.DefaultMutableFeatureGate.Enabled value is false in prepareProvision =======

I1010 21:39:52.829865       1 controller.go:966] ======= utilfeature.DefaultFeatureGate.Enabled value is false in Provision =======
I1010 21:39:52.829947       1 controller.go:967] ======= utilfeature.DefaultMutableFeatureGate.Enabled value is false in Provision=======
```

kubetest --up

```
I1010 22:06:36.067088       1 csi-provisioner.go:211] ======= volumeAttributesClassV1Enabled is false =======

I1010 22:07:10.722910       1 controller.go:617] ======= utilfeature.DefaultFeatureGate.Enabled value is false in prepareProvision =======
I1010 22:07:10.722922       1 controller.go:618] ======= utilfeature.DefaultMutableFeatureGate.Enabled value is false in prepareProvision =======

I1010 22:07:11.782009       1 controller.go:966] ======= utilfeature.DefaultFeatureGate.Enabled value is false in Provision =======
I1010 22:07:11.782032       1 controller.go:967] ======= utilfeature.DefaultMutableFeatureGate.Enabled value is false in Provision=======
```

#### 1.34 with VAC **V1 API enabled** 

KUBE_FEATURE_GATES="VolumeAttributesClass=**false**" kubetest --up 

```
I1010 21:08:06.797616       1 csi-provisioner.go:211] ======= volumeAttributesClassV1Enabled is true =======

I1010 21:09:37.719031       1 controller.go:617] ======= utilfeature.DefaultFeatureGate.Enabled value is true in prepareProvision =======
I1010 21:09:37.719071       1 controller.go:618] ======= utilfeature.DefaultMutableFeatureGate.Enabled value is true in prepareProvision =======

I1010 21:09:38.663047       1 controller.go:966] ======= utilfeature.DefaultFeatureGate.Enabled value is true in Provision =======
I1010 21:09:38.663066       1 controller.go:967] ======= utilfeature.DefaultMutableFeatureGate.Enabled value is true in Provision=======
```

kubetest --up

```
I1010 22:32:38.224946       1 csi-provisioner.go:211] ======= volumeAttributesClassV1Enabled is true =======

I1010 22:33:19.761703       1 controller.go:617] ======= utilfeature.DefaultFeatureGate.Enabled value is true in prepareProvision =======
I1010 22:33:19.761713       1 controller.go:618] ======= utilfeature.DefaultMutableFeatureGate.Enabled value is true in prepareProvision =======

I1010 22:33:20.894447       1 controller.go:966] ======= utilfeature.DefaultFeatureGate.Enabled value is true in Provision =======
I1010 22:33:20.894516       1 controller.go:967] ======= utilfeature.DefaultMutableFeatureGate.Enabled value is true in Provision=======

```

**Does this PR introduce a user-facing change?**:

```release-note
Disable VolumeAttributesClass Feature Gate If V1 API Not Present
```
