### PR TITLE
Filter capacity work items by storage class allowed topologies

### DIFF
--- a/pkg/capacity/capacity.go
+++ b/pkg/capacity/capacity.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"sync"
 	"time"
@@ -368,6 +369,10 @@ func (c *Controller) onTopologyChanges(added []*topology.Segment, removed []*top
 			continue
 		}
 		for _, segment := range added {
+			if !segmentCompatibleWithStorageClass(segment, sc) {
+				klog.V(5).Infof("Capacity Controller: skipping segment %s for storage class %s, not compatible with its allowed topologies", segment.SimpleString(), sc.Name)
+				continue
+			}
 			c.addWorkItem(segment, sc)
 		}
 		for _, segment := range removed {
@@ -393,8 +398,67 @@ func (c *Controller) onSCAddOrUpdate(sc *storagev1.StorageClass) {
 	c.capacitiesLock.Lock()
 	defer c.capacitiesLock.Unlock()
 	for _, segment := range segments {
+		if !segmentCompatibleWithStorageClass(segment, sc) {
+			// Remove instead of merely skipping: the allowed topologies
+			// may have been changed in an update, in which case some
+			// existing items might have become obsolete.
+			klog.V(5).Infof("Capacity Controller: segment %s is not compatible with the allowed topologies of storage class %s", segment.SimpleString(), sc.Name)
+			c.removeWorkItem(segment, sc)
+			continue
+		}
 		c.addWorkItem(segment, sc)
 	}
+}
+
+// segmentCompatibleWithStorageClass determines whether the storage class
+// might be usable in the given topology segment. Combinations that are
+// ruled out by the storage class's allowed topologies don't need a
+// CSIStorageCapacity object.
+//
+// The check is intentionally conservative and only filters out combinations
+// which are provably impossible: a segment is considered incompatible with a
+// topology selector term only if the term contains a requirement for one of
+// the segment's keys which does not allow the segment's value. Requirements
+// for label keys that are not part of the segment cannot be checked here
+// (the CSI driver's topology keys are not necessarily the same as the node
+// label keys used in the allowed topologies) and therefore are assumed to
+// match.
+func segmentCompatibleWithStorageClass(segment *topology.Segment, sc *storagev1.StorageClass) bool {
+	if len(sc.AllowedTopologies) == 0 {
+		// No restrictions.
+		return true
+	}
+	// The terms are ORed, so one compatible term is enough.
+	for _, term := range sc.AllowedTopologies {
+		if segmentCompatibleWithTerm(segment, term) {
+			return true
+		}
+	}
+	return false
+}
+
+func segmentCompatibleWithTerm(segment *topology.Segment, term v1.TopologySelectorTerm) bool {
+	// The requirements within a term are ANDed, so one conflicting
+	// requirement rules out the term.
+	for _, req := range term.MatchLabelExpressions {
+		value, found := segmentValue(segment, req.Key)
+		if !found {
+			continue
+		}
+		if !slices.Contains(req.Values, value) {
+			return false
+		}
+	}
+	return true
+}
+
+func segmentValue(segment *topology.Segment, key string) (string, bool) {
+	for _, entry := range *segment {
+		if entry.Key == key {
+			return entry.Value, true
+		}
+	}
+	return "", false
 }
 
 // onSCDelete is called for delete events by the storage class listener.

--- a/pkg/capacity/capacity_test.go
+++ b/pkg/capacity/capacity_test.go
@@ -1083,6 +1083,184 @@ func TestCapacityController(t *testing.T) {
 			},
 			expectedTotalProcessed: 1,
 		},
