### PR TITLE
capacity: fix duplicate topology (attempt #2)

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -449,6 +449,7 @@ func main() {
 	)
 
 	var capacityController *capacity.Controller
+	var topologyInformer topology.Informer
 	if *enableCapacity {
 		// Publishing storage capacity information uses its own client
 		// with separate rate limiting.
@@ -483,7 +484,6 @@ func main() {
 			klog.Infof("using %s/%s %s as owner of CSIStorageCapacity objects", controller.APIVersion, controller.Kind, controller.Name)
 		}
 
-		var topologyInformer topology.Informer
 		if nodeDeployment == nil {
 			topologyRateLimiter := workqueue.NewTypedItemExponentialFailureRateLimiter[string](*retryIntervalStart, *retryIntervalMax)
 			topologyInformer = topology.NewNodeTopology(
@@ -503,7 +503,6 @@ func main() {
 			klog.Infof("producing CSIStorageCapacity objects with fixed topology segment %s", segment)
 			topologyInformer = topology.NewFixedNodeTopology(&segment)
 		}
-		go topologyInformer.RunWorker(ctx)
 
 		managedByID := "external-provisioner"
 		if *enableNodeDeployment {
@@ -662,9 +661,12 @@ func main() {
 
 		factory.Start(ctx.Done())
 		if factoryForNamespace != nil {
-			// Starting is enough, the capacity controller will
+			// Starting is enough, the capacityController and topologyInformer will
 			// wait for sync.
 			factoryForNamespace.Start(ctx.Done())
+		}
+		if topologyInformer != nil {
+			go topologyInformer.RunWorker(ctx)
 		}
 		cacheSyncResult := factory.WaitForCacheSync(ctx.Done())
 		for _, v := range cacheSyncResult {

--- a/pkg/capacity/topology/nodes.go
+++ b/pkg/capacity/topology/nodes.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"sort"
 	"sync"
+	"sync/atomic"
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -159,6 +160,7 @@ type nodeTopology struct {
 	nodeInformer    coreinformersv1.NodeInformer
 	csiNodeInformer storageinformersv1.CSINodeInformer
 	queue           workqueue.TypedRateLimitingInterface[string]
+	hasSynced       atomic.Bool
 
 	mutex sync.Mutex
 	// segments hold a list of all currently known topology segments.
@@ -201,23 +203,32 @@ func (nt *nodeTopology) List() []*Segment {
 	return segments
 }
 
+// RunWorker starts a worker that processes topology updates from the queue.
+//
+// It must only be called once per instance. Calling it more than once would
+// result in simultaneous sync() calls that produce duplicate topology segments
+// and pass them to callbacks. Consumers depend on the address of
+// the same topology segment to be consistent for efficient hashing.
 func (nt *nodeTopology) RunWorker(ctx context.Context) {
 	klog.Info("Started node topology worker")
 	defer klog.Info("Shutting node topology worker")
 
+	if !cache.WaitForCacheSync(ctx.Done(),
+		nt.nodeInformer.Informer().HasSynced, nt.csiNodeInformer.Informer().HasSynced) {
+		return
+	}
+
+	go func() {
+		<-ctx.Done()
+		nt.queue.ShutDown()
+	}()
+	nt.queue.Add("") // Initial sync to ensure HasSynced() will become true.
 	for nt.processNextWorkItem(ctx) {
 	}
 }
 
 func (nt *nodeTopology) HasSynced() bool {
-	if nt.nodeInformer.Informer().HasSynced() &&
-		nt.csiNodeInformer.Informer().HasSynced() {
-		// Now that both informers are up-to-date, use that
-		// information to update our own view of the world.
-		nt.sync(context.Background())
-		return true
-	}
-	return false
+	return nt.hasSynced.Load()
 }
 
 func (nt *nodeTopology) processNextWorkItem(ctx context.Context) bool {
@@ -227,6 +238,7 @@ func (nt *nodeTopology) processNextWorkItem(ctx context.Context) bool {
 	}
 	defer nt.queue.Done(obj)
 	nt.sync(ctx)
+	nt.hasSynced.Store(true)
 	return true
 }
 

--- a/pkg/capacity/topology/nodes_test.go
+++ b/pkg/capacity/topology/nodes_test.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 	"sort"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -557,6 +558,39 @@ func TestNodeTopology(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHasSynced(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		client := fakeclientset.NewSimpleClientset()
+		informerFactory := informers.NewSharedInformerFactory(client, 0)
+		nodeInformer := informerFactory.Core().V1().Nodes()
+		csiNodeInformer := informerFactory.Storage().V1().CSINodes()
+		rateLimiter := workqueue.NewTypedItemExponentialFailureRateLimiter[string](time.Second, 2*time.Second)
+		queue := workqueue.NewTypedRateLimitingQueueWithConfig(rateLimiter, workqueue.TypedRateLimitingQueueConfig[string]{Name: "items"})
+
+		nt := NewNodeTopology(
+			driverName,
+			client,
+			nodeInformer,
+			csiNodeInformer,
+			queue,
+		).(*nodeTopology)
+
+		ctx := t.Context()
+		go nt.RunWorker(ctx)
+		time.Sleep(10 * time.Second)
+		if nt.HasSynced() {
+			t.Fatalf("upstream informer not started yet, expected HasSynced to return false")
+		}
+
+		informerFactory.Start(ctx.Done())
+		informerFactory.WaitForCacheSync(ctx.Done())
+		synctest.Wait()
+		if !nt.HasSynced() {
+			t.Fatalf("nt should be synced now")
+		}
+	})
 }
 
 type segmentsFound map[*Segment]bool


### PR DESCRIPTION
When the controller starts, 2 sync() call will run simultaneously, one from HasSynced(), another from processNextWorkItem(). Each will produce an instance for the same topology segment, and pass it to callbacks.

This will result in duplicated entries in capacities map, resulting in: either
- Two CSIStorageCapacity object get created for the same topology, or
- The same CSIStorageCapacity object get assigned to two keys in capacities map. When one of them is updated, the other one will hold an outdated object and all subsequent update will fail with conflict.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Please see also #1435

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed possible duplicated CSIStorageCapacity and constantly failing update request.
```

/cc @pohly 