### PR TITLE
Add a finalizer on VolumeSnapshot as Source

### DIFF
--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -38,6 +38,11 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  # The "watch" and "update" verbs for volumesnapshots are optional but recommended.
+  # They enable finalizer-based protection to prevent snapshots from being deleted
+  # during provisioning. Without these permissions, the provisioner will still function
+  # but snapshot protection will be unavailable. This makes the provisioner backwards
+  # compatible with older RBAC configurations.
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
     verbs: ["get", "list", "watch", "update"]

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -4652,12 +4652,27 @@ func TestProvisionFromSnapshot(t *testing.T) {
 				// Set up finalizers based on what the test is checking:
 				// - snapshotWithDifferentFinalizer: add a different finalizer to verify we check for the specific source-protection one
 				// - snapshotWithoutSourceProtectionFinalizer: don't add any finalizers (simulates new provisioning attempt)
-				// - default: add the volumesnapshot-as-source-protection finalizer (simulates in-flight provisioning)
+				// - default: add the provisioner.storage.kubernetes.io/volumesnapshot-as-source-protection finalizer (simulates in-flight provisioning)
 				if tc.snapshotWithDifferentFinalizer {
 					snap.ObjectMeta.Finalizers = []string{"some-other-finalizer"}
 				} else if !tc.snapshotWithoutSourceProtectionFinalizer {
-					snap.ObjectMeta.Finalizers = []string{"snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection"}
+					snap.ObjectMeta.Finalizers = []string{"provisioner.storage.kubernetes.io/volumesnapshot-as-source-protection"}
 				}
+			}
+			return true, snap, nil
+		})
+
+		// Mock the update operation for volumesnapshots to handle finalizer additions/removals.
+		// The provisioner adds/removes the provisioner.storage.kubernetes.io/volumesnapshot-as-source-protection
+		// finalizer to protect snapshots during provisioning operations.
+		client.AddReactor("update", "volumesnapshots", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			updateAction, ok := action.(k8stesting.UpdateAction)
+			if !ok {
+				return false, nil, fmt.Errorf("expected UpdateAction, got %T", action)
+			}
+			snap, ok := updateAction.GetObject().(*crdv1.VolumeSnapshot)
+			if !ok {
+				return false, nil, fmt.Errorf("expected VolumeSnapshot, got %T", updateAction.GetObject())
 			}
 			return true, snap, nil
 		})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In this PR https://github.com/kubernetes-csi/external-provisioner/pull/1448, we added a check for this finalizer "snapshot.storage.kubernetes.io/volumesnapshot-as-source-protection" which is added and removed by external-snapshotter to prevent a VolumeSnapshot from being deleted while it is being used as a source to create PVC. However, there is a race condition. When a user deletes a pending PVC, the PVC is removed from the informer cache by [the external-snapshotter logic](https://github.com/kubernetes-csi/external-snapshotter/blob/7dd22e0a905756e095d2989591d40cc2f44a9e1d/pkg/common-controller/snapshot_controller.go#L951), even though the volume is still being created from snapshot in the backend and the external-provsioner is still processing it. The external-snapshotter has no knowledge of whether the provisioner is still processing the volume. So it is not in the best position to handle the life cycle of this kind of finalizer.

In this PR, we add a new finalizer "provisioner.storage.kubernetes.io/volumesnapshot-as-source-protection". It is added and removed by external-provisioner.
* When Added: The provisioner.storage.kubernetes.io/volumesnapshot-as-source-protection finalizer is added to the VolumeSnapshot when the provisioner starts provisioning a PVC from that snapshot (before calling the CSI driver's CreateVolume).
* When Removed: The finalizer is removed when the provisioner completes provisioning (either successfully creating the PV or encountering a final error), as indicated by returning ProvisioningFinished state from the Provision method.

The original finalizer managed by external-snapshotter is deprecated and will be removed in a future release. When removing the old finalizer, we should add logic in external-snapshotter to always remove it. This way user won't get stuck with a finalizer not being removed by any component.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add provisioner.storage.kubernetes.io/volumesnapshot-as-source-protection finalizer on VolumeSnapshot as Source. Add rbac rules to watch/update volumesnapshots.
```