+		"allowed topologies filter segments": {
+			topology: topology.NewMock(&layer0, &layer0other),
+			storage: mockCapacity{
+				capacity: map[string]any{
+					// This matches layer0.
+					"foo": "1Gi",
+					// This matches layer0other.
+					"bar": "2Gi",
+				},
+			},
+			initialSCs: []testSC{
+				{
+					name:       "other-sc",
+					driverName: driverName,
+					allowedTopologies: []v1.TopologySelectorTerm{
+						{
+							MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+								{Key: "layer0", Values: []string{"foo"}},
+							},
+						},
+					},
+				},
+			},
+			expectedCapacities: []testCapacity{
+				{
+					uid:              "CSISC-UID-1",
+					resourceVersion:  csiscRev + "0",
+					segment:          layer0,
+					storageClassName: "other-sc",
+					quantity:         "1Gi",
+				},
+			},
+			expectedObjectsPrepared: objects{
+				goal: 1,
+			},
+			expectedTotalProcessed: 1,
+		},
+		"allowed topologies with different label keys": {
+			topology: topology.NewMock(&layer0),
+			storage: mockCapacity{
+				capacity: map[string]any{
+					// This matches layer0.
+					"foo": "1Gi",
+				},
+			},
+			initialSCs: []testSC{
+				{
+					name:       "other-sc",
+					driverName: driverName,
+					// The label key is not one of the topology segment
+					// keys, so it cannot be used for filtering.
+					allowedTopologies: []v1.TopologySelectorTerm{
+						{
+							MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+								{Key: "some-node-label", Values: []string{"some-value"}},
+							},
+						},
+					},
+				},
+			},
+			expectedCapacities: []testCapacity{
+				{
+					uid:              "CSISC-UID-1",
+					resourceVersion:  csiscRev + "0",
+					segment:          layer0,
+					storageClassName: "other-sc",
+					quantity:         "1Gi",
+				},
+			},
+			expectedObjectsPrepared: objects{
+				goal: 1,
+			},
+			expectedTotalProcessed: 1,
+		},
+		"allowed topologies filter added segment": {
+			topology: topology.NewMock(&layer0),
+			storage: mockCapacity{
+				capacity: map[string]any{
+					// This matches layer0.
+					"foo": "1Gi",
+					// This matches layer0other.
+					"bar": "2Gi",
+				},
+			},
+			initialSCs: []testSC{
+				{
+					name:       "other-sc",
+					driverName: driverName,
+					allowedTopologies: []v1.TopologySelectorTerm{
+						{
+							MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+								{Key: "layer0", Values: []string{"foo"}},
+							},
+						},
+					},
+				},
+			},
+			expectedCapacities: []testCapacity{
+				{
+					uid:              "CSISC-UID-1",
+					resourceVersion:  csiscRev + "0",
+					segment:          layer0,
+					storageClassName: "other-sc",
+					quantity:         "1Gi",
+				},
+			},
+			topologyChange: func(ctx context.Context, topo *topology.Mock, expected []testCapacity) []testCapacity {
+				// The new segment is not compatible with the allowed
+				// topologies of the storage class, so nothing changes.
+				topo.Modify([]*topology.Segment{&layer0other} /* added */, nil /* removed */)
+				return expected
+			},
+			expectedObjectsPrepared: objects{
+				goal: 1,
+			},
+			expectedTotalProcessed: 1,
+		},
+		"allowed topologies changed in update": {
+			topology: topology.NewMock(&layer0, &layer0other),
+			storage: mockCapacity{
+				capacity: map[string]any{
+					// This matches layer0.
+					"foo": "1Gi",
+					// This matches layer0other.
+					"bar": "2Gi",
+				},
+			},
+			initialSCs: []testSC{
+				{
+					name:       "other-sc",
+					driverName: driverName,
+				},
+			},
+			expectedCapacities: []testCapacity{
+				{
+					resourceVersion:  csiscRev + "0",
+					segment:          layer0,
+					storageClassName: "other-sc",
+					quantity:         "1Gi",
+				},
+				{
+					resourceVersion:  csiscRev + "0",
+					segment:          layer0other,
+					storageClassName: "other-sc",
+					quantity:         "2Gi",
+				},
+			},
+			modify: func(ctx context.Context, clientSet *fakeclientset.Clientset, expected []testCapacity) ([]testCapacity, error) {
+				// Restricting the allowed topologies must remove the
+				// capacity object for the other segment.
+				sc, err := clientSet.StorageV1().StorageClasses().Get(ctx, "other-sc", metav1.GetOptions{})
+				if err != nil {
+					return nil, err
+				}
+				sc.AllowedTopologies = []v1.TopologySelectorTerm{
+					{
+						MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+							{Key: "layer0", Values: []string{"foo"}},
+						},
+					},
+				}
+				if _, err := clientSet.StorageV1().StorageClasses().Update(ctx, sc, metav1.UpdateOptions{}); err != nil {
+					return nil, err
+				}
+				return []testCapacity{
+					{
+						resourceVersion:  csiscRev + "0",
+						segment:          layer0,
+						storageClassName: "other-sc",
+						quantity:         "1Gi",
+					},
+				}, nil
+			},
+			expectedObjectsPrepared: objects{
+				goal: 2,
+			},
+			expectedTotalProcessed: 1,
+		},
 	}
 
 	for name, tc := range testcases {
@@ -1655,10 +1833,11 @@ func makeCapacity(in testCapacity) *storagev1.CSIStorageCapacity {
 }
 
 type testSC struct {
-	name             string
-	driverName       string
-	parameters       map[string]string
-	immediateBinding bool
+	name              string
+	driverName        string
+	parameters        map[string]string
+	immediateBinding  bool
+	allowedTopologies []v1.TopologySelectorTerm
 }
 
 func makeSC(in testSC) *storagev1.StorageClass {
@@ -1673,6 +1852,7 @@ func makeSC(in testSC) *storagev1.StorageClass {
 		Provisioner:       in.driverName,
 		Parameters:        in.parameters,
 		VolumeBindingMode: &volumeBinding,
+		AllowedTopologies: in.allowedTopologies,
 	}
 }
 
@@ -1681,6 +1861,131 @@ func makeSCs(in []testSC) (items []runtime.Object) {
 		items = append(items, makeSC(item))
 	}
 	return
+}
+
+func TestSegmentCompatibleWithStorageClass(t *testing.T) {
+	testcases := map[string]struct {
+		segment           topology.Segment
+		allowedTopologies []v1.TopologySelectorTerm
+		expectCompatible  bool
+	}{
+		"no allowed topologies": {
+			segment:          layer0,
+			expectCompatible: true,
+		},
+		"matching value": {
+			segment: layer0,
+			allowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{Key: "layer0", Values: []string{"foo"}},
+					},
+				},
+			},
+			expectCompatible: true,
+		},
+		"conflicting value": {
+			segment: layer0,
+			allowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{Key: "layer0", Values: []string{"bar"}},
+					},
+				},
+			},
+			expectCompatible: false,
+		},
+		"different label key": {
+			segment: layer0,
+			allowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{Key: "some-node-label", Values: []string{"some-value"}},
+					},
+				},
+			},
+			expectCompatible: true,
+		},
+		"conflict beats unknown key in same term": {
+			segment: layer0,
+			allowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{Key: "some-node-label", Values: []string{"some-value"}},
+						{Key: "layer0", Values: []string{"bar"}},
+					},
+				},
+			},
+			expectCompatible: false,
+		},
+		"terms are ORed": {
+			segment: layer0,
+			allowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{Key: "layer0", Values: []string{"bar"}},
+					},
+				},
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{Key: "layer0", Values: []string{"foo"}},
+					},
+				},
+			},
+			expectCompatible: true,
+		},
+		"multiple values": {
+			segment: layer0,
+			allowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{Key: "layer0", Values: []string{"bar", "foo"}},
+					},
+				},
+			},
+			expectCompatible: true,
+		},
+		"deep segment matches": {
+			segment: deep,
+			allowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{Key: "layer0", Values: []string{"foo"}},
+						{Key: "layer2", Values: []string{"A"}},
+					},
+				},
+			},
+			expectCompatible: true,
+		},
+		"deep segment conflicts": {
+			segment: deep,
+			allowedTopologies: []v1.TopologySelectorTerm{
+				{
+					MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+						{Key: "layer0", Values: []string{"foo"}},
+						{Key: "layer2", Values: []string{"B"}},
+					},
+				},
+			},
+			expectCompatible: false,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			sc := &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-sc",
+				},
+				Provisioner:       driverName,
+				AllowedTopologies: tc.allowedTopologies,
+			}
+			compatible := segmentCompatibleWithStorageClass(&tc.segment, sc)
+			if compatible != tc.expectCompatible {
+				t.Errorf("expected compatible %v, got %v", tc.expectCompatible, compatible)
+			}
+		})
+	}
 }
 
 func TestTermToSegment(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

The central capacity controller creates a work item (and with it a `CSIStorageCapacity` object) for every combination of topology segment and storage class, even when the storage class's `allowedTopologies` rule out that segment. This PR filters out those impossible combinations when a storage class is added/updated and when new topology segments appear, reducing work queue depth and the number of `CSIStorageCapacity` objects.

The check is intentionally conservative: a combination is only skipped when a topology selector term contains a requirement for one of the segment's keys with a value that is not allowed. Requirements using label keys which are not part of the segment are assumed to match, because the CSI driver's topology keys are not necessarily the same as the node label keys used in `allowedTopologies` — this avoids regressions for such setups.

When the `allowedTopologies` of an existing storage class are changed, work items that have become impossible are removed so that their `CSIStorageCapacity` objects get deleted.

**Which issue(s) this PR fixes**:

Fixes #1162

**Special notes for your reviewer**:

- `onSCDelete` intentionally stays unfiltered: removing a work item that was never created is a cheap no-op, and this keeps deletion robust.
- New unit test `TestSegmentCompatibleWithStorageClass` covers the matching semantics (OR of terms, AND of requirements, unknown label keys), and `TestCapacityController` gained cases for initial filtering, filtering of newly added segments, non-segment label keys, and narrowing `allowedTopologies` on an update.

**Does this PR introduce a user-facing change?**:
```release-note
The central storage capacity controller no longer creates CSIStorageCapacity objects for topology segments that are ruled out by a storage class's allowedTopologies.
```
