### PR TITLE
fix: fallback to API server on missing Node topology key

### DIFF
--- a/pkg/controller/topology.go
+++ b/pkg/controller/topology.go
@@ -550,7 +550,7 @@ func extractTopologyTerm(labels map[string]string, topologyKeys []string) (topol
 	for _, key := range topologyKeys {
 		v, ok := labels[key]
 		if !ok {
-			return nil, nil, true // isMissingKey = true
+			return nil, labels, true // isMissingKey = true
 		}
 		term = append(term, topologySegment{key, v})
 	}
@@ -562,7 +562,12 @@ func getTopologyFromNodeName(nodeName string, topologyKeys []string, nodeLister 
 	// Read from the cache first.
 	nodeLabels, err := getNodeLabelsFromCache(pvcNodeStore, pvcKeyForStore)
 	if err == nil && len(nodeLabels) > 0 {
-		return extractTopologyTerm(nodeLabels, topologyKeys)
+		selectedTopology, selectedNodeLabels, isMissingKey := extractTopologyTerm(nodeLabels, topologyKeys)
+		if !isMissingKey {
+			return selectedTopology, selectedNodeLabels, isMissingKey
+		}
+		// If there are missing keys, we fallback to getting the Node from API server.
+		// This is to account for eventual consistency delays where some topology labels are on the CSINode but not the Node.
 	}
 
 	// Get Node from API server.

--- a/pkg/controller/topology.go
+++ b/pkg/controller/topology.go
@@ -566,17 +566,17 @@ func getTopologyFromNodeName(nodeName string, topologyKeys []string, nodeLister 
 		if !isMissingKey {
 			return selectedTopology, selectedNodeLabels, isMissingKey
 		}
-		// If there are missing keys, we fallback to getting the Node from API server.
-		// This is to account for eventual consistency delays where some topology labels are on the CSINode but not the Node.
+		// If required topology keys are missing, refresh node labels from nodeLister
+		// to avoid using stale or incomplete entries from pvcNodeStore.
 	}
 
-	// Get Node from API server.
+	// Get Node from informer cache.
 	if nodeLister != nil {
 		node, err := nodeLister.Get(nodeName)
 		if err != nil {
 			// Any error, including NotFound, results in us not being
 			// able to determine topology. The cache was already checked.
-			return nil, nil, true
+			return nil, nodeLabels, true
 		}
 
 		// Add or update cache for the node.

--- a/pkg/controller/topology_test.go
+++ b/pkg/controller/topology_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -1792,6 +1793,136 @@ func TestProvisionWithDeletedNodeFromCache(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNodeTopologyLabelFallback(t *testing.T) {
+	// When the Node initially has incomplete topology labels, provisioning is expected to fail.
+	// Once those labels are added, provisioning should succeed.
+	topologyKeys := []string{
+		"com.example.csi/zone",
+		"com.example.csi/rack",
+		"com.example.csi/region",
+		"com.example.csi/compute-type",
+	}
+	incompleteNodeLabels := map[string]string{
+		"com.example.csi/zone":   "zone1",
+		"com.example.csi/rack":   "rackA",
+		"com.example.csi/region": "us-west",
+	}
+	completeNodeLabels := map[string]string{
+		"com.example.csi/zone":         "zone1",
+		"com.example.csi/rack":         "rackA",
+		"com.example.csi/region":       "us-west",
+		"com.example.csi/compute-type": "standard",
+	}
+
+	// originally the node has incomplete topology labels
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-node",
+			Labels: incompleteNodeLabels,
+		},
+	}
+	csiNode := &storagev1.CSINode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+		},
+		Spec: storagev1.CSINodeSpec{
+			Drivers: []storagev1.CSINodeDriver{
+				{
+					Name:         testDriverName,
+					NodeID:       "test-node",
+					TopologyKeys: topologyKeys,
+				},
+			},
+		},
+	}
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+			UID:       "test-pvc-uid",
+		},
+	}
+	kubeClient := fakeclientset.NewSimpleClientset(node, csiNode, pvc)
+	_, csiNodeLister, nodeLister, _, _, stopChan := listers(kubeClient)
+	defer close(stopChan)
+	pvcNodeStore := NewInMemoryStore()
+
+	t.Run("first provisioning attempt should fail because incomplete node labels", func(t *testing.T) {
+		_, err := GenerateAccessibilityRequirements(
+			kubeClient,
+			testDriverName,
+			pvc.UID,
+			pvc.Name,
+			nil,
+			"test-node",
+			false,
+			false,
+			csiNodeLister,
+			nodeLister,
+			pvcNodeStore,
+		)
+		if err == nil {
+			t.Fatal("expected error due to missing topology label, got nil")
+		}
+		expectedError := "topology labels from selected node"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Errorf("expected error containing %q, got: %v", expectedError, err)
+		}
+	})
+
+	// update the Node with the missing label
+	node.Labels = completeNodeLabels
+	_, err := kubeClient.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("failed to update node: %v", err)
+	}
+	_, csiNodeLister2, nodeLister2, _, _, stopChan2 := listers(kubeClient)
+	defer close(stopChan2)
+
+	t.Run("second provisioning attempt should succeed after labels added", func(t *testing.T) {
+		requirements, err := GenerateAccessibilityRequirements(
+			kubeClient,
+			testDriverName,
+			pvc.UID,
+			pvc.Name,
+			nil,
+			"test-node",
+			false,
+			false,
+			csiNodeLister2,
+			nodeLister2,
+			pvcNodeStore,
+		)
+		if err != nil {
+			t.Fatalf("expected success after fallback, got error: %v", err)
+		}
+		if requirements == nil {
+			t.Fatal("expected requirements to be generated, got nil")
+		}
+
+		expectedTopology := &csi.Topology{
+			Segments: map[string]string{
+				"com.example.csi/zone":         "zone1",
+				"com.example.csi/rack":         "rackA",
+				"com.example.csi/region":       "us-west",
+				"com.example.csi/compute-type": "standard",
+			},
+		}
+		if len(requirements.Requisite) != 1 {
+			t.Errorf("expected 1 requisite topology, got %d", len(requirements.Requisite))
+		} else if !cmp.Equal(requirements.Requisite[0], expectedTopology, protocmp.Transform()) {
+			t.Errorf("requisite topology mismatch.\nExpected: %v\nGot: %v",
+				expectedTopology, requirements.Requisite[0])
+		}
+		if len(requirements.Preferred) != 1 {
+			t.Errorf("expected 1 preferred topology, got %d", len(requirements.Preferred))
+		} else if !cmp.Equal(requirements.Preferred[0], expectedTopology, protocmp.Transform()) {
+			t.Errorf("preferred topology mismatch.\nExpected: %v\nGot: %v",
+				expectedTopology, requirements.Preferred[0])
+		}
+	})
 }
 
 func BenchmarkDedupAndSortZone(b *testing.B) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:e
This PR adds a fallback to the API server in Node Topology if the topology labels on the Node do not match the labels on the CSINode. 

This fixes a bug where during provisioning, if the Node does not yet have all topology labels then provisioning continually fails. Even when the Node eventually does have all the labels.

**Testing After Fix**
1. Launch Node
In this case, I use EKS Auto to launch the Node. There are 4 required topology labels are:
```
eks.amazonaws.com/compute-type
kubernetes.io/os
topology.ebs.csi.eks.amazonaws.com/zone
topology.kubernetes.io/zone
```
2. Remove A Required Topology Label From The Node
```
k label node {NODE_LABEL} eks.amazonaws.com/compute-type-
```
3. Create Stateful Set with volumeClaimTemplate so PVC created and volume provisioned
Looking at the PVC events
```
Warning  ProvisioningFailed    40s (x7 over 103s)     ebs.csi.eks.amazonaws.com_ebscsicontroller-7b864487cb-dgx8v_07b290e6-86d7-4bb5-a604-410cd0ef97ba  error generating accessibility requirements: topology labels from selected node map[] does not match topology keys from CSINode [eks.amazonaws.com/compute-type kubernetes.io/os topology.ebs.csi.eks.amazonaws.com/zone topology.kubernetes.io/zone]
```
4. Add Label Back Onto The Node
```
k label node i-096987243751a321d eks.amazonaws.com/compute-type=auto
```
5. PVC Should Be Bound Soon After
```
NAME                     STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
data-my-stateful-app-0   Bound    pvc-a733f911-6d1a-4e30-9c8d-8f249b465ea5   8Gi        RWO            auto-ebs-sc    <unset>                 4m37s
data-my-stateful-app-1   Bound    pvc-6b8dac92-770e-4ba6-ae0c-c2f57dbd833e   8Gi        RWO            auto-ebs-sc    <unset>                 7s
```

Before this new version of external provisioner, PVCs would remain unbound with provisioning failures of:
```
error generating accessibility requirements: topology labels from selected node map[] does not match topology keys from CSINode
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-csi/external-provisioner/issues/1478

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
