### PR TITLE
[Cherry-pick 6.1] Allow provisioning to proceed when snapshot is being deleted and add a finalizer on VolumeSnapshot as Source

### DIFF
--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -38,6 +38,11 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  # The "watch" and "update" verbs for volumesnapshots are optional but recommended.
+  # They enable finalizer-based protection to prevent snapshots from being deleted
+  # during provisioning. Without these permissions, the provisioner will still function
+  # but snapshot protection will be unavailable. This makes the provisioner backwards
+  # compatible with older RBAC configurations.
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
     verbs: ["get", "list", "watch", "update"]

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1035,14 +1035,22 @@ func (p *csiProvisioner) setSnapshotFinalizer(ctx context.Context, dataSource *v
 	}
 
 	snapshotClone := snapshot.DeepCopy()
-	if !checkFinalizer(snapshotClone, snapshotSourceProtectionFinalizer) {
-		snapshotClone.Finalizers = append(snapshotClone.Finalizers, snapshotSourceProtectionFinalizer)
-		_, err := p.snapshotClient.SnapshotV1().VolumeSnapshots(snapshotClone.Namespace).Update(ctx, snapshotClone, metav1.UpdateOptions{})
-		if err != nil {
-			return err
-		}
-		klog.V(3).Infof("Added finalizer %s to snapshot %s/%s", snapshotSourceProtectionFinalizer, snapshotClone.Namespace, snapshotClone.Name)
+	if checkFinalizer(snapshotClone, snapshotSourceProtectionFinalizer) {
+		return nil
 	}
+
+	snapshotClone.Finalizers = append(snapshotClone.Finalizers, snapshotSourceProtectionFinalizer)
+	_, err = p.snapshotClient.SnapshotV1().VolumeSnapshots(snapshotClone.Namespace).Update(ctx, snapshotClone, metav1.UpdateOptions{})
+	if err != nil {
+		// If we don't have permission to update VolumeSnapshots, log at info level and continue.
+		// This allows the provisioner to work without the new RBAC permissions for backwards compatibility.
+		if apierrors.IsForbidden(err) {
+			klog.V(3).Infof("Unable to add finalizer to snapshot %s/%s due to missing RBAC permissions (needs 'update' on volumesnapshots): %v. Provisioning will continue without snapshot protection. Please update RBAC to include 'update' verb for volumesnapshots.", snapshotClone.Namespace, snapshotClone.Name, err)
+			return nil
+		}
+		return err
+	}
+	klog.V(3).Infof("Added finalizer %s to snapshot %s/%s", snapshotSourceProtectionFinalizer, snapshotClone.Namespace, snapshotClone.Name)
 
 	return nil
 }
@@ -1076,6 +1084,12 @@ func (p *csiProvisioner) removeSnapshotFinalizer(ctx context.Context, namespace,
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Snapshot was deleted while we were trying to update it, that's fine
+			return nil
+		}
+		// If we don't have permission to update VolumeSnapshots, log at info level and continue.
+		// This allows the provisioner to work without the new RBAC permissions for backwards compatibility.
+		if apierrors.IsForbidden(err) {
+			klog.V(3).Infof("Unable to remove finalizer from snapshot %s/%s due to missing RBAC permissions (needs 'update' on volumesnapshots): %v. The finalizer will remain on the snapshot. Please update RBAC to include 'update' verb for volumesnapshots.", namespace, name, err)
 			return nil
 		}
 		return err


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cherry-pick https://github.com/kubernetes-csi/external-provisioner/pull/1448 and https://github.com/kubernetes-csi/external-provisioner/pull/1458

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Cherry-pick #1448: Allow provisioning to proceed when snapshot is being deleted to prevent leaking volumes and snapshots.
Cherry-pick #1458: Add a finalizer on VolumeSnapshot as Source.
```
