### PR TITLE
Add namespace label/annotation values to CreateVolume parameters

### DIFF
--- a/cmd/csi-provisioner/csi-provisioner.go
+++ b/cmd/csi-provisioner/csi-provisioner.go
@@ -92,7 +92,10 @@ var (
 	strictTopology      = flag.Bool("strict-topology", false, "Late binding: pass only selected node topology to CreateVolume Request, unlike default behavior of passing aggregated cluster topologies that match with topology keys of the selected node.")
 	immediateTopology   = flag.Bool("immediate-topology", true, "Immediate binding: pass aggregated cluster topologies for all nodes where the CSI driver is available (enabled, the default) or no topology requirements (if disabled).")
 	extraCreateMetadata = flag.Bool("extra-create-metadata", false, "If set, add pv/pvc metadata to plugin create requests as parameters.")
-	enableProfile       = flag.Bool("enable-pprof", false, "Enable pprof profiling on the TCP network address specified by --http-endpoint. The HTTP path is `/debug/pprof/`.")
+
+	extraCreateMetadataNamespaceLabels      = flag.StringSlice("extra-create-metadata-namespace-labels", nil, "A list of PVC-namespace label keys whose values are added to plugin create requests as parameters under the csi.storage.k8s.io/namespace/labels/ prefix. Requires get access to namespaces. Works independently of --extra-create-metadata.")
+	extraCreateMetadataNamespaceAnnotations = flag.StringSlice("extra-create-metadata-namespace-annotations", nil, "A list of PVC-namespace annotation keys whose values are added to plugin create requests as parameters under the csi.storage.k8s.io/namespace/annotations/ prefix. Requires get access to namespaces. Works independently of --extra-create-metadata.")
+	enableProfile                           = flag.Bool("enable-pprof", false, "Enable pprof profiling on the TCP network address specified by --http-endpoint. The HTTP path is `/debug/pprof/`.")
 
 	defaultFSType = flag.String("default-fstype", "", "The default filesystem type of the volume to provision when fstype is unspecified in the StorageClass. If the default is not set and fstype is unset in the StorageClass, then no fstype will be set")
 
@@ -447,6 +450,10 @@ func main() {
 		*controllerPublishReadOnly,
 		*preventVolumeModeConversion,
 		pvcNodeStore,
+		ctrl.NamespaceMetadataConfig{
+			Labels:      *extraCreateMetadataNamespaceLabels,
+			Annotations: *extraCreateMetadataNamespaceAnnotations,
+		},
 	)
 
 	var capacityController *capacity.Controller

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -127,6 +127,11 @@ const (
 	pvcNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
 	pvNameKey       = "csi.storage.k8s.io/pv/name"
 
+	// PVC namespace label/annotation values, when configured, are sent to drivers on
+	// create requests as parameters under these prefixes, optional.
+	namespaceLabelsParameterPrefix      = "csi.storage.k8s.io/namespace/labels/"
+	namespaceAnnotationsParameterPrefix = "csi.storage.k8s.io/namespace/annotations/"
+
 	snapshotKind     = "VolumeSnapshot"
 	snapshotAPIGroup = snapapi.GroupName       // "snapshot.storage.k8s.io"
 	pvcKind          = "PersistentVolumeClaim" // Native types don't require an API group
@@ -297,6 +302,7 @@ type csiProvisioner struct {
 	vaLister                              storagelistersv1.VolumeAttachmentLister
 	referenceGrantLister                  referenceGrantv1beta1.ReferenceGrantLister
 	extraCreateMetadata                   bool
+	namespaceMetadata                     NamespaceMetadataConfig
 	eventRecorder                         record.EventRecorder
 	nodeDeployment                        *internalNodeDeployment
 	controllerPublishReadOnly             bool
@@ -358,6 +364,15 @@ func GetNodeInfo(conn *grpc.ClientConn, timeout time.Duration) (*csi.NodeGetInfo
 //
 // vaLister is optional and only needed when VolumeAttachments are
 // meant to be checked before deleting a volume.
+// NamespaceMetadataConfig lists the PVC-namespace label and annotation keys whose
+// values are forwarded to the driver as CreateVolume parameters (under the
+// csi.storage.k8s.io/namespace/labels/ and csi.storage.k8s.io/namespace/annotations/
+// prefixes respectively).
+type NamespaceMetadataConfig struct {
+	Labels      []string
+	Annotations []string
+}
+
 func NewCSIProvisioner(client kubernetes.Interface,
 	connectionTimeout time.Duration,
 	identity string,
@@ -384,6 +399,7 @@ func NewCSIProvisioner(client kubernetes.Interface,
 	controllerPublishReadOnly bool,
 	preventVolumeModeConversion bool,
 	pvcNodeStore TopologyProvider,
+	namespaceMetadata NamespaceMetadataConfig,
 ) controller.Provisioner {
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartLogging(klog.Infof)
@@ -416,6 +432,7 @@ func NewCSIProvisioner(client kubernetes.Interface,
 		vaLister:                              vaLister,
 		referenceGrantLister:                  referenceGrantLister,
 		extraCreateMetadata:                   extraCreateMetadata,
+		namespaceMetadata:                     namespaceMetadata,
 		eventRecorder:                         eventRecorder,
 		controllerPublishReadOnly:             controllerPublishReadOnly,
 		preventVolumeModeConversion:           preventVolumeModeConversion,
@@ -795,6 +812,26 @@ func (p *csiProvisioner) prepareProvision(ctx context.Context, claim *v1.Persist
 		req.Parameters[pvcNameKey] = claim.GetName()
 		req.Parameters[pvcNamespaceKey] = claim.GetNamespace()
 		req.Parameters[pvNameKey] = pvName
+	}
+
+	// add configured PVC-namespace label/annotation values to the request for use by
+	// the plugin, so drivers can consume namespace metadata without namespace access
+	// of their own. Independent of extraCreateMetadata.
+	if len(p.namespaceMetadata.Labels) > 0 || len(p.namespaceMetadata.Annotations) > 0 {
+		namespace, err := p.client.CoreV1().Namespaces().Get(ctx, claim.GetNamespace(), metav1.GetOptions{})
+		if err != nil {
+			return nil, controller.ProvisioningNoChange, fmt.Errorf("failed to get namespace %q for create metadata: %v", claim.GetNamespace(), err)
+		}
+		for _, key := range p.namespaceMetadata.Labels {
+			if value, ok := namespace.Labels[key]; ok {
+				req.Parameters[namespaceLabelsParameterPrefix+key] = value
+			}
+		}
+		for _, key := range p.namespaceMetadata.Annotations {
+			if value, ok := namespace.Annotations[key]; ok {
+				req.Parameters[namespaceAnnotationsParameterPrefix+key] = value
+			}
+		}
 	}
 
 	deletionAnnSecrets := new(annotatedSecretParams)

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -435,7 +435,7 @@ func TestCreateDriverReturnsInvalidCapacityDuringProvision(t *testing.T) {
 		pvcNodeStore = NewInMemoryStore()
 	}
 	csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test",
-		5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), nil, nil, nil, nil, nil, nil, false, defaultfsType, nil, true, false, pvcNodeStore)
+		5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), nil, nil, nil, nil, nil, nil, false, defaultfsType, nil, true, false, pvcNodeStore, NamespaceMetadataConfig{})
 
 	// Requested PVC with requestedBytes storage
 	deletePolicy := v1.PersistentVolumeReclaimDelete
@@ -878,6 +878,7 @@ type provisioningTestcase struct {
 	expectState               controller.ProvisioningState
 	expectCreateVolDo         func(t *testing.T, ctx context.Context, req *csi.CreateVolumeRequest)
 	withExtraMetadata         bool
+	namespaceMetadata         NamespaceMetadataConfig
 	skipCreateVolume          bool
 	deploymentNode            string // fake distributed provisioning with this node as host
 	immediateBinding          bool   // enable immediate binding support for distributed provisioning
@@ -1189,6 +1190,77 @@ func provisionTestcases() (int64, map[string]provisioningTestcase) {
 				}
 			},
 			expectState: controller.ProvisioningFinished,
+		},
+		"normal provision with namespace metadata": {
+			volOpts: controller.ProvisionOptions{
+				StorageClass: &storagev1.StorageClass{
+					ReclaimPolicy: &deletePolicy,
+					Parameters: map[string]string{
+						"fstype": "ext3",
+					},
+				},
+				PVName: "test-name",
+				PVC:    createFakePVC(requestedBytes),
+			},
+			namespaceMetadata: NamespaceMetadataConfig{
+				Labels:      []string{"example.com/tier"},
+				Annotations: []string{"example.com/account-id", "example.com/absent"},
+			},
+			clientSetObjects: []runtime.Object{
+				&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "fake-ns",
+						Labels:      map[string]string{"example.com/tier": "gold"},
+						Annotations: map[string]string{"example.com/account-id": "acct-123"},
+					},
+				},
+			},
+			expectedPVSpec: &pvSpec{
+				Name:          "test-testi",
+				ReclaimPolicy: v1.PersistentVolumeReclaimDelete,
+				Capacity: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): bytesToQuantity(requestedBytes),
+				},
+				CSIPVS: &v1.CSIPersistentVolumeSource{
+					Driver:       "test-driver",
+					VolumeHandle: "test-volume-id",
+					FSType:       "ext3",
+					VolumeAttributes: map[string]string{
+						"storage.kubernetes.io/csiProvisionerIdentity": "test-provisioner",
+					},
+				},
+			},
+			expectCreateVolDo: func(t *testing.T, ctx context.Context, req *csi.CreateVolumeRequest) {
+				expectedParams := map[string]string{
+					"fstype": "ext3",
+					namespaceLabelsParameterPrefix + "example.com/tier":            "gold",
+					namespaceAnnotationsParameterPrefix + "example.com/account-id": "acct-123",
+					// "example.com/absent" is configured but not present on the namespace, so it is not injected
+				}
+				if fmt.Sprintf("%v", req.Parameters) != fmt.Sprintf("%v", expectedParams) {
+					t.Errorf("Unexpected parameters: %v", req.Parameters)
+				}
+			},
+			expectState: controller.ProvisioningFinished,
+		},
+		"namespace metadata with missing namespace fails": {
+			volOpts: controller.ProvisionOptions{
+				StorageClass: &storagev1.StorageClass{
+					ReclaimPolicy: &deletePolicy,
+					Parameters: map[string]string{
+						"fstype": "ext3",
+					},
+				},
+				PVName: "test-name",
+				PVC:    createFakePVC(requestedBytes),
+			},
+			namespaceMetadata: NamespaceMetadataConfig{
+				Annotations: []string{"example.com/account-id"},
+			},
+			// no Namespace object in clientSetObjects, so the lookup fails and provisioning is retried
+			expectErr:        true,
+			skipCreateVolume: true,
+			expectState:      controller.ProvisioningNoChange,
 		},
 		"multiple fsType provision": {
 			volOpts: controller.ProvisionOptions{
@@ -2609,7 +2681,7 @@ func runFSTypeProvisionTest(t *testing.T, k string, tc provisioningFSTypeTestcas
 		myDefaultfsType = ""
 	}
 	csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn,
-		nil, provisionDriverName, pluginCaps, controllerCaps, supportsMigrationFromInTreePluginName, false, true, csitrans.New(), nil, nil, nil, nil, nil, nil, false, myDefaultfsType, nil, false, false, pvcNodeStore)
+		nil, provisionDriverName, pluginCaps, controllerCaps, supportsMigrationFromInTreePluginName, false, true, csitrans.New(), nil, nil, nil, nil, nil, nil, false, myDefaultfsType, nil, false, false, pvcNodeStore, NamespaceMetadataConfig{})
 	out := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
 			CapacityBytes: requestedBytes,
@@ -2799,7 +2871,7 @@ func runProvisionTest(t *testing.T, tc provisioningTestcase, requestedBytes int6
 	}
 	mycontrollerPublishReadOnly := tc.controllerPublishReadOnly
 	csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn,
-		nil, provisionDriverName, pluginCaps, controllerCaps, supportsMigrationFromInTreePluginName, false, true, csitrans.New(), scInformer.Lister(), csiNodeInformer.Lister(), nodeInformer.Lister(), claimInformer.Lister(), nil, nil, tc.withExtraMetadata, defaultfsType, nodeDeployment, mycontrollerPublishReadOnly, false, pvcNodeStore)
+		nil, provisionDriverName, pluginCaps, controllerCaps, supportsMigrationFromInTreePluginName, false, true, csitrans.New(), scInformer.Lister(), csiNodeInformer.Lister(), nodeInformer.Lister(), claimInformer.Lister(), nil, nil, tc.withExtraMetadata, defaultfsType, nodeDeployment, mycontrollerPublishReadOnly, false, pvcNodeStore, tc.namespaceMetadata)
 
 	// Adding objects to the informer ensures that they are consistent with
 	// the fake storage without having to start the informers.
@@ -4739,7 +4811,7 @@ func TestProvisionFromSnapshot(t *testing.T) {
 			pvcNodeStore = NewInMemoryStore()
 		}
 		csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn,
-			client, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), nil, nil, nil, nil, nil, refGrantLister, false, defaultfsType, nil, true, true, pvcNodeStore)
+			client, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), nil, nil, nil, nil, nil, refGrantLister, false, defaultfsType, nil, true, true, pvcNodeStore, NamespaceMetadataConfig{})
 
 		out := &csi.CreateVolumeResponse{
 			Volume: &csi.Volume{
@@ -4923,7 +4995,7 @@ func TestProvisionWithTopologyEnabled(t *testing.T) {
 			defer close(stopChan)
 
 			csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5,
-				csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), scLister, csiNodeLister, nodeLister, claimLister, vaLister, nil, false, defaultfsType, nil, true, false, pvcNodeStore)
+				csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), scLister, csiNodeLister, nodeLister, claimLister, vaLister, nil, false, defaultfsType, nil, true, false, pvcNodeStore, NamespaceMetadataConfig{})
 
 			pv, _, err := csiProvisioner.Provision(context.Background(), controller.ProvisionOptions{
 				StorageClass: &storagev1.StorageClass{},
@@ -5021,7 +5093,7 @@ func TestProvisionErrorHandling(t *testing.T) {
 					defer close(stopChan)
 
 					csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5,
-						csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), scLister, csiNodeLister, nodeLister, claimLister, vaLister, nil, false, defaultfsType, nil, true, false, pvcNodeStore)
+						csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), scLister, csiNodeLister, nodeLister, claimLister, vaLister, nil, false, defaultfsType, nil, true, false, pvcNodeStore, NamespaceMetadataConfig{})
 
 					options := controller.ProvisionOptions{
 						StorageClass: &storagev1.StorageClass{},
@@ -5098,7 +5170,7 @@ func TestProvisionWithTopologyDisabled(t *testing.T) {
 		pvcNodeStore = NewInMemoryStore()
 	}
 	csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5,
-		csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), nil, nil, nil, nil, nil, nil, false, defaultfsType, nil, true, false, pvcNodeStore)
+		csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), nil, nil, nil, nil, nil, nil, false, defaultfsType, nil, true, false, pvcNodeStore, NamespaceMetadataConfig{})
 
 	out := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
@@ -5794,7 +5866,7 @@ func runDeleteTest(t *testing.T, k string, tc deleteTestcase) {
 	}
 	scLister, _, _, _, vaLister, _ := listers(clientSet)
 	csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5,
-		csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), scLister, nil, nil, nil, vaLister, nil, false, defaultfsType, nodeDeployment, true, false, pvcNodeStore)
+		csiConn.conn, nil, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), scLister, nil, nil, nil, vaLister, nil, false, defaultfsType, nodeDeployment, true, false, pvcNodeStore, NamespaceMetadataConfig{})
 
 	err = csiProvisioner.Delete(context.Background(), tc.persistentVolume)
 	if tc.expectErr && err == nil {
@@ -6883,7 +6955,7 @@ func TestProvisionFromPVC(t *testing.T) {
 
 			// Phase: execute the test
 			csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn,
-				nil, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), nil, nil, nil, claimLister, nil, refGrantLister, false, defaultfsType, nil, true, false, pvcNodeStore)
+				nil, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), nil, nil, nil, claimLister, nil, refGrantLister, false, defaultfsType, nil, true, false, pvcNodeStore, NamespaceMetadataConfig{})
 
 			pv, _, err = csiProvisioner.Provision(context.Background(), tc.volOpts)
 			if tc.expectErr && err == nil {
@@ -7021,7 +7093,7 @@ func TestProvisionWithMigration(t *testing.T) {
 			}
 			csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner",
 				"test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps,
-				inTreePluginName, false, true, mockTranslator, nil, nil, nil, nil, nil, nil, false, defaultfsType, nil, true, false, pvcNodeStore)
+				inTreePluginName, false, true, mockTranslator, nil, nil, nil, nil, nil, nil, false, defaultfsType, nil, true, false, pvcNodeStore, NamespaceMetadataConfig{})
 
 			// Set up return values (AnyTimes to avoid overfitting on implementation)
 
@@ -7201,7 +7273,7 @@ func TestDeleteMigration(t *testing.T) {
 			defer close(stopCh)
 			csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner",
 				"test", 5, csiConn.conn, nil, driverName, pluginCaps, controllerCaps, inTreePluginName,
-				false, true, mockTranslator, scLister, nil, nil, nil, vaLister, nil, false, defaultfsType, nil, true, false, pvcNodeStore)
+				false, true, mockTranslator, scLister, nil, nil, nil, vaLister, nil, false, defaultfsType, nil, true, false, pvcNodeStore, NamespaceMetadataConfig{})
 
 			// Set mock return values (AnyTimes to avoid overfitting on implementation details)
 			mockTranslator.EXPECT().IsPVMigratable(gomock.Any()).Return(tc.expectTranslation).AnyTimes()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

## **What type of PR is this?**
/kind feature

## **What this PR does / why we need it**:
Adds two flags, `--extra-create-metadata-namespace-labels` and `--extra-create-metadata-namespace-annotations`. When either is set, the provisioner fetches the PVC's namespace and forwards the configured label / annotation values to the driver on `CreateVolume` requests as parameters, under the `csi.storage.k8s.io/namespace/labels/<key>` and `csi.storage.k8s.io/namespace/annotations/<key>` prefixes respectively.

This lets CSI drivers consume namespace metadata (for example a tenant or pool identifier recorded on the namespace) without needing namespace read access of their own — the provisioner already runs with the necessary scope. Only the explicitly configured keys are forwarded, and only when present on the namespace.

Both flags default off and operate independently of `--extra-create-metadata`.

### **Usage example**:
A platform records a quota-pool identifier on each namespace and wants the storage backend to account new volumes against that pool at provision time, without granting the CSI driver cluster-wide namespace read access.

  Configure the provisioner to forward the relevant keys:
  
  ```yaml
  # csi-provisioner container args
  - --extra-create-metadata-namespace-annotations=example.com/quota-pool-id
  - --extra-create-metadata-namespace-labels=example.com/tier
```

Grant the provisioner's ServiceAccount read access to namespaces:

 ```yaml
  - apiGroups: [""]
    resources: ["namespaces"]
    verbs: ["get"]
```

Given a namespace:

 ```yaml
  apiVersion: v1
  kind: Namespace
  metadata:
    name: team-a
    labels:
      example.com/tier: gold
    annotations:
      example.com/quota-pool-id: pool-1234
```

A PVC created in team-a results in a CreateVolumeRequest whose parameters include:

```
csi.storage.k8s.io/namespace/annotations/example.com/quota-pool-id: pool-1234
csi.storage.k8s.io/namespace/labels/example.com/tier:               gold
```

The driver reads these parameters and forwards the pool id / tier to its backend. Keys configured but absent on the namespace are simply not added.

## **Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

## **Special notes for your reviewer**:
- When either flag is set, the provisioner requires `get` on `namespaces`; a lookup failure reschedules the provision (`ProvisioningNoChange`) rather than silently dropping metadata.
- Injected keys use the existing `csi.storage.k8s.io/` parameter convention and are added after StorageClass parameter stripping, so they reach the driver.
- Only the configured keys present on the namespace are forwarded; absent keys are skipped.

## **Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added --extra-create-metadata-namespace-labels and --extra-create-metadata-namespace-annotations flags to forward configured PVC-namespace label/annotation values to drivers as CreateVolume parameters (under the csi.storage.k8s.io/namespace/labels/ and csi.storage.k8s.io/namespace/annotations/ prefixes). When set, the provisioner requires get access to namespaces.
```
