### PR TITLE
Add secret reference in PV annotations for ControllerModifyVolume

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -237,6 +237,8 @@ func TestStripPrefixedCSIParams(t *testing.T) {
 				prefixedDefaultSecretNamespaceKey:           "csiBar",
 				prefixedNodeExpandSecretNameKey:             "csiBar",
 				prefixedNodeExpandSecretNamespaceKey:        "csiBar",
+				prefixedControllerModifySecretNameKey:       "csiBar",
+				prefixedControllerModifySecretNamespaceKey:  "csiBar",
 			},
 			expectedParams: map[string]string{},
 		},
@@ -926,6 +928,8 @@ func getDefaultStorageClassSecretParameters() map[string]string {
 		prefixedProvisionerSecretNamespaceKey:      defaultSecretNsName,
 		prefixedNodeExpandSecretNameKey:            "nodeexpandsecret",
 		prefixedNodeExpandSecretNamespaceKey:       defaultSecretNsName,
+		prefixedControllerModifySecretNameKey:      "ctrlmodifysecret",
+		prefixedControllerModifySecretNamespaceKey: defaultSecretNsName,
 	}
 }
 
@@ -1623,6 +1627,8 @@ func provisionTestcases() (int64, map[string]provisioningTestcase) {
 			expectedPVSpec: &pvSpec{
 				Name: "test-testi",
 				Annotations: map[string]string{
+					annModifyControllerSecretRefName:         "ctrlmodifysecret",
+					annModifyControllerSecretRefNamespace:    defaultSecretNsName,
 					annDeletionProvisionerSecretRefName:      "provisionersecret",
 					annDeletionProvisionerSecretRefNamespace: defaultSecretNsName,
 				},
@@ -1682,6 +1688,8 @@ func provisionTestcases() (int64, map[string]provisioningTestcase) {
 			expectedPVSpec: &pvSpec{
 				Name: "test-testi",
 				Annotations: map[string]string{
+					annModifyControllerSecretRefName:         "default-secret",
+					annModifyControllerSecretRefNamespace:    "default-ns",
 					annDeletionProvisionerSecretRefName:      "default-secret",
 					annDeletionProvisionerSecretRefNamespace: "default-ns",
 				},
@@ -1741,6 +1749,8 @@ func provisionTestcases() (int64, map[string]provisioningTestcase) {
 			expectedPVSpec: &pvSpec{
 				Name: "test-testi",
 				Annotations: map[string]string{
+					annModifyControllerSecretRefName:         "my-pvc",
+					annModifyControllerSecretRefNamespace:    "default-ns",
 					annDeletionProvisionerSecretRefName:      "my-pvc",
 					annDeletionProvisionerSecretRefNamespace: "default-ns",
 				},


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

The ControllerModifyVolume CSI procedure should be able to receive credentials if the storage provider requires them.

The values of the following keys in the StorageClass are copied into annotations of the PersistentVolume:
 - csi.storage.k8s.io/controller-modify-secret-name
   > volume.kubernetes.io/controller-modify-secret-name
 - csi.storage.k8s.io/controller-modify-secret-namespace
   > volume.kubernetes.io/controller-modify-secret-namespace

The external-resizer can use these annotations to resolve the secret that needs to be passed in ControllerModifyVolume.

**Which issue(s) this PR fixes**:

Related to kubernetes-csi/external-resizer#544

**Special notes for your reviewer**:

Approach has been discussed in [a thread at #csi](https://kubernetes.slack.com/archives/C8EJ01Z46/p1762534822913969).

**Does this PR introduce a user-facing change?**:

```release-note
A StorageClass can use `csi.storage.k8s.io/controller-modify-secret-name` and `csi.storage.k8s.io/controller-modify-secret-namespace` to reference the credentials that should be used to modify a volume according to the parameters of a VolumeAttributeClass.
```
