### PR TITLE
CSI Release tools update 

### DIFF
--- a/release-tools/.github/workflows/codespell.yml
+++ b/release-tools/.github/workflows/codespell.yml
@@ -8,7 +8,7 @@ jobs:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true

--- a/release-tools/.github/workflows/trivy.yaml
+++ b/release-tools/.github/workflows/trivy.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get Go version
         id: go-version

--- a/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
+++ b/release-tools/KUBERNETES_CSI_OWNERS_ALIASES
@@ -19,7 +19,6 @@ aliases:
   kubernetes-csi-reviewers:
   - andyzhangx
   - carlory
-  - chrishenzie
   - ggriffiths
   - gnufied
   - humblec

--- a/release-tools/cloudbuild.yaml
+++ b/release-tools/cloudbuild.yaml
@@ -26,7 +26,7 @@ steps:
   # The image must contain bash and curl. Ideally it should also contain
   # the desired version of Go (currently defined in release-tools/prow.sh),
   # but that just speeds up the build and is not required.
-  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20240718-5ef92b5c36'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36'
     entrypoint: ./.cloudbuild.sh
     env:
     - GIT_TAG=${_GIT_TAG}

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -86,7 +86,7 @@ configvar CSI_PROW_BUILD_PLATFORMS "linux amd64 amd64; linux ppc64le ppc64le -pp
 # which is disabled with GOFLAGS=-mod=vendor).
 configvar GOFLAGS_VENDOR "$( [ -d vendor ] && echo '-mod=vendor' )" "Go flags for using the vendor directory"
 
-configvar CSI_PROW_GO_VERSION_BUILD "1.24.2" "Go version for building the component" # depends on component's source code
+configvar CSI_PROW_GO_VERSION_BUILD "1.24.6" "Go version for building the component" # depends on component's source code
 configvar CSI_PROW_GO_VERSION_E2E "" "override Go version for building the Kubernetes E2E test suite" # normally doesn't need to be set, see install_e2e
 configvar CSI_PROW_GO_VERSION_SANITY "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building the csi-sanity test suite" # depends on CSI_PROW_SANITY settings below
 configvar CSI_PROW_GO_VERSION_KIND "${CSI_PROW_GO_VERSION_BUILD}" "Go version for building 'kind'" # depends on CSI_PROW_KIND_VERSION below
@@ -199,7 +199,7 @@ kindest/node:v1.26.15@sha256:c79602a44b4056d7e48dc20f7504350f1e87530fe953428b792
 # If the deployment script is called with CSI_PROW_TEST_DRIVER=<file name> as
 # environment variable, then it must write a suitable test driver configuration
 # into that file in addition to installing the driver.
-configvar CSI_PROW_DRIVER_VERSION "v1.15.0" "CSI driver version"
+configvar CSI_PROW_DRIVER_VERSION "v1.17.0" "CSI driver version"
 configvar CSI_PROW_DRIVER_REPO https://github.com/kubernetes-csi/csi-driver-host-path "CSI driver repo"
 configvar CSI_PROW_DEPLOYMENT "" "deployment"
 configvar CSI_PROW_DEPLOYMENT_SUFFIX "" "additional suffix in kubernetes-x.yy[suffix].yaml files"


### PR DESCRIPTION
/kind cleanup

Squashed 'release-tools/' changes from 0a435bf98..74502e544
74502e544 Merge pull request https://github.com/kubernetes-csi/external-provisioner/issues/278 from liangyuanpeng/migrate_k8s_testimages
533443055 Merge pull request https://github.com/kubernetes-csi/external-provisioner/pull/281 from kubernetes-csi/dependabot/github_actions/actions/checkout-5
458ce146f Bump actions/checkout from 4 to 5
5f38a9075 Merge pull request https://github.com/kubernetes-csi/external-provisioner/pull/282 from rhrmo/update-go-1.24.6
579f62421 Update go to 1.24.6
5ec1a52b8 use gcr.io/k8s-staging-test-infra instead of gcr.io/k8s-testimages
74e066a82 Merge pull request https://github.com/kubernetes-csi/external-provisioner/pull/279 from Aishwarya-Hebbar/update-csi-prow-version
6f236be7d Update CSI prow driver version to v1.17.0
0ee55894b Merge pull request https://github.com/kubernetes-csi/external-provisioner/issues/280 from xing-yang/update_go_1.24.4
9af101534 update to go 1.24.4
f5fec3e36 Merge pull request https://github.com/kubernetes-csi/external-provisioner/pull/275 from chrishenzie/emeritus
c5d285db8 Remove chrishenzie from kubernetes-csi-reviewers

git-subtree-dir: release-tools
git-subtree-split: 74502e544bc6a17820892c0d490e8f0b59462998