### PR TITLE
[Cherry-pick] Allow provisioning to proceed when snapshot is being deleted to prevent leaking volumes and snapshots.

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -150,7 +150,8 @@ const (
 
 	snapshotNotBound = "snapshot %s not bound"
 
-	pvcCloneFinalizer = "provisioner.storage.kubernetes.io/cloning-protection"
+	pvcCloneFinalizer                 = "provisioner.storage.kubernetes.io/cloning-protection"
+	snapshotSourceProtectionFinalizer = "snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection"
 
 	annAllowVolumeModeChange = "snapshot.storage.kubernetes.io/allow-volume-mode-change"
 )
@@ -1161,15 +1162,15 @@ func (p *csiProvisioner) getSnapshotSource(ctx context.Context, claim *v1.Persis
 	}
 
 	if snapshotObj.ObjectMeta.DeletionTimestamp != nil {
-		// VolumeSnapshot is being deleted. Check if provisioning already started by looking for finalizers.
-		// If the snapshot has finalizers, it means provisioning was started before deletion began,
-		// so we should continue to prevent resource leaks. The external-snapshotter adds finalizers
-		// when a snapshot is used as a data source.
-		// If there are no finalizers, this is a new provisioning attempt and should be rejected.
-		if len(snapshotObj.ObjectMeta.Finalizers) == 0 {
+		// VolumeSnapshot is being deleted. Check if provisioning already started by looking for
+		// the specific finalizer added by external-snapshotter when a snapshot is used as a data source.
+		// If the finalizer exists, it means provisioning was started before deletion began,
+		// so we should continue to prevent resource leaks.
+		// If the finalizer doesn't exist, this is a new provisioning attempt and should be rejected.
+		if !checkFinalizer(snapshotObj, snapshotSourceProtectionFinalizer) {
 			return nil, fmt.Errorf("snapshot %s is being deleted", dataSource.Name)
 		}
-		klog.V(3).Infof("Snapshot %s/%s is being deleted but has finalizers, allowing provisioning to continue", dataSource.Namespace, dataSource.Name)
+		klog.V(3).Infof("Snapshot %s/%s is being deleted but has volumesnapshot-as-source-protection finalizer, allowing provisioning to continue", dataSource.Namespace, dataSource.Name)
 	}
 	klog.V(5).Infof("VolumeSnapshot %+v", snapshotObj)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cherry-pick https://github.com/kubernetes-csi/external-provisioner/pull/1448

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow provisioning to proceed when snapshot is being deleted to prevent leaking volumes and snapshots.
```
