### PR TITLE
Remove finalizer from volume snapshot in error cases during volume provision workflow

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -867,6 +867,13 @@ func (p *csiProvisioner) Provision(ctx context.Context, options controller.Provi
 
 	result, state, err := p.prepareProvision(ctx, claim, options.StorageClass, options.SelectedNodeName)
 	if result == nil {
+		// prepareProvision may have added the snapshot finalizer before
+		// hitting a subsequent error. Clean it up when provisioning
+		// will not be retried (ProvisioningFinished / ProvisioningReschedule).
+		if state != controller.ProvisioningNoChange &&
+			state != controller.ProvisioningInBackground {
+			p.cleanupSnapshotFinalizer(ctx, claim)
+		}
 		return nil, state, err
 	}
 	req := result.req
@@ -905,6 +912,13 @@ func (p *csiProvisioner) Provision(ctx context.Context, options controller.Provi
 		// Delete the entry in in memory cache if the error is final
 		if p.supportsTopology() && (state == controller.ProvisioningFinished || state == controller.ProvisioningReschedule) {
 			p.pvcNodeStore.Delete(claim.UID)
+		}
+		// Remove snapshot finalizer when CreateVolume definitively failed.
+		// Keep the finalizer for ProvisioningInBackground since
+		// CreateVolume may still be running and the snapshot needs
+		// protection.
+		if state != controller.ProvisioningInBackground {
+			p.cleanupSnapshotFinalizer(ctx, claim)
 		}
 		return nil, state, err
 	}
@@ -1041,12 +1055,7 @@ func (p *csiProvisioner) Provision(ctx context.Context, options controller.Provi
 	}
 
 	// Remove snapshot finalizer if this PVC was provisioned from a snapshot
-	if claim.Spec.DataSource != nil && claim.Spec.DataSource.Kind == snapshotKind {
-		if err := p.removeSnapshotFinalizer(ctx, claim.Namespace, claim.Spec.DataSource.Name); err != nil {
-			klog.Warningf("Failed to remove snapshot finalizer from %s/%s: %v", claim.Namespace, claim.Spec.DataSource.Name, err)
-			// Don't fail provisioning if we can't remove the finalizer - it will be cleaned up later
-		}
-	}
+	p.cleanupSnapshotFinalizer(ctx, claim)
 
 	return pv, controller.ProvisioningFinished, nil
 }
@@ -1136,6 +1145,27 @@ func (p *csiProvisioner) removeSnapshotFinalizer(ctx context.Context, namespace,
 
 	klog.V(3).Infof("Removed finalizer %s from snapshot %s/%s", snapshotSourceProtectionFinalizer, namespace, name)
 	return nil
+}
+
+// cleanupSnapshotFinalizer removes the snapshot source-protection finalizer
+// if the PVC's data source is a VolumeSnapshot. Called on error paths where
+// provisioning will not be retried so the snapshot is not left with a
+// dangling finalizer that blocks deletion.
+func (p *csiProvisioner) cleanupSnapshotFinalizer(
+	ctx context.Context, claim *v1.PersistentVolumeClaim,
+) {
+	if claim.Spec.DataSource != nil &&
+		claim.Spec.DataSource.Kind == snapshotKind {
+		if err := p.removeSnapshotFinalizer(
+			ctx, claim.Namespace, claim.Spec.DataSource.Name,
+		); err != nil {
+			klog.Warningf(
+				"Failed to remove snapshot finalizer from %s/%s: %v",
+				claim.Namespace, claim.Spec.DataSource.Name, err,
+			)
+			// Don't fail provisioning if we can't remove the finalizer - it will be cleaned up later
+		}
+	}
 }
 
 func (p *csiProvisioner) supportsTopology() bool {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -2982,6 +2982,7 @@ func TestProvisionFromSnapshot(t *testing.T) {
 		refGrantsrcNamespace                     string
 		referenceGrantFrom                       []gatewayv1beta1.ReferenceGrantFrom
 		referenceGrantTo                         []gatewayv1beta1.ReferenceGrantTo
+		expectSnapshotFinalizerRemoved           bool
 	}
 	testcases := map[string]testcase{
 		"provision with volume snapshot data source": {
@@ -4616,6 +4617,43 @@ func TestProvisionFromSnapshot(t *testing.T) {
 			},
 			expectCSICall: true,
 		},
+		"snapshot finalizer removed when CreateVolume fails with InvalidArgument": {
+			volOpts: controller.ProvisionOptions{
+				StorageClass: &storagev1.StorageClass{
+					ReclaimPolicy: &deletePolicy,
+					Parameters:    map[string]string{},
+					Provisioner:   "test-driver",
+				},
+				PVName: "test-name",
+				PVC: &v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:         "testid",
+						Namespace:   "default",
+						Annotations: driverNameAnnotation,
+					},
+					Spec: v1.PersistentVolumeClaimSpec{
+						StorageClassName: &snapClassName,
+						Resources: v1.VolumeResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceName(v1.ResourceStorage): resource.MustParse(
+									strconv.FormatInt(requestedBytes, 10),
+								),
+							},
+						},
+						AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+						DataSource: &v1.TypedLocalObjectReference{
+							Name:     snapName,
+							Kind:     "VolumeSnapshot",
+							APIGroup: &apiGrp,
+						},
+					},
+				},
+			},
+			snapshotStatusReady:            true,
+			expectErr:                      true,
+			expectCSICall:                  true,
+			expectSnapshotFinalizerRemoved: true,
+		},
 	}
 
 	tmpdir := tempDir(t)
@@ -4631,10 +4669,16 @@ func TestProvisionFromSnapshot(t *testing.T) {
 		var clientSet kubernetes.Interface = fakeclientset.NewSimpleClientset()
 		client := &fake.Clientset{}
 
+		var snapshotUpdates []*crdv1.VolumeSnapshot
+		var currentSnapshot *crdv1.VolumeSnapshot
+
 		client.AddReactor("get", "volumesnapshots", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 			namespace := "default"
 			if tc.snapNamespace != "" {
 				namespace = tc.snapNamespace
+			}
+			if currentSnapshot != nil {
+				return true, currentSnapshot.DeepCopy(), nil
 			}
 			snap := newSnapshot(snapName, namespace, snapClassName, "snapcontent-snapuid", "snapuid", "claim", tc.snapshotStatusReady, nil, metaTimeNowUnix, resource.NewQuantity(requestedBytes, resource.BinarySI))
 			if tc.nilSnapshotStatus {
@@ -4659,6 +4703,7 @@ func TestProvisionFromSnapshot(t *testing.T) {
 					snap.ObjectMeta.Finalizers = []string{"provisioner.storage.kubernetes.io/volumesnapshot-as-source-protection"}
 				}
 			}
+			currentSnapshot = snap.DeepCopy()
 			return true, snap, nil
 		})
 
@@ -4674,6 +4719,8 @@ func TestProvisionFromSnapshot(t *testing.T) {
 			if !ok {
 				return false, nil, fmt.Errorf("expected VolumeSnapshot, got %T", updateAction.GetObject())
 			}
+			snapshotUpdates = append(snapshotUpdates, snap.DeepCopy())
+			currentSnapshot = snap.DeepCopy()
 			return true, snap, nil
 		})
 
@@ -4755,7 +4802,15 @@ func TestProvisionFromSnapshot(t *testing.T) {
 		// When the following if condition is met, it is a valid create volume from snapshot
 		// operation and CreateVolume is expected to be called.
 		if tc.expectCSICall {
-			if tc.notPopulated {
+			if tc.expectSnapshotFinalizerRemoved {
+				controllerServer.EXPECT().CreateVolume(gomock.Any(), gomock.Any()).Return(
+					nil,
+					status.Error(
+						codes.InvalidArgument,
+						"requested volume size must match source snapshot size",
+					),
+				).Times(1)
+			} else if tc.notPopulated {
 				out.Volume.ContentSource = nil
 				controllerServer.EXPECT().CreateVolume(gomock.Any(), gomock.Any()).Return(out, nil).Times(1)
 				controllerServer.EXPECT().DeleteVolume(gomock.Any(), utils.Protobuf(&csi.DeleteVolumeRequest{
@@ -4796,6 +4851,46 @@ func TestProvisionFromSnapshot(t *testing.T) {
 				if tc.expectedPVSpec.CSIPVS != nil {
 					if !reflect.DeepEqual(pv.Spec.PersistentVolumeSource.CSI, tc.expectedPVSpec.CSIPVS) {
 						t.Errorf("expected PV: %v, got: %v", tc.expectedPVSpec.CSIPVS, pv.Spec.PersistentVolumeSource.CSI)
+					}
+				}
+			}
+		}
+
+		if tc.expectSnapshotFinalizerRemoved {
+			if err == nil {
+				t.Errorf("expected error for finalizer removal test, got none")
+			}
+			if len(snapshotUpdates) == 0 {
+				t.Errorf("expected snapshot updates during provisioning")
+			} else {
+				fin := snapshotSourceProtectionFinalizer
+				hasFinalizer := func(s *crdv1.VolumeSnapshot) bool {
+					for _, f := range s.Finalizers {
+						if f == fin {
+							return true
+						}
+					}
+					return false
+				}
+				if !hasFinalizer(snapshotUpdates[0]) {
+					t.Errorf(
+						"expected source protection finalizer on first snapshot update",
+					)
+				}
+				if len(snapshotUpdates) < 2 {
+					t.Errorf(
+						"expected at least 2 snapshot updates "+
+							"(add + remove finalizer), got %d",
+						len(snapshotUpdates),
+					)
+				} else {
+					last := snapshotUpdates[len(snapshotUpdates)-1]
+					if hasFinalizer(last) {
+						t.Errorf(
+							"expected finalizer removed in last update, "+
+								"still present after %d updates",
+							len(snapshotUpdates),
+						)
 					}
 				}
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
If we create a volume from VolumeSnapshot and CreateVolume returns error, then finalizer from VolumeSnapshot won't be removed and snapshot will not be deleted. Fixed this issue by removing finalizer from volume snapshot in error cases during volume provision workflow.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
