### PR TITLE
Add SnapshotFinalizerController to clean up orphaned snapshot source-protection finalizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Note that the external-provisioner does not scale with more replicas. Only one e
 
 * `--cloning-protection-threads <num>`: Number of simultaneously running threads, handling cloning finalizer removal. Defaults to `1`.
 
+* `--snapshot-orphan-sweep-interval <duration>`: How often to check for orphaned snapshot source-protection finalizers. These finalizers can become stuck if the provisioner crashes during snapshot-based provisioning. Set to `0` to disable. Defaults to `5m`.
+
 * `--http-endpoint`: The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: `:8080` which corresponds to port 8080 on local host). The default is empty string, which means the server is disabled.
 
 * `--metrics-path`: The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.

--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -78,15 +78,16 @@ import (
 )
 
 var (
-	master               = flag.String("master", "", "Master URL to build a client config from. Either this or kubeconfig needs to be set if the provisioner is being run out of cluster.")
-	volumeNamePrefix     = flag.String("volume-name-prefix", "pvc", "Prefix to apply to the name of a created volume.")
-	volumeNameUUIDLength = flag.Int("volume-name-uuid-length", -1, "Truncates generated UUID of a created volume to this length. Defaults behavior is to NOT truncate.")
-	retryIntervalStart   = flag.Duration("retry-interval-start", time.Second, "Initial retry interval of failed provisioning or deletion. It doubles with each failure, up to retry-interval-max.")
-	retryIntervalMax     = flag.Duration("retry-interval-max", 5*time.Minute, "Maximum retry interval of failed provisioning or deletion.")
-	workerThreads        = flag.Uint("worker-threads", 100, "Number of provisioner worker threads, in other words nr. of simultaneous CSI calls.")
-	finalizerThreads     = flag.Uint("cloning-protection-threads", 1, "Number of simultaneously running threads, handling cloning finalizer removal")
-	capacityThreads      = flag.Uint("capacity-threads", 1, "Number of simultaneously running threads, handling CSIStorageCapacity objects")
-	operationTimeout     = flag.Duration("timeout", 10*time.Second, "Timeout for waiting for volume operation (creation, deletion, capacity queries)")
+	master                      = flag.String("master", "", "Master URL to build a client config from. Either this or kubeconfig needs to be set if the provisioner is being run out of cluster.")
+	volumeNamePrefix            = flag.String("volume-name-prefix", "pvc", "Prefix to apply to the name of a created volume.")
+	volumeNameUUIDLength        = flag.Int("volume-name-uuid-length", -1, "Truncates generated UUID of a created volume to this length. Defaults behavior is to NOT truncate.")
+	retryIntervalStart          = flag.Duration("retry-interval-start", time.Second, "Initial retry interval of failed provisioning or deletion. It doubles with each failure, up to retry-interval-max.")
+	retryIntervalMax            = flag.Duration("retry-interval-max", 5*time.Minute, "Maximum retry interval of failed provisioning or deletion.")
+	workerThreads               = flag.Uint("worker-threads", 100, "Number of provisioner worker threads, in other words nr. of simultaneous CSI calls.")
+	finalizerThreads            = flag.Uint("cloning-protection-threads", 1, "Number of simultaneously running threads, handling cloning finalizer removal")
+	snapshotOrphanSweepInterval = flag.Duration("snapshot-orphan-sweep-interval", 5*time.Minute, "How often to check for orphaned snapshot source-protection finalizers. Set to 0 to disable the sweep controller.")
+	capacityThreads             = flag.Uint("capacity-threads", 1, "Number of simultaneously running threads, handling CSIStorageCapacity objects")
+	operationTimeout            = flag.Duration("timeout", 10*time.Second, "Timeout for waiting for volume operation (creation, deletion, capacity queries)")
 
 	strictTopology      = flag.Bool("strict-topology", false, "Late binding: pass only selected node topology to CreateVolume Request, unlike default behavior of passing aggregated cluster topologies that match with topology keys of the selected node.")
 	immediateTopology   = flag.Bool("immediate-topology", true, "Immediate binding: pass aggregated cluster topologies for all nodes where the CSI driver is available (enabled, the default) or no topology requirements (if disabled).")
@@ -634,6 +635,18 @@ func main() {
 		controllerCapabilities,
 	)
 
+	var csiSnapshotFinalizerController *ctrl.SnapshotFinalizerController
+	if *snapshotOrphanSweepInterval > 0 {
+		if volumeSnapshotAvailable, err := features.IsVolumeSnapshotV1Available(clientset.Discovery()); err == nil && volumeSnapshotAvailable {
+			csiSnapshotFinalizerController = ctrl.NewSnapshotFinalizerController(
+				snapClient,
+				claimLister,
+				controllerCapabilities,
+				*snapshotOrphanSweepInterval,
+			)
+		}
+	}
+
 	// handle SIGTERM and SIGINT by cancelling the context.
 	var (
 		terminate       func()          // called when all controllers are finished
@@ -703,6 +716,13 @@ func main() {
 					csiClaimController.Run(controllerCtx, int(*finalizerThreads), &wg)
 				}()
 			}
+			if csiSnapshotFinalizerController != nil {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					csiSnapshotFinalizerController.Run(controllerCtx, &wg)
+				}()
+			}
 			provisionController.ControllerWaitGroup(&wg)
 			provisionController.Run(controllerCtx)
 			wg.Wait()
@@ -713,6 +733,9 @@ func main() {
 			}
 			if csiClaimController != nil {
 				go csiClaimController.Run(ctx, int(*finalizerThreads), nil)
+			}
+			if csiSnapshotFinalizerController != nil {
+				go csiSnapshotFinalizerController.Run(ctx, nil)
 			}
 			provisionController.Run(ctx)
 		}

--- a/deploy/kubernetes/rbac.yaml
+++ b/deploy/kubernetes/rbac.yaml
@@ -38,11 +38,12 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  # The "watch" and "update" verbs for volumesnapshots are optional but recommended.
-  # They enable finalizer-based protection to prevent snapshots from being deleted
-  # during provisioning. Without these permissions, the provisioner will still function
-  # but snapshot protection will be unavailable. This makes the provisioner backwards
-  # compatible with older RBAC configurations.
+  # The "watch", "update", and "list" verbs for volumesnapshots are optional but
+  # recommended. They enable finalizer-based protection to prevent snapshots from
+  # being deleted during provisioning, and allow periodic sweeps to clean up
+  # orphaned finalizers. Without these permissions, the provisioner will still
+  # function but snapshot protection will be unavailable. This makes the
+  # provisioner backwards compatible with older RBAC configurations.
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
     verbs: ["get", "list", "watch", "update"]

--- a/pkg/controller/snapshot_finalizer_controller.go
+++ b/pkg/controller/snapshot_finalizer_controller.go
@@ -1,0 +1,234 @@
+package controller
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-csi/csi-lib-utils/rpc"
+	"github.com/kubernetes-csi/external-provisioner/v6/pkg/features"
+	v1 "k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	snapclientset "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned"
+)
+
+// SnapshotFinalizerController periodically sweeps all VolumeSnapshots (via a
+// local informer cache) looking for the provisioner's source-protection
+// finalizer. When it finds one, it checks whether any Pending PVC still
+// references that snapshot. If not, the finalizer is orphaned and is removed.
+//
+// This handles the case where the finalizer becomes orphaned due to:
+//   - Provisioner crash between setting and removing the finalizer
+//   - Duplicate provisioning race where the second attempt fails permanently
+//   - PVC deletion while provisioning is still in progress
+type SnapshotFinalizerController struct {
+	snapshotClient   snapclientset.Interface
+	snapshotInformer cache.SharedInformer
+	claimLister      corelisters.PersistentVolumeClaimLister
+
+	resyncInterval time.Duration
+}
+
+// NewSnapshotFinalizerController creates a new controller for removing orphaned
+// snapshot source-protection finalizers after provisioning completes or fails.
+// Returns nil if the snapshot client is nil or the driver lacks snapshot capability.
+func NewSnapshotFinalizerController(
+	snapshotClient snapclientset.Interface,
+	claimLister corelisters.PersistentVolumeClaimLister,
+	controllerCapabilities rpc.ControllerCapabilitySet,
+	sweepInterval time.Duration,
+) *SnapshotFinalizerController {
+	if snapshotClient == nil {
+		return nil
+	}
+	if !controllerCapabilities[csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT] {
+		return nil
+	}
+
+	snapshotInformer := cache.NewSharedInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return snapshotClient.SnapshotV1().VolumeSnapshots("").List(context.Background(), options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return snapshotClient.SnapshotV1().VolumeSnapshots("").Watch(context.Background(), options)
+			},
+		},
+		&crdv1.VolumeSnapshot{},
+		10*time.Minute,
+	)
+
+	return &SnapshotFinalizerController{
+		snapshotClient:   snapshotClient,
+		snapshotInformer: snapshotInformer,
+		claimLister:      claimLister,
+		resyncInterval:   sweepInterval,
+	}
+}
+
+// Run starts the controller's periodic sweep loop.
+func (c *SnapshotFinalizerController) Run(ctx context.Context, wg *sync.WaitGroup) {
+	klog.Info("Starting SnapshotFinalizerProtection controller")
+	defer utilruntime.HandleCrash()
+
+	// Preflight: verify we have list/watch permissions on VolumeSnapshots.
+	// These are optional RBAC verbs, so exit gracefully if forbidden.
+	if _, err := c.snapshotClient.SnapshotV1().VolumeSnapshots("").List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
+		if apierrs.IsForbidden(err) {
+			klog.V(3).Infof("SnapshotFinalizerProtection: disabled, missing list permission on volumesnapshots: %v", err)
+			return
+		}
+	}
+
+	go c.snapshotInformer.Run(ctx.Done())
+
+	if !cache.WaitForCacheSync(ctx.Done(), c.snapshotInformer.HasSynced) {
+		klog.Error("SnapshotFinalizerProtection: failed to sync informer caches")
+		return
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.ReleaseLeaderElectionOnExit) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			wait.Until(func() { c.sweepOrphanedFinalizers(ctx) }, c.resyncInterval, ctx.Done())
+		}()
+	} else {
+		go wait.Until(func() { c.sweepOrphanedFinalizers(ctx) }, c.resyncInterval, ctx.Done())
+	}
+
+	klog.Info("Started SnapshotFinalizerProtection controller")
+	<-ctx.Done()
+	klog.Info("Shutting down SnapshotFinalizerProtection controller")
+}
+
+// sweepOrphanedFinalizers iterates VolumeSnapshots from the local informer cache
+// and checks whether any still carry the provisioner's finalizer without a
+// corresponding Pending PVC. This catches cases where PVC deletion events were
+// missed (e.g., controller was not running when the PVC was deleted).
+func (c *SnapshotFinalizerController) sweepOrphanedFinalizers(ctx context.Context) {
+	snapshots := c.snapshotInformer.GetStore().List()
+
+	// Build an index of snapshots that have at least one Pending PVC referencing
+	// them. This makes the per-snapshot check O(1) instead of scanning all PVCs.
+	pendingSnapshots := c.buildPendingSnapshotIndex()
+
+	for _, obj := range snapshots {
+		if ctx.Err() != nil {
+			return
+		}
+		snapshot, ok := obj.(*crdv1.VolumeSnapshot)
+		if !ok {
+			continue
+		}
+		if !checkFinalizer(snapshot, snapshotSourceProtectionFinalizer) {
+			continue
+		}
+		key := snapshot.Namespace + "/" + snapshot.Name
+		if pendingSnapshots.Has(key) {
+			continue
+		}
+		c.removeSnapshotFinalizer(ctx, snapshot)
+	}
+}
+
+// buildPendingSnapshotIndex returns a set of "namespace/name" keys for snapshots
+// that are currently referenced by at least one PVC whose provisioning has not
+// yet completed (Phase is Pending or empty).
+func (c *SnapshotFinalizerController) buildPendingSnapshotIndex() sets.Set[string] {
+	allPVCs, err := c.claimLister.List(labels.Everything())
+	if err != nil {
+		klog.V(3).Infof("SnapshotFinalizerProtection: failed to list PVCs: %v", err)
+		return nil
+	}
+
+	pending := sets.New[string]()
+	for _, pvc := range allPVCs {
+		if pvc.Status.Phase != v1.ClaimPending && pvc.Status.Phase != "" {
+			continue
+		}
+		if !isSnapshotSourcePVC(pvc) {
+			continue
+		}
+		snapNs, snapName := snapshotNameFromPVC(pvc)
+		pending.Insert(snapNs + "/" + snapName)
+	}
+	return pending
+}
+
+// removeSnapshotFinalizer removes the provisioner's source-protection finalizer
+// from the given snapshot.
+func (c *SnapshotFinalizerController) removeSnapshotFinalizer(ctx context.Context, snapshot *crdv1.VolumeSnapshot) {
+	namespace := snapshot.Namespace
+	snapshotName := snapshot.Name
+
+	// No Pending PVC references this snapshot. Remove the finalizer.
+	finalizers := make([]string, 0, len(snapshot.Finalizers))
+	for _, f := range snapshot.Finalizers {
+		if f != snapshotSourceProtectionFinalizer {
+			finalizers = append(finalizers, f)
+		}
+	}
+
+	clone := snapshot.DeepCopy()
+	clone.Finalizers = finalizers
+	if _, err := c.snapshotClient.SnapshotV1().VolumeSnapshots(namespace).Update(ctx, clone, metav1.UpdateOptions{}); err != nil {
+		if apierrs.IsNotFound(err) || apierrs.IsConflict(err) {
+			klog.V(4).Infof("SnapshotFinalizerProtection: transient error removing finalizer from snapshot %s/%s, will retry: %v", namespace, snapshotName, err)
+			return
+		}
+		if apierrs.IsForbidden(err) {
+			klog.V(3).Infof("SnapshotFinalizerProtection: unable to remove finalizer from snapshot %s/%s due to missing RBAC permissions: %v", namespace, snapshotName, err)
+			return
+		}
+		klog.Warningf("SnapshotFinalizerProtection: failed to remove finalizer from snapshot %s/%s: %v", namespace, snapshotName, err)
+		return
+	}
+
+	klog.Infof("SnapshotFinalizerProtection: removed orphaned finalizer from snapshot %s/%s", namespace, snapshotName)
+}
+
+func isSnapshotSourcePVC(pvc *v1.PersistentVolumeClaim) bool {
+	if pvc.Spec.DataSource != nil && pvc.Spec.DataSource.Kind == snapshotKind &&
+		(pvc.Spec.DataSource.APIGroup == nil || *pvc.Spec.DataSource.APIGroup == snapshotAPIGroup) {
+		return true
+	}
+	if pvc.Spec.DataSourceRef != nil && pvc.Spec.DataSourceRef.Kind == snapshotKind &&
+		(pvc.Spec.DataSourceRef.APIGroup == nil || *pvc.Spec.DataSourceRef.APIGroup == snapshotAPIGroup) {
+		return true
+	}
+	return false
+}
+
+// snapshotNameFromPVC returns the snapshot name and namespace referenced by a PVC.
+// It checks both DataSource and DataSourceRef fields. For cross-namespace references
+// via DataSourceRef, the snapshot namespace may differ from the PVC namespace.
+func snapshotNameFromPVC(pvc *v1.PersistentVolumeClaim) (namespace, name string) {
+	if pvc.Spec.DataSource != nil && pvc.Spec.DataSource.Kind == snapshotKind &&
+		(pvc.Spec.DataSource.APIGroup == nil || *pvc.Spec.DataSource.APIGroup == snapshotAPIGroup) {
+		return pvc.Namespace, pvc.Spec.DataSource.Name
+	}
+	if pvc.Spec.DataSourceRef != nil && pvc.Spec.DataSourceRef.Kind == snapshotKind &&
+		(pvc.Spec.DataSourceRef.APIGroup == nil || *pvc.Spec.DataSourceRef.APIGroup == snapshotAPIGroup) {
+		ns := pvc.Namespace
+		if pvc.Spec.DataSourceRef.Namespace != nil && len(*pvc.Spec.DataSourceRef.Namespace) > 0 {
+			ns = *pvc.Spec.DataSourceRef.Namespace
+		}
+		return ns, pvc.Spec.DataSourceRef.Name
+	}
+	return "", ""
+}

--- a/pkg/controller/snapshot_finalizer_controller_test.go
+++ b/pkg/controller/snapshot_finalizer_controller_test.go
@@ -1,0 +1,466 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/kubernetes-csi/csi-lib-utils/rpc"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	crdv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	snapshotfake "github.com/kubernetes-csi/external-snapshotter/client/v8/clientset/versioned/fake"
+)
+
+func newFakeClaimLister(pvcs ...*v1.PersistentVolumeClaim) corelisters.PersistentVolumeClaimLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, pvc := range pvcs {
+		indexer.Add(pvc)
+	}
+	return corelisters.NewPersistentVolumeClaimLister(indexer)
+}
+
+func fakeSnapshotFinalizerController(snapClient *snapshotfake.Clientset, claimLister corelisters.PersistentVolumeClaimLister, snapshots ...*crdv1.VolumeSnapshot) *SnapshotFinalizerController {
+	controllerCapabilities := rpc.ControllerCapabilitySet{
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT: true,
+	}
+
+	ctrl := NewSnapshotFinalizerController(
+		snapClient,
+		claimLister,
+		controllerCapabilities,
+		5*time.Minute,
+	)
+
+	// Replace the informer with one pre-populated with test data.
+	snapshotInformer := cache.NewSharedInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return &crdv1.VolumeSnapshotList{}, nil
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return watch.NewFake(), nil
+			},
+		},
+		&crdv1.VolumeSnapshot{},
+		0,
+	)
+	for _, s := range snapshots {
+		snapshotInformer.GetStore().Add(s)
+	}
+	ctrl.snapshotInformer = snapshotInformer
+	return ctrl
+}
+
+func TestSyncSnapshot_RemoveFinalizerWhenNoPendingPVC(t *testing.T) {
+	snapshotName := "test-snapshot"
+	namespace := "default"
+
+	snapshot := &crdv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      snapshotName,
+			Namespace: namespace,
+			Finalizers: []string{
+				"snapshot.storage.kubernetes.io/volumesnapshot-bound-protection",
+				snapshotSourceProtectionFinalizer,
+			},
+		},
+	}
+
+	boundPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restored-pvc",
+			Namespace: namespace,
+			UID:       types.UID("pvc-uid-1"),
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			DataSource: &v1.TypedLocalObjectReference{
+				Kind: snapshotKind,
+				Name: snapshotName,
+			},
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: v1.ClaimBound,
+		},
+	}
+
+	snapClient := snapshotfake.NewSimpleClientset(snapshot)
+	claimLister := newFakeClaimLister(boundPVC)
+	ctrl := fakeSnapshotFinalizerController(snapClient, claimLister, snapshot)
+
+	ctrl.sweepOrphanedFinalizers(context.Background())
+
+	updated, err := snapClient.SnapshotV1().VolumeSnapshots(namespace).Get(context.Background(), snapshotName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get snapshot: %v", err)
+	}
+	if checkFinalizer(updated, snapshotSourceProtectionFinalizer) {
+		t.Error("expected snapshot source-protection finalizer to be removed")
+	}
+	if !checkFinalizer(updated, "snapshot.storage.kubernetes.io/volumesnapshot-bound-protection") {
+		t.Error("expected other finalizers to be preserved")
+	}
+}
+
+func TestSyncSnapshot_KeepFinalizerWhenPVCPending(t *testing.T) {
+	snapshotName := "test-snapshot"
+	namespace := "default"
+
+	snapshot := &crdv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      snapshotName,
+			Namespace: namespace,
+			Finalizers: []string{
+				snapshotSourceProtectionFinalizer,
+			},
+		},
+	}
+
+	pendingPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pending-pvc",
+			Namespace: namespace,
+			UID:       types.UID("pvc-uid-2"),
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			DataSource: &v1.TypedLocalObjectReference{
+				Kind: snapshotKind,
+				Name: snapshotName,
+			},
+		},
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: v1.ClaimPending,
+		},
+	}
+
+	snapClient := snapshotfake.NewSimpleClientset(snapshot)
+	claimLister := newFakeClaimLister(pendingPVC)
+	ctrl := fakeSnapshotFinalizerController(snapClient, claimLister, snapshot)
+
+	ctrl.sweepOrphanedFinalizers(context.Background())
+
+	updated, err := snapClient.SnapshotV1().VolumeSnapshots(namespace).Get(context.Background(), snapshotName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get snapshot: %v", err)
+	}
+	if !checkFinalizer(updated, snapshotSourceProtectionFinalizer) {
+		t.Error("expected finalizer to still be present")
+	}
+}
+
+func TestSyncSnapshot_RemoveFinalizerWhenNoPVCExists(t *testing.T) {
+	snapshotName := "test-snapshot"
+	namespace := "default"
+
+	snapshot := &crdv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      snapshotName,
+			Namespace: namespace,
+			Finalizers: []string{
+				snapshotSourceProtectionFinalizer,
+			},
+		},
+	}
+
+	snapClient := snapshotfake.NewSimpleClientset(snapshot)
+	claimLister := newFakeClaimLister()
+	ctrl := fakeSnapshotFinalizerController(snapClient, claimLister, snapshot)
+
+	ctrl.sweepOrphanedFinalizers(context.Background())
+
+	updated, err := snapClient.SnapshotV1().VolumeSnapshots(namespace).Get(context.Background(), snapshotName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get snapshot: %v", err)
+	}
+	if checkFinalizer(updated, snapshotSourceProtectionFinalizer) {
+		t.Error("expected finalizer to be removed when no PVCs reference the snapshot")
+	}
+}
+
+func TestSyncSnapshot_MultiplePVCs(t *testing.T) {
+	snapshotName := "test-snapshot"
+	namespace := "default"
+
+	snapshot := &crdv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      snapshotName,
+			Namespace: namespace,
+			Finalizers: []string{
+				snapshotSourceProtectionFinalizer,
+			},
+		},
+	}
+
+	boundPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "bound-pvc", Namespace: namespace},
+		Spec: v1.PersistentVolumeClaimSpec{
+			DataSource: &v1.TypedLocalObjectReference{Kind: snapshotKind, Name: snapshotName},
+		},
+		Status: v1.PersistentVolumeClaimStatus{Phase: v1.ClaimBound},
+	}
+	pendingPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pending-pvc", Namespace: namespace},
+		Spec: v1.PersistentVolumeClaimSpec{
+			DataSource: &v1.TypedLocalObjectReference{Kind: snapshotKind, Name: snapshotName},
+		},
+		Status: v1.PersistentVolumeClaimStatus{Phase: v1.ClaimPending},
+	}
+
+	snapClient := snapshotfake.NewSimpleClientset(snapshot)
+	claimLister := newFakeClaimLister(boundPVC, pendingPVC)
+	ctrl := fakeSnapshotFinalizerController(snapClient, claimLister, snapshot)
+
+	ctrl.sweepOrphanedFinalizers(context.Background())
+
+	updated, err := snapClient.SnapshotV1().VolumeSnapshots(namespace).Get(context.Background(), snapshotName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get snapshot: %v", err)
+	}
+	if !checkFinalizer(updated, snapshotSourceProtectionFinalizer) {
+		t.Error("expected finalizer to still be present while provisioning is active")
+	}
+}
+
+func TestNewSnapshotFinalizerController_NilSnapshotClient(t *testing.T) {
+	ctrl := NewSnapshotFinalizerController(nil, newFakeClaimLister(), nil, 5*time.Minute)
+	if ctrl != nil {
+		t.Error("expected nil controller when snapshotClient is nil")
+	}
+}
+
+func TestNewSnapshotFinalizerController_NoSnapshotCapability(t *testing.T) {
+	capabilities := rpc.ControllerCapabilitySet{
+		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME: true,
+	}
+	ctrl := NewSnapshotFinalizerController(
+		snapshotfake.NewSimpleClientset(),
+		newFakeClaimLister(),
+		capabilities,
+		5*time.Minute,
+	)
+	if ctrl != nil {
+		t.Error("expected nil controller when driver lacks snapshot capability")
+	}
+}
+
+func TestSweepOrphanedFinalizers(t *testing.T) {
+	namespace := "default"
+
+	orphanSnapshot := &crdv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "orphan-snap",
+			Namespace:  namespace,
+			Finalizers: []string{snapshotSourceProtectionFinalizer},
+		},
+	}
+	cleanSnapshot := &crdv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "clean-snap",
+			Namespace:  namespace,
+			Finalizers: []string{"other-finalizer"},
+		},
+	}
+
+	snapClient := snapshotfake.NewSimpleClientset(orphanSnapshot, cleanSnapshot)
+	claimLister := newFakeClaimLister()
+	ctrl := fakeSnapshotFinalizerController(snapClient, claimLister, orphanSnapshot, cleanSnapshot)
+
+	ctrl.sweepOrphanedFinalizers(context.Background())
+
+	updated, err := snapClient.SnapshotV1().VolumeSnapshots(namespace).Get(context.Background(), "orphan-snap", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get snapshot: %v", err)
+	}
+	if checkFinalizer(updated, snapshotSourceProtectionFinalizer) {
+		t.Error("expected sweep to remove orphaned finalizer")
+	}
+
+	clean, err := snapClient.SnapshotV1().VolumeSnapshots(namespace).Get(context.Background(), "clean-snap", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get snapshot: %v", err)
+	}
+	if !checkFinalizer(clean, "other-finalizer") {
+		t.Error("expected clean snapshot's finalizer to be untouched")
+	}
+}
+
+func TestSweepOrphanedFinalizers_RetainsPendingPVC(t *testing.T) {
+	namespace := "default"
+	snapshotName := "active-snap"
+
+	snapshot := &crdv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       snapshotName,
+			Namespace:  namespace,
+			Finalizers: []string{snapshotSourceProtectionFinalizer},
+		},
+	}
+
+	pendingPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "still-provisioning", Namespace: namespace},
+		Spec: v1.PersistentVolumeClaimSpec{
+			DataSource: &v1.TypedLocalObjectReference{Kind: snapshotKind, Name: snapshotName},
+		},
+		Status: v1.PersistentVolumeClaimStatus{Phase: v1.ClaimPending},
+	}
+
+	snapClient := snapshotfake.NewSimpleClientset(snapshot)
+	claimLister := newFakeClaimLister(pendingPVC)
+	ctrl := fakeSnapshotFinalizerController(snapClient, claimLister, snapshot)
+
+	ctrl.sweepOrphanedFinalizers(context.Background())
+
+	updated, err := snapClient.SnapshotV1().VolumeSnapshots(namespace).Get(context.Background(), snapshotName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get snapshot: %v", err)
+	}
+	if !checkFinalizer(updated, snapshotSourceProtectionFinalizer) {
+		t.Error("expected sweep to retain finalizer while PVC is still Pending")
+	}
+}
+
+func TestIsSnapshotSourcePVC(t *testing.T) {
+	snapshotAPIGroup := "snapshot.storage.k8s.io"
+	tests := []struct {
+		name   string
+		pvc    *v1.PersistentVolumeClaim
+		expect bool
+	}{
+		{
+			name: "DataSource with snapshot kind",
+			pvc: &v1.PersistentVolumeClaim{
+				Spec: v1.PersistentVolumeClaimSpec{
+					DataSource: &v1.TypedLocalObjectReference{Kind: snapshotKind, Name: "snap"},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "DataSourceRef with snapshot kind",
+			pvc: &v1.PersistentVolumeClaim{
+				Spec: v1.PersistentVolumeClaimSpec{
+					DataSourceRef: &v1.TypedObjectReference{APIGroup: &snapshotAPIGroup, Kind: snapshotKind, Name: "snap"},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "DataSource with PVC kind",
+			pvc: &v1.PersistentVolumeClaim{
+				Spec: v1.PersistentVolumeClaimSpec{
+					DataSource: &v1.TypedLocalObjectReference{Kind: pvcKind, Name: "pvc"},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "No data source",
+			pvc: &v1.PersistentVolumeClaim{
+				Spec: v1.PersistentVolumeClaimSpec{},
+			},
+			expect: false,
+		},
+		{
+			name: "DataSource with wrong APIGroup is not a snapshot",
+			pvc: &v1.PersistentVolumeClaim{
+				Spec: v1.PersistentVolumeClaimSpec{
+					DataSource: &v1.TypedLocalObjectReference{
+						APIGroup: func() *string { s := "example.com"; return &s }(),
+						Kind:     snapshotKind,
+						Name:     "snap",
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "DataSourceRef with wrong APIGroup is not a snapshot",
+			pvc: &v1.PersistentVolumeClaim{
+				Spec: v1.PersistentVolumeClaimSpec{
+					DataSourceRef: &v1.TypedObjectReference{
+						APIGroup: func() *string { s := "example.com"; return &s }(),
+						Kind:     snapshotKind,
+						Name:     "snap",
+					},
+				},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSnapshotSourcePVC(tt.pvc); got != tt.expect {
+				t.Errorf("isSnapshotSourcePVC() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestSnapshotNameFromPVC_CrossNamespace(t *testing.T) {
+	snapshotAPIGroup := "snapshot.storage.k8s.io"
+	otherNs := "other-namespace"
+
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pvc1", Namespace: "local-ns"},
+		Spec: v1.PersistentVolumeClaimSpec{
+			DataSourceRef: &v1.TypedObjectReference{
+				APIGroup:  &snapshotAPIGroup,
+				Kind:      snapshotKind,
+				Name:      "remote-snapshot",
+				Namespace: &otherNs,
+			},
+		},
+	}
+
+	ns, name := snapshotNameFromPVC(pvc)
+	if ns != "other-namespace" {
+		t.Errorf("expected namespace %q, got %q", "other-namespace", ns)
+	}
+	if name != "remote-snapshot" {
+		t.Errorf("expected name %q, got %q", "remote-snapshot", name)
+	}
+}
+
+func TestSyncSnapshot_DataSourceRefPending(t *testing.T) {
+	snapshotName := "test-snapshot"
+	namespace := "default"
+	snapshotAPIGroup := "snapshot.storage.k8s.io"
+
+	snapshot := &crdv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       snapshotName,
+			Namespace:  namespace,
+			Finalizers: []string{snapshotSourceProtectionFinalizer},
+		},
+	}
+
+	pendingPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "pending-pvc", Namespace: namespace},
+		Spec: v1.PersistentVolumeClaimSpec{
+			DataSourceRef: &v1.TypedObjectReference{APIGroup: &snapshotAPIGroup, Kind: snapshotKind, Name: snapshotName},
+		},
+		Status: v1.PersistentVolumeClaimStatus{Phase: v1.ClaimPending},
+	}
+
+	snapClient := snapshotfake.NewSimpleClientset(snapshot)
+	claimLister := newFakeClaimLister(pendingPVC)
+	ctrl := fakeSnapshotFinalizerController(snapClient, claimLister, snapshot)
+
+	ctrl.sweepOrphanedFinalizers(context.Background())
+
+	updated, err := snapClient.SnapshotV1().VolumeSnapshots(namespace).Get(context.Background(), snapshotName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get snapshot: %v", err)
+	}
+	if !checkFinalizer(updated, snapshotSourceProtectionFinalizer) {
+		t.Error("expected finalizer to still be present when DataSourceRef PVC is Pending")
+	}
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -71,6 +71,11 @@ func IsVolumeAttributesClassV1Enabled(d discovery.DiscoveryInterface) (bool, err
 	return resourceExists(d, "storage.k8s.io/v1", "VolumeAttributesClass")
 }
 
+// IsVolumeSnapshotV1Available checks if the VolumeSnapshot v1 API is available on the cluster.
+func IsVolumeSnapshotV1Available(d discovery.DiscoveryInterface) (bool, error) {
+	return resourceExists(d, "snapshot.storage.k8s.io/v1", "VolumeSnapshot")
+}
+
 func resourceExists(d discovery.DiscoveryInterface, groupVersion, kind string) (bool, error) {
 	res, err := d.ServerResourcesForGroupVersion(groupVersion)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds a `SnapshotFinalizerController` that periodically sweeps all VolumeSnapshots and removes orphaned `provisioner.storage.kubernetes.io/volumesnapshot-as-source-protection` finalizers when no Pending PVC references the snapshot.

The inline `removeSnapshotFinalizer` in the provisioning path handles the happy case, but the finalizer can become permanently orphaned in several scenarios:
- Provisioner crashes between setting and removing the finalizer
- Duplicate provisioning race where the second attempt fails permanently
- PVC is deleted while provisioning is still in progress

An orphaned finalizer blocks snapshot deletion indefinitely. This controller ensures we actively reconcile broken states by sweeping a local VolumeSnapshot informer cache every 5 minutes and cleaning up any finalizer where no Pending PVC still references the snapshot.

The controller is only started when the driver reports `CREATE_DELETE_SNAPSHOT` capability, and gracefully handles missing RBAC permissions (the `list`/`watch`/`update` verbs on volumesnapshots remain optional for backwards compatibility).

**Which issue(s) this PR fixes**:

Fixes #1507

**Special notes for your reviewer**:

- I've tested this with both the EBS CSI Driver and hostpath CSI Driver.
- The sweep uses an in-memory informer cache . I'm not married to this implementation and could change from informer to live `List` calls but I figured this solution was more scalable.
- The snapshot sweep controller is enabled by default, configurable with the flag `--snapshot-orphan-sweep-interval` (zero disables the sweeper). Default is every 5 minutes which seems to be standard in other CSI sidecars.

**Does this PR introduce a user-facing change?**:
```release-note
Add controller to clean up orphaned snapshot source-protection finalizers that can block snapshot deletion after provisioner crashes or PVC deletions.
```