### PR TITLE
deploy: update csi-provisioner image version in storage-capacity example

### DIFF
--- a/deploy/kubernetes/storage-capacity.yaml
+++ b/deploy/kubernetes/storage-capacity.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccount: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.3.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"


### PR DESCRIPTION
Update the `csi-provisioner` image reference in the storage-capacity example manifest to the latest stable release.

## Changes

**`deploy/kubernetes/storage-capacity.yaml`:**
- `csi-provisioner`: v6.2.0 → v6.3.0