### PR TITLE
fix: pin GitHub Actions to full-length commit SHA on release-6.2

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -8,8 +8,8 @@ jobs:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: codespell-project/actions-codespell@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
         with:
           check_filenames: true
           skip: ./.git,./.github/workflows/codespell.yml,.git,*.png,*.jpg,*.svg,*.sum,./vendor,go.sum,./release-tools/prow.sh


### PR DESCRIPTION
## What this PR does:
Pin `actions/checkout` and `codespell-project/actions-codespell` to full-length commit SHAs in `.github/workflows/codespell.yml` on the `release-6.2` branch.

This is required by the kubernetes-csi org policy that all GitHub Actions must be pinned to a full-length commit SHA.

### Changes:
- `actions/checkout@v6.0.2` → `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
- `codespell-project/actions-codespell@master` → `codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2`

> Note: The `master` branch already has these pins.

```release-note
none
```