### PR TITLE
fix: upgrade Go to 1.25.5 to address CVE-2025-61729

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-csi/external-provisioner/v5
 
-go 1.24.2
+go 1.25.5
 
 require (
 	github.com/container-storage-interface/spec v1.12.0


### PR DESCRIPTION
**What type of PR is this?**

kind bug

**What this PR does / why we need it**:

This PR upgrades the Go version from 1.24.2 to 1.25.5 to address CVE-2025-61729, a high-severity security vulnerability in the `crypto/x509` package.

The vulnerability (CVSS Score: 7.5) causes excessive resource consumption through quadratic runtime in `HostnameError.Error()` when constructing error strings. A malicious actor could provide a certificate that results in unlimited host printing, leading to denial of service through resource exhaustion.

**Which issue(s) this PR fixes**:

Fixes CVE-2025-61729

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Upgraded Go to version 1.25.5 to fix CVE-2025-61729, a high-severity security vulnerability in crypto/x509 that could lead to excessive resource consumption.
```