### PR TITLE
Add snapshot topology support for Immediate binding (KEP-5943)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -214,3 +214,8 @@ replace k8s.io/cri-streaming => k8s.io/cri-streaming v0.36.1
 replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.36.1
 
 replace k8s.io/streaming => k8s.io/streaming v0.36.1
+
+// TODO(KEP-5943): points at the fork carrying VolumeSnapshotContent.Spec.NodeAffinity.
+// Drop this replace and depend on an official external-snapshotter client release
+// once the snapshot-topology change merges upstream and a client version is tagged.
+replace github.com/kubernetes-csi/external-snapshotter/client/v8 => github.com/mdzraf/external-snapshotter/client/v8 v8.4.1-0.20260730192112-9610545fc807

--- a/go.mod
+++ b/go.mod
@@ -212,3 +212,8 @@ replace k8s.io/cri-streaming => k8s.io/cri-streaming v0.36.1
 replace k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.36.1
 
 replace k8s.io/streaming => k8s.io/streaming v0.36.1
+
+// TODO(KEP-5943): points at the fork carrying VolumeSnapshotContent.Spec.NodeAffinity.
+// Drop this replace and depend on an official external-snapshotter client release
+// once the snapshot-topology change merges upstream and a client version is tagged.
+replace github.com/kubernetes-csi/external-snapshotter/client/v8 => github.com/mdzraf/external-snapshotter/client/v8 v8.4.1-0.20260730192112-9610545fc807

--- a/go.sum
+++ b/go.sum
@@ -143,12 +143,12 @@ github.com/kubernetes-csi/csi-lib-utils v0.24.0 h1:hpL5ecxtr07/DNIF9Qn/gbNG/ZlgM
 github.com/kubernetes-csi/csi-lib-utils v0.24.0/go.mod h1:JbvkvtWghDcVZnwQoSi6Np9ITwqN7+sqLiSsM9y4kRE=
 github.com/kubernetes-csi/csi-test/v5 v5.5.0 h1:21NYP33XXfzsAGwFuFHJUIf60hY08B4ANLj819++f98=
 github.com/kubernetes-csi/csi-test/v5 v5.5.0/go.mod h1:5ZyneETi47SniZuPA9e8fIL6TTkkKv8/+jkaF0IHqKY=
-github.com/kubernetes-csi/external-snapshotter/client/v8 v8.6.0 h1:FtGewu2k6HWw6evLGXY8JqUZ9eHpti1kd3e4amj+ilA=
-github.com/kubernetes-csi/external-snapshotter/client/v8 v8.6.0/go.mod h1:Vxl89NySJ45J+ah3NTMan/KJXW+NpcGHE2Tw0GSw53k=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
+github.com/mdzraf/external-snapshotter/client/v8 v8.4.1-0.20260730192112-9610545fc807 h1:kTDQx+0mPvxfxU4A9uE3ZhMSSumuzwTXgy6/9jsjwWs=
+github.com/mdzraf/external-snapshotter/client/v8 v8.4.1-0.20260730192112-9610545fc807/go.mod h1:Vxl89NySJ45J+ah3NTMan/KJXW+NpcGHE2Tw0GSw53k=
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/miekg/dns v1.1.72 h1:vhmr+TF2A3tuoGNkLDFK9zi36F2LS+hKTRW0Uf8kbzI=

--- a/go.sum
+++ b/go.sum
@@ -141,12 +141,12 @@ github.com/kubernetes-csi/csi-lib-utils v0.24.0 h1:hpL5ecxtr07/DNIF9Qn/gbNG/ZlgM
 github.com/kubernetes-csi/csi-lib-utils v0.24.0/go.mod h1:JbvkvtWghDcVZnwQoSi6Np9ITwqN7+sqLiSsM9y4kRE=
 github.com/kubernetes-csi/csi-test/v5 v5.6.0 h1:fQgB/CRoqTEAtlHwfD0Y785LjQJ/OxNGUE7AHw68VLg=
 github.com/kubernetes-csi/csi-test/v5 v5.6.0/go.mod h1:IXPOop3n6Mlco/6/3nGrE+MTOx3uXiIQVDJh3KBt/DI=
-github.com/kubernetes-csi/external-snapshotter/client/v8 v8.6.0 h1:FtGewu2k6HWw6evLGXY8JqUZ9eHpti1kd3e4amj+ilA=
-github.com/kubernetes-csi/external-snapshotter/client/v8 v8.6.0/go.mod h1:Vxl89NySJ45J+ah3NTMan/KJXW+NpcGHE2Tw0GSw53k=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
+github.com/mdzraf/external-snapshotter/client/v8 v8.4.1-0.20260730192112-9610545fc807 h1:kTDQx+0mPvxfxU4A9uE3ZhMSSumuzwTXgy6/9jsjwWs=
+github.com/mdzraf/external-snapshotter/client/v8 v8.4.1-0.20260730192112-9610545fc807/go.mod h1:Vxl89NySJ45J+ah3NTMan/KJXW+NpcGHE2Tw0GSw53k=
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/miekg/dns v1.1.73 h1:uhT8nJxmTrPJYClxVxTCX+CVn6qnzSiybRk72Z6DgrE=

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -695,12 +695,14 @@ func (p *csiProvisioner) prepareProvision(ctx context.Context, claim *v1.Persist
 		},
 	}
 
+	var snapshotNodeAffinity []v1.TopologySelectorTerm
 	if dataSource != nil && (rc.clone || rc.snapshot) {
-		volumeContentSource, err := p.getVolumeContentSource(ctx, claim, sc, dataSource)
+		volumeContentSource, nodeAffinity, err := p.getVolumeContentSource(ctx, claim, sc, dataSource)
 		if err != nil {
 			return nil, controller.ProvisioningNoChange, fmt.Errorf("error getting handle for DataSource Type %s by Name %s: %v", dataSource.Kind, dataSource.Name, err)
 		}
 		req.VolumeContentSource = volumeContentSource
+		snapshotNodeAffinity = nodeAffinity
 	}
 
 	if dataSource != nil && rc.clone {
@@ -737,6 +739,19 @@ func (p *csiProvisioner) prepareProvision(ctx context.Context, claim *v1.Persist
 			return nil, controller.ProvisioningNoChange, fmt.Errorf("error generating accessibility requirements: %v", err)
 		}
 		req.AccessibilityRequirements = requirements
+
+		if utilfeature.DefaultFeatureGate.Enabled(features.VolumeSnapshotTopology) &&
+			rc.snapshot && selectedNodeName == "" && len(snapshotNodeAffinity) > 0 {
+			intersected := intersectSnapshotTopology(sc.AllowedTopologies, snapshotNodeAffinity)
+			if len(intersected) == 0 {
+				return nil, controller.ProvisioningFinished, fmt.Errorf("no compatible topology: snapshot %s NodeAffinity does not intersect StorageClass %s AllowedTopologies, so the volume cannot be provisioned where the snapshot is accessible", dataSource.Name, sc.Name)
+			}
+			req.AccessibilityRequirements = &csi.TopologyRequirement{
+				Requisite: intersected,
+				Preferred: intersected,
+			}
+			klog.V(2).Infof("prepareProvision: constrained snapshot-sourced PVC %s to %d topology terms from the intersection of snapshot NodeAffinity and StorageClass.AllowedTopologies", claim.Name, len(intersected))
+		}
 	}
 
 	// Resolve provision secret credentials.
@@ -1181,15 +1196,18 @@ func removePrefixedParameters(param map[string]string) (map[string]string, error
 // currently we provide Snapshot and PVC, the default case allows the provisioner to still create a volume
 // so that an external controller can act upon it.   Additional DataSource types can be added here with
 // an appropriate implementation function
-func (p *csiProvisioner) getVolumeContentSource(ctx context.Context, claim *v1.PersistentVolumeClaim, sc *storagev1.StorageClass, dataSource *v1.ObjectReference) (*csi.VolumeContentSource, error) {
+// getVolumeContentSource returns the CSI VolumeContentSource and, for snapshot
+// sources, the bound VolumeSnapshotContent's Spec.NodeAffinity (nil otherwise).
+func (p *csiProvisioner) getVolumeContentSource(ctx context.Context, claim *v1.PersistentVolumeClaim, sc *storagev1.StorageClass, dataSource *v1.ObjectReference) (*csi.VolumeContentSource, []v1.TopologySelectorTerm, error) {
 	switch dataSource.Kind {
 	case snapshotKind:
 		return p.getSnapshotSource(ctx, claim, sc, dataSource)
 	case pvcKind:
-		return p.getPVCSource(ctx, claim, sc, dataSource)
+		src, err := p.getPVCSource(ctx, claim, sc, dataSource)
+		return src, nil, err
 	default:
 		// For now we shouldn't pass other things to this function, but treat it as a noop and extend as needed
-		return nil, nil
+		return nil, nil, nil
 	}
 }
 
@@ -1285,11 +1303,13 @@ func (p *csiProvisioner) getPVCSource(ctx context.Context, claim *v1.PersistentV
 }
 
 // getSnapshotSource verifies DataSource.Kind of type VolumeSnapshot, making sure that the requested Snapshot is available/ready
-// returns the VolumeContentSource for the requested snapshot
-func (p *csiProvisioner) getSnapshotSource(ctx context.Context, claim *v1.PersistentVolumeClaim, sc *storagev1.StorageClass, dataSource *v1.ObjectReference) (*csi.VolumeContentSource, error) {
+// returns the VolumeContentSource for the requested snapshot, along with the
+// bound VolumeSnapshotContent's Spec.NodeAffinity so callers don't
+// need to re-fetch the snapshot and its content.
+func (p *csiProvisioner) getSnapshotSource(ctx context.Context, claim *v1.PersistentVolumeClaim, sc *storagev1.StorageClass, dataSource *v1.ObjectReference) (*csi.VolumeContentSource, []v1.TopologySelectorTerm, error) {
 	snapshotObj, err := p.snapshotClient.SnapshotV1().VolumeSnapshots(dataSource.Namespace).Get(ctx, dataSource.Name, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error getting snapshot %s from api server: %v", dataSource.Name, err)
+		return nil, nil, fmt.Errorf("error getting snapshot %s from api server: %v", dataSource.Name, err)
 	}
 
 	if snapshotObj.ObjectMeta.DeletionTimestamp != nil {
@@ -1299,40 +1319,40 @@ func (p *csiProvisioner) getSnapshotSource(ctx context.Context, claim *v1.Persis
 		// so we should continue to prevent resource leaks.
 		// If the finalizer doesn't exist, this is a new provisioning attempt and should be rejected.
 		if !checkFinalizer(snapshotObj, snapshotSourceProtectionFinalizer) {
-			return nil, fmt.Errorf("snapshot %s is being deleted", dataSource.Name)
+			return nil, nil, fmt.Errorf("snapshot %s is being deleted", dataSource.Name)
 		}
 		klog.V(3).Infof("Snapshot %s/%s is being deleted but has volumesnapshot-as-source-protection finalizer, allowing provisioning to continue", dataSource.Namespace, dataSource.Name)
 	}
 	klog.V(5).Infof("VolumeSnapshot %+v", snapshotObj)
 
 	if snapshotObj.Status == nil || snapshotObj.Status.BoundVolumeSnapshotContentName == nil {
-		return nil, fmt.Errorf(snapshotNotBound, dataSource.Name)
+		return nil, nil, fmt.Errorf(snapshotNotBound, dataSource.Name)
 	}
 
 	snapContentObj, err := p.snapshotClient.SnapshotV1().VolumeSnapshotContents().Get(ctx, *snapshotObj.Status.BoundVolumeSnapshotContentName, metav1.GetOptions{})
 	if err != nil {
 		klog.Warningf("error getting snapshotcontent %s for snapshot %s/%s from api server: %s", *snapshotObj.Status.BoundVolumeSnapshotContentName, snapshotObj.Namespace, snapshotObj.Name, err)
-		return nil, fmt.Errorf(errorGettingSnapshotContent, *snapshotObj.Status.BoundVolumeSnapshotContentName, dataSource.Name)
+		return nil, nil, fmt.Errorf(errorGettingSnapshotContent, *snapshotObj.Status.BoundVolumeSnapshotContentName, dataSource.Name)
 	}
 
 	if snapContentObj.Spec.VolumeSnapshotRef.UID != snapshotObj.UID || snapContentObj.Spec.VolumeSnapshotRef.Namespace != snapshotObj.Namespace || snapContentObj.Spec.VolumeSnapshotRef.Name != snapshotObj.Name {
 		klog.Warningf("snapshotcontent %s for snapshot %s/%s is bound to a different snapshot", *snapshotObj.Status.BoundVolumeSnapshotContentName, snapshotObj.Namespace, snapshotObj.Name)
-		return nil, fmt.Errorf(snapshotContentNotBoundToSnapshot, *snapshotObj.Status.BoundVolumeSnapshotContentName, dataSource.Name)
+		return nil, nil, fmt.Errorf(snapshotContentNotBoundToSnapshot, *snapshotObj.Status.BoundVolumeSnapshotContentName, dataSource.Name)
 	}
 
 	if snapContentObj.Spec.Driver != sc.Provisioner {
 		klog.Warningf("snapshotcontent %s for snapshot %s/%s is handled by a different CSI driver than requested by StorageClass %s", *snapshotObj.Status.BoundVolumeSnapshotContentName, snapshotObj.Namespace, snapshotObj.Name, sc.Name)
-		return nil, fmt.Errorf(snapshotDifferentDriver, *snapshotObj.Status.BoundVolumeSnapshotContentName, dataSource.Name, sc.Name)
+		return nil, nil, fmt.Errorf(snapshotDifferentDriver, *snapshotObj.Status.BoundVolumeSnapshotContentName, dataSource.Name, sc.Name)
 	}
 
 	if snapshotObj.Status.ReadyToUse == nil || !*snapshotObj.Status.ReadyToUse {
-		return nil, fmt.Errorf("snapshot %s is not Ready", dataSource.Name)
+		return nil, nil, fmt.Errorf("snapshot %s is not Ready", dataSource.Name)
 	}
 
 	klog.V(5).Infof("VolumeSnapshotContent %+v", snapContentObj)
 
 	if snapContentObj.Status == nil || snapContentObj.Status.SnapshotHandle == nil {
-		return nil, fmt.Errorf("snapshot handle %s is not available", dataSource.Name)
+		return nil, nil, fmt.Errorf("snapshot handle %s is not available", dataSource.Name)
 	}
 
 	snapshotSource := csi.VolumeContentSource_Snapshot{
@@ -1345,14 +1365,14 @@ func (p *csiProvisioner) getSnapshotSource(ctx context.Context, claim *v1.Persis
 	if snapshotObj.Status.RestoreSize != nil {
 		capacity, exists := claim.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 		if !exists {
-			return nil, fmt.Errorf("error getting capacity for PVC %s when creating snapshot %s", claim.Name, snapshotObj.Name)
+			return nil, nil, fmt.Errorf("error getting capacity for PVC %s when creating snapshot %s", claim.Name, snapshotObj.Name)
 		}
 		volSizeBytes := capacity.Value()
 		klog.V(5).Infof("Requested volume size is %d and snapshot size is %d for the source snapshot %s", int64(volSizeBytes), int64(snapshotObj.Status.RestoreSize.Value()), snapshotObj.Name)
 		// When restoring volume from a snapshot, the volume size should
 		// be equal to or larger than its snapshot size.
 		if int64(volSizeBytes) < int64(snapshotObj.Status.RestoreSize.Value()) {
-			return nil, fmt.Errorf("requested volume size %d is less than the size %d for the source snapshot %s", int64(volSizeBytes), int64(snapshotObj.Status.RestoreSize.Value()), snapshotObj.Name)
+			return nil, nil, fmt.Errorf("requested volume size %d is less than the size %d for the source snapshot %s", int64(volSizeBytes), int64(snapshotObj.Status.RestoreSize.Value()), snapshotObj.Name)
 		}
 		if int64(volSizeBytes) > int64(snapshotObj.Status.RestoreSize.Value()) {
 			klog.Warningf("requested volume size %d is greater than the size %d for the source snapshot %s. Volume plugin needs to handle volume expansion.", int64(volSizeBytes), int64(snapshotObj.Status.RestoreSize.Value()), snapshotObj.Name)
@@ -1365,16 +1385,16 @@ func (p *csiProvisioner) getSnapshotSource(ctx context.Context, claim *v1.Persis
 			// Verify if this volume is allowed to alter its mode.
 			allowVolumeModeChange, ok := snapContentObj.Annotations[annAllowVolumeModeChange]
 			if !ok {
-				return nil, fmt.Errorf("requested volume %s/%s modifies the mode of the source volume but does not have permission to do so. "+
+				return nil, nil, fmt.Errorf("requested volume %s/%s modifies the mode of the source volume but does not have permission to do so. "+
 					"%s annotation is not present on snapshotcontent %s", claim.Namespace, claim.Name, annAllowVolumeModeChange, snapContentObj.Name)
 			}
 			allowVolumeModeChangeBool, err := strconv.ParseBool(allowVolumeModeChange)
 			if err != nil {
-				return nil, fmt.Errorf("requested volume %s/%s modifies the mode of the source volume but does not have permission to do so. "+
+				return nil, nil, fmt.Errorf("requested volume %s/%s modifies the mode of the source volume but does not have permission to do so. "+
 					"failed to convert %s annotation value to boolean with error: %v", claim.Namespace, claim.Name, annAllowVolumeModeChange, err)
 			}
 			if !allowVolumeModeChangeBool {
-				return nil, fmt.Errorf("requested volume %s/%s modifies the mode of the source volume but does not have permission to do so. "+
+				return nil, nil, fmt.Errorf("requested volume %s/%s modifies the mode of the source volume but does not have permission to do so. "+
 					"%s is set to false on snapshotcontent %s", claim.Namespace, claim.Name, annAllowVolumeModeChange, snapContentObj.Name)
 			}
 		}
@@ -1384,7 +1404,7 @@ func (p *csiProvisioner) getSnapshotSource(ctx context.Context, claim *v1.Persis
 		Type: &snapshotSource,
 	}
 
-	return volumeContentSource, nil
+	return volumeContentSource, snapContentObj.Spec.NodeAffinity, nil
 }
 
 func (p *csiProvisioner) Delete(ctx context.Context, volume *v1.PersistentVolume) error {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -695,12 +695,14 @@ func (p *csiProvisioner) prepareProvision(ctx context.Context, claim *v1.Persist
 		},
 	}
 
+	var snapshotNodeAffinity []v1.TopologySelectorTerm
 	if dataSource != nil && (rc.clone || rc.snapshot) {
-		volumeContentSource, err := p.getVolumeContentSource(ctx, claim, sc, dataSource)
+		volumeContentSource, nodeAffinity, err := p.getVolumeContentSource(ctx, claim, sc, dataSource)
 		if err != nil {
 			return nil, controller.ProvisioningNoChange, fmt.Errorf("error getting handle for DataSource Type %s by Name %s: %v", dataSource.Kind, dataSource.Name, err)
 		}
 		req.VolumeContentSource = volumeContentSource
+		snapshotNodeAffinity = nodeAffinity
 	}
 
 	if dataSource != nil && rc.clone {
@@ -718,12 +720,22 @@ func (p *csiProvisioner) prepareProvision(ctx context.Context, claim *v1.Persist
 	}
 
 	if p.supportsTopology() {
+		allowedTopologies := sc.AllowedTopologies
+		if utilfeature.DefaultFeatureGate.Enabled(features.VolumeSnapshotTopology) &&
+			rc.snapshot && selectedNodeName == "" && len(snapshotNodeAffinity) > 0 {
+			allowedTopologies = intersectSnapshotTopology(sc.AllowedTopologies, snapshotNodeAffinity)
+			if len(allowedTopologies) == 0 {
+				return nil, controller.ProvisioningFinished, fmt.Errorf("no compatible topology: snapshot %s NodeAffinity does not intersect StorageClass %s AllowedTopologies, so the volume cannot be provisioned where the snapshot is accessible", dataSource.Name, sc.Name)
+			}
+			klog.V(2).Infof("prepareProvision: constrained snapshot-sourced PVC %s to %d topology terms from the intersection of snapshot NodeAffinity and StorageClass.AllowedTopologies", claim.Name, len(allowedTopologies))
+		}
+
 		requirements, err := GenerateAccessibilityRequirements(
 			p.client,
 			p.driverName,
 			claim.UID,
 			claim.Name,
-			sc.AllowedTopologies,
+			allowedTopologies,
 			selectedNodeName,
 			p.strictTopology,
 			p.immediateTopology,
@@ -1181,15 +1193,18 @@ func removePrefixedParameters(param map[string]string) (map[string]string, error
 // currently we provide Snapshot and PVC, the default case allows the provisioner to still create a volume
 // so that an external controller can act upon it.   Additional DataSource types can be added here with
 // an appropriate implementation function
-func (p *csiProvisioner) getVolumeContentSource(ctx context.Context, claim *v1.PersistentVolumeClaim, sc *storagev1.StorageClass, dataSource *v1.ObjectReference) (*csi.VolumeContentSource, error) {
+// getVolumeContentSource returns the CSI VolumeContentSource and, for snapshot
+// sources, the bound VolumeSnapshotContent's Spec.NodeAffinity (nil otherwise).
+func (p *csiProvisioner) getVolumeContentSource(ctx context.Context, claim *v1.PersistentVolumeClaim, sc *storagev1.StorageClass, dataSource *v1.ObjectReference) (*csi.VolumeContentSource, []v1.TopologySelectorTerm, error) {
 	switch dataSource.Kind {
 	case snapshotKind:
 		return p.getSnapshotSource(ctx, claim, sc, dataSource)
 	case pvcKind:
-		return p.getPVCSource(ctx, claim, sc, dataSource)
+		src, err := p.getPVCSource(ctx, claim, sc, dataSource)
+		return src, nil, err
 	default:
 		// For now we shouldn't pass other things to this function, but treat it as a noop and extend as needed
-		return nil, nil
+		return nil, nil, nil
 	}
 }
 
@@ -1285,11 +1300,13 @@ func (p *csiProvisioner) getPVCSource(ctx context.Context, claim *v1.PersistentV
 }
 
 // getSnapshotSource verifies DataSource.Kind of type VolumeSnapshot, making sure that the requested Snapshot is available/ready
-// returns the VolumeContentSource for the requested snapshot
-func (p *csiProvisioner) getSnapshotSource(ctx context.Context, claim *v1.PersistentVolumeClaim, sc *storagev1.StorageClass, dataSource *v1.ObjectReference) (*csi.VolumeContentSource, error) {
+// returns the VolumeContentSource for the requested snapshot, along with the
+// bound VolumeSnapshotContent's Spec.NodeAffinity so callers don't
+// need to re-fetch the snapshot and its content.
+func (p *csiProvisioner) getSnapshotSource(ctx context.Context, claim *v1.PersistentVolumeClaim, sc *storagev1.StorageClass, dataSource *v1.ObjectReference) (*csi.VolumeContentSource, []v1.TopologySelectorTerm, error) {
 	snapshotObj, err := p.snapshotClient.SnapshotV1().VolumeSnapshots(dataSource.Namespace).Get(ctx, dataSource.Name, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error getting snapshot %s from api server: %v", dataSource.Name, err)
+		return nil, nil, fmt.Errorf("error getting snapshot %s from api server: %v", dataSource.Name, err)
 	}
 
 	if snapshotObj.ObjectMeta.DeletionTimestamp != nil {
@@ -1299,40 +1316,40 @@ func (p *csiProvisioner) getSnapshotSource(ctx context.Context, claim *v1.Persis
 		// so we should continue to prevent resource leaks.
 		// If the finalizer doesn't exist, this is a new provisioning attempt and should be rejected.
 		if !checkFinalizer(snapshotObj, snapshotSourceProtectionFinalizer) {
-			return nil, fmt.Errorf("snapshot %s is being deleted", dataSource.Name)
+			return nil, nil, fmt.Errorf("snapshot %s is being deleted", dataSource.Name)
 		}
 		klog.V(3).Infof("Snapshot %s/%s is being deleted but has volumesnapshot-as-source-protection finalizer, allowing provisioning to continue", dataSource.Namespace, dataSource.Name)
 	}
 	klog.V(5).Infof("VolumeSnapshot %+v", snapshotObj)
 
 	if snapshotObj.Status == nil || snapshotObj.Status.BoundVolumeSnapshotContentName == nil {
-		return nil, fmt.Errorf(snapshotNotBound, dataSource.Name)
+		return nil, nil, fmt.Errorf(snapshotNotBound, dataSource.Name)
 	}
 
 	snapContentObj, err := p.snapshotClient.SnapshotV1().VolumeSnapshotContents().Get(ctx, *snapshotObj.Status.BoundVolumeSnapshotContentName, metav1.GetOptions{})
 	if err != nil {
 		klog.Warningf("error getting snapshotcontent %s for snapshot %s/%s from api server: %s", *snapshotObj.Status.BoundVolumeSnapshotContentName, snapshotObj.Namespace, snapshotObj.Name, err)
-		return nil, fmt.Errorf(errorGettingSnapshotContent, *snapshotObj.Status.BoundVolumeSnapshotContentName, dataSource.Name)
+		return nil, nil, fmt.Errorf(errorGettingSnapshotContent, *snapshotObj.Status.BoundVolumeSnapshotContentName, dataSource.Name)
 	}
 
 	if snapContentObj.Spec.VolumeSnapshotRef.UID != snapshotObj.UID || snapContentObj.Spec.VolumeSnapshotRef.Namespace != snapshotObj.Namespace || snapContentObj.Spec.VolumeSnapshotRef.Name != snapshotObj.Name {
 		klog.Warningf("snapshotcontent %s for snapshot %s/%s is bound to a different snapshot", *snapshotObj.Status.BoundVolumeSnapshotContentName, snapshotObj.Namespace, snapshotObj.Name)
-		return nil, fmt.Errorf(snapshotContentNotBoundToSnapshot, *snapshotObj.Status.BoundVolumeSnapshotContentName, dataSource.Name)
+		return nil, nil, fmt.Errorf(snapshotContentNotBoundToSnapshot, *snapshotObj.Status.BoundVolumeSnapshotContentName, dataSource.Name)
 	}
 
 	if snapContentObj.Spec.Driver != sc.Provisioner {
 		klog.Warningf("snapshotcontent %s for snapshot %s/%s is handled by a different CSI driver than requested by StorageClass %s", *snapshotObj.Status.BoundVolumeSnapshotContentName, snapshotObj.Namespace, snapshotObj.Name, sc.Name)
-		return nil, fmt.Errorf(snapshotDifferentDriver, *snapshotObj.Status.BoundVolumeSnapshotContentName, dataSource.Name, sc.Name)
+		return nil, nil, fmt.Errorf(snapshotDifferentDriver, *snapshotObj.Status.BoundVolumeSnapshotContentName, dataSource.Name, sc.Name)
 	}
 
 	if snapshotObj.Status.ReadyToUse == nil || !*snapshotObj.Status.ReadyToUse {
-		return nil, fmt.Errorf("snapshot %s is not Ready", dataSource.Name)
+		return nil, nil, fmt.Errorf("snapshot %s is not Ready", dataSource.Name)
 	}
 
 	klog.V(5).Infof("VolumeSnapshotContent %+v", snapContentObj)
 
 	if snapContentObj.Status == nil || snapContentObj.Status.SnapshotHandle == nil {
-		return nil, fmt.Errorf("snapshot handle %s is not available", dataSource.Name)
+		return nil, nil, fmt.Errorf("snapshot handle %s is not available", dataSource.Name)
 	}
 
 	snapshotSource := csi.VolumeContentSource_Snapshot{
@@ -1345,14 +1362,14 @@ func (p *csiProvisioner) getSnapshotSource(ctx context.Context, claim *v1.Persis
 	if snapshotObj.Status.RestoreSize != nil {
 		capacity, exists := claim.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 		if !exists {
-			return nil, fmt.Errorf("error getting capacity for PVC %s when creating snapshot %s", claim.Name, snapshotObj.Name)
+			return nil, nil, fmt.Errorf("error getting capacity for PVC %s when creating snapshot %s", claim.Name, snapshotObj.Name)
 		}
 		volSizeBytes := capacity.Value()
 		klog.V(5).Infof("Requested volume size is %d and snapshot size is %d for the source snapshot %s", int64(volSizeBytes), int64(snapshotObj.Status.RestoreSize.Value()), snapshotObj.Name)
 		// When restoring volume from a snapshot, the volume size should
 		// be equal to or larger than its snapshot size.
 		if int64(volSizeBytes) < int64(snapshotObj.Status.RestoreSize.Value()) {
-			return nil, fmt.Errorf("requested volume size %d is less than the size %d for the source snapshot %s", int64(volSizeBytes), int64(snapshotObj.Status.RestoreSize.Value()), snapshotObj.Name)
+			return nil, nil, fmt.Errorf("requested volume size %d is less than the size %d for the source snapshot %s", int64(volSizeBytes), int64(snapshotObj.Status.RestoreSize.Value()), snapshotObj.Name)
 		}
 		if int64(volSizeBytes) > int64(snapshotObj.Status.RestoreSize.Value()) {
 			klog.Warningf("requested volume size %d is greater than the size %d for the source snapshot %s. Volume plugin needs to handle volume expansion.", int64(volSizeBytes), int64(snapshotObj.Status.RestoreSize.Value()), snapshotObj.Name)
@@ -1365,16 +1382,16 @@ func (p *csiProvisioner) getSnapshotSource(ctx context.Context, claim *v1.Persis
 			// Verify if this volume is allowed to alter its mode.
 			allowVolumeModeChange, ok := snapContentObj.Annotations[annAllowVolumeModeChange]
 			if !ok {
-				return nil, fmt.Errorf("requested volume %s/%s modifies the mode of the source volume but does not have permission to do so. "+
+				return nil, nil, fmt.Errorf("requested volume %s/%s modifies the mode of the source volume but does not have permission to do so. "+
 					"%s annotation is not present on snapshotcontent %s", claim.Namespace, claim.Name, annAllowVolumeModeChange, snapContentObj.Name)
 			}
 			allowVolumeModeChangeBool, err := strconv.ParseBool(allowVolumeModeChange)
 			if err != nil {
-				return nil, fmt.Errorf("requested volume %s/%s modifies the mode of the source volume but does not have permission to do so. "+
+				return nil, nil, fmt.Errorf("requested volume %s/%s modifies the mode of the source volume but does not have permission to do so. "+
 					"failed to convert %s annotation value to boolean with error: %v", claim.Namespace, claim.Name, annAllowVolumeModeChange, err)
 			}
 			if !allowVolumeModeChangeBool {
-				return nil, fmt.Errorf("requested volume %s/%s modifies the mode of the source volume but does not have permission to do so. "+
+				return nil, nil, fmt.Errorf("requested volume %s/%s modifies the mode of the source volume but does not have permission to do so. "+
 					"%s is set to false on snapshotcontent %s", claim.Namespace, claim.Name, annAllowVolumeModeChange, snapContentObj.Name)
 			}
 		}
@@ -1384,7 +1401,7 @@ func (p *csiProvisioner) getSnapshotSource(ctx context.Context, claim *v1.Persis
 		Type: &snapshotSource,
 	}
 
-	return volumeContentSource, nil
+	return volumeContentSource, snapContentObj.Spec.NodeAffinity, nil
 }
 
 func (p *csiProvisioner) Delete(ctx context.Context, volume *v1.PersistentVolume) error {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -4809,6 +4809,177 @@ func TestProvisionFromSnapshot(t *testing.T) {
 	}
 }
 
+// TestProvisionFromSnapshotWithTopology covers the VolumeSnapshotTopology
+// feature-gated path in prepareProvision: for Immediate binding (empty
+// selectedNodeName), the snapshot's VolumeSnapshotContent.Spec.NodeAffinity is
+// intersected with StorageClass.AllowedTopologies and used as the CreateVolume
+// AccessibilityRequirements, failing fast when the intersection is empty.
+func TestProvisionFromSnapshotWithTopology(t *testing.T) {
+	apiGrp := "snapshot.storage.k8s.io"
+	var requestedBytes int64 = 1000
+	snapName := "test-snapshot"
+	snapClassName := "test-snapclass"
+	timeNow := time.Now().UnixNano()
+	metaTimeNowUnix := &metav1.Time{Time: time.Unix(0, timeNow)}
+	deletePolicy := v1.PersistentVolumeReclaimDelete
+
+	zoneKey := "topology.kubernetes.io/zone"
+	// snapshot is usable from 2a and 2b.
+	snapshotNodeAffinity := []v1.TopologySelectorTerm{{
+		MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+			{Key: zoneKey, Values: []string{"us-east-1a", "us-east-1b"}},
+		},
+	}}
+
+	newSnapshotSC := func(allowed []v1.TopologySelectorTerm) *storagev1.StorageClass {
+		return &storagev1.StorageClass{
+			ReclaimPolicy:     &deletePolicy,
+			Parameters:        map[string]string{},
+			Provisioner:       "test-driver",
+			AllowedTopologies: allowed,
+		}
+	}
+	newSnapshotPVC := func() *v1.PersistentVolumeClaim {
+		return &v1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{UID: "testid", Annotations: driverNameAnnotation},
+			Spec: v1.PersistentVolumeClaimSpec{
+				StorageClassName: &snapClassName,
+				Resources: v1.VolumeResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceName(v1.ResourceStorage): resource.MustParse(strconv.FormatInt(requestedBytes, 10)),
+					},
+				},
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				DataSource: &v1.TypedLocalObjectReference{
+					Name:     snapName,
+					Kind:     "VolumeSnapshot",
+					APIGroup: &apiGrp,
+				},
+			},
+		}
+	}
+
+	type testcase struct {
+		gateEnabled       bool
+		scAllowed         []v1.TopologySelectorTerm
+		expectErr         bool
+		expectCSICall     bool
+		expectedRequisite []*csi.Topology // AccessibilityRequirements.Requisite expected on CreateVolume
+	}
+	testcases := map[string]testcase{
+		"gate on, overlapping topologies constrains CreateVolume to the intersection": {
+			gateEnabled: true,
+			scAllowed: []v1.TopologySelectorTerm{{
+				MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+					{Key: zoneKey, Values: []string{"us-east-1a"}},
+				},
+			}},
+			expectCSICall:     true,
+			expectedRequisite: []*csi.Topology{{Segments: map[string]string{zoneKey: "us-east-1a"}}},
+		},
+		"gate on, disjoint topologies fails fast without CreateVolume": {
+			gateEnabled: true,
+			scAllowed: []v1.TopologySelectorTerm{{
+				MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+					{Key: zoneKey, Values: []string{"us-east-1c"}},
+				},
+			}},
+			expectErr:     true,
+			expectCSICall: false,
+		},
+		"gate off, snapshot NodeAffinity is ignored": {
+			gateEnabled: false,
+			scAllowed: []v1.TopologySelectorTerm{{
+				MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+					{Key: zoneKey, Values: []string{"us-east-1c"}},
+				},
+			}},
+			expectCSICall: true,
+		},
+	}
+
+	tmpdir := tempDir(t)
+	defer os.RemoveAll(tmpdir)
+	mockController, driver, _, controllerServer, csiConn, err := createMockServer(t, tmpdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mockController.Finish()
+	defer driver.Stop()
+
+	doit := func(t *testing.T, tc testcase) {
+		utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.VolumeSnapshotTopology, tc.gateEnabled)
+
+		var clientSet kubernetes.Interface = fakeclientset.NewSimpleClientset()
+		client := &fake.Clientset{}
+
+		client.AddReactor("get", "volumesnapshots", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			snap := newSnapshot(snapName, "default", snapClassName, "snapcontent-snapuid", "snapuid", "claim", true, nil, metaTimeNowUnix, resource.NewQuantity(requestedBytes, resource.BinarySI))
+			return true, snap, nil
+		})
+		client.AddReactor("update", "volumesnapshots", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			return true, action.(k8stesting.UpdateAction).GetObject(), nil
+		})
+		client.AddReactor("get", "volumesnapshotcontents", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+			content := newContent("snapcontent-snapuid", "default", snapClassName, "sid", "snapuid", snapName, &requestedBytes, &timeNow)
+			content.Spec.NodeAffinity = snapshotNodeAffinity
+			return true, content, nil
+		})
+
+		// Topology-capable caps so p.supportsTopology() is true (required to
+		// reach the intersection path).
+		pluginCaps, controllerCaps := provisionWithTopologyCapabilities()
+		controllerCaps[csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT] = true
+		pvcNodeStore := NewInMemoryStore()
+		csiProvisioner := NewCSIProvisioner(clientSet, 5*time.Second, "test-provisioner", "test", 5, csiConn.conn,
+			client, driverName, pluginCaps, controllerCaps, "", false, true, csitrans.New(), nil, nil, nil, nil, nil, nil, false, defaultfsType, nil, true, true, pvcNodeStore)
+
+		out := &csi.CreateVolumeResponse{
+			Volume: &csi.Volume{
+				CapacityBytes: requestedBytes,
+				VolumeId:      "test-volume-id",
+				ContentSource: &csi.VolumeContentSource{
+					Type: &csi.VolumeContentSource_Snapshot{
+						Snapshot: &csi.VolumeContentSource_SnapshotSource{SnapshotId: "sid"},
+					},
+				},
+			},
+		}
+		if tc.expectCSICall {
+			controllerServer.EXPECT().CreateVolume(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
+					if tc.expectedRequisite != nil {
+						if req.GetAccessibilityRequirements() == nil {
+							t.Errorf("expected AccessibilityRequirements to be set")
+						} else if !reflect.DeepEqual(req.GetAccessibilityRequirements().GetRequisite(), tc.expectedRequisite) {
+							t.Errorf("expected Requisite %v, got %v", tc.expectedRequisite, req.GetAccessibilityRequirements().GetRequisite())
+						}
+					}
+					return out, nil
+				}).Times(1)
+		}
+
+		opts := controller.ProvisionOptions{
+			StorageClass: newSnapshotSC(tc.scAllowed),
+			PVName:       "test-name",
+			PVC:          newSnapshotPVC(),
+		}
+		_, _, err := csiProvisioner.Provision(context.Background(), opts)
+		if tc.expectErr && err == nil {
+			t.Errorf("expected error, got none")
+		}
+		if !tc.expectErr && err != nil {
+			t.Errorf("got unexpected error: %v", err)
+		}
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			doit(t, tc)
+		})
+	}
+}
+
 // TestProvisionWithTopology is a basic test of provisioner integration with topology functions.
 func TestProvisionWithTopologyEnabled(t *testing.T) {
 	utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.Topology, true)

--- a/pkg/controller/snapshot_topology_test.go
+++ b/pkg/controller/snapshot_topology_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	snapRegionKey = "topology.kubernetes.io/region"
+	snapZoneKey   = "topology.kubernetes.io/zone"
+)
+
+func zoneTerm(values ...string) v1.TopologySelectorTerm {
+	return v1.TopologySelectorTerm{
+		MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+			{Key: snapZoneKey, Values: values},
+		},
+	}
+}
+
+// TestIntersectSnapshotTopology covers the Immediate-binding intersection of
+// StorageClass.AllowedTopologies with a snapshot's NodeAffinity (KEP-5943).
+func TestIntersectSnapshotTopology(t *testing.T) {
+	testcases := map[string]struct {
+		scTopology   []v1.TopologySelectorTerm
+		snapTopology []v1.TopologySelectorTerm
+		expected     []*csi.Topology
+	}{
+		"no snapshot topology falls back to StorageClass terms": {
+			scTopology:   []v1.TopologySelectorTerm{zoneTerm("us-west-2a", "us-west-2b")},
+			snapTopology: nil,
+			expected: []*csi.Topology{
+				{Segments: map[string]string{snapZoneKey: "us-west-2a"}},
+				{Segments: map[string]string{snapZoneKey: "us-west-2b"}},
+			},
+		},
+		"no StorageClass topology falls back to snapshot terms": {
+			scTopology:   nil,
+			snapTopology: []v1.TopologySelectorTerm{zoneTerm("us-west-2c")},
+			expected: []*csi.Topology{
+				{Segments: map[string]string{snapZoneKey: "us-west-2c"}},
+			},
+		},
+		"overlapping zones intersect to the common subset": {
+			scTopology:   []v1.TopologySelectorTerm{zoneTerm("us-west-2a", "us-west-2b")},
+			snapTopology: []v1.TopologySelectorTerm{zoneTerm("us-west-2b", "us-west-2c")},
+			expected: []*csi.Topology{
+				{Segments: map[string]string{snapZoneKey: "us-west-2b"}},
+			},
+		},
+		"identical single zone": {
+			scTopology:   []v1.TopologySelectorTerm{zoneTerm("us-west-2a")},
+			snapTopology: []v1.TopologySelectorTerm{zoneTerm("us-west-2a")},
+			expected: []*csi.Topology{
+				{Segments: map[string]string{snapZoneKey: "us-west-2a"}},
+			},
+		},
+		"disjoint zones yield empty intersection": {
+			scTopology:   []v1.TopologySelectorTerm{zoneTerm("us-west-2d")},
+			snapTopology: []v1.TopologySelectorTerm{zoneTerm("us-west-2a", "us-west-2b", "us-west-2c")},
+			expected:     []*csi.Topology{},
+		},
+		"snapshot zone within StorageClass region keeps the more specific snapshot term": {
+			scTopology: []v1.TopologySelectorTerm{{
+				MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+					{Key: snapRegionKey, Values: []string{"us-west-2"}},
+				},
+			}},
+			snapTopology: []v1.TopologySelectorTerm{{
+				MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+					{Key: snapRegionKey, Values: []string{"us-west-2"}},
+					{Key: snapZoneKey, Values: []string{"us-west-2a"}},
+				},
+			}},
+			expected: []*csi.Topology{
+				{Segments: map[string]string{snapRegionKey: "us-west-2", snapZoneKey: "us-west-2a"}},
+			},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			got := intersectSnapshotTopology(tc.scTopology, tc.snapTopology)
+			if !cmp.Equal(got, tc.expected, protocmp.Transform()) {
+				t.Errorf("intersectSnapshotTopology() mismatch (-got +want):\n%s",
+					cmp.Diff(got, tc.expected, protocmp.Transform()))
+			}
+		})
+	}
+}
+
+// TestIntersectSnapshotTopologyEmptyIsFatalSignal documents that an empty (but
+// non-nil) result is the signal callers use to fail provisioning fast when the
+// snapshot and StorageClass topologies are incompatible.
+func TestIntersectSnapshotTopologyEmptyIsFatalSignal(t *testing.T) {
+	got := intersectSnapshotTopology(
+		[]v1.TopologySelectorTerm{zoneTerm("us-west-2d")},
+		[]v1.TopologySelectorTerm{zoneTerm("us-west-2a")},
+	)
+	if len(got) != 0 {
+		t.Fatalf("expected empty intersection for disjoint topologies, got %v", got)
+	}
+}

--- a/pkg/controller/snapshot_topology_test.go
+++ b/pkg/controller/snapshot_topology_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	snapRegionKey = "topology.kubernetes.io/region"
+	snapZoneKey   = "topology.kubernetes.io/zone"
+)
+
+func zoneTerm(values ...string) v1.TopologySelectorTerm {
+	return v1.TopologySelectorTerm{
+		MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+			{Key: snapZoneKey, Values: values},
+		},
+	}
+}
+
+// singleZoneTerm builds a term with one single-value zone expression, matching
+// the flattened shape intersectSnapshotTopology returns.
+func singleZoneTerm(value string) v1.TopologySelectorTerm {
+	return zoneTerm(value)
+}
+
+// TestIntersectSnapshotTopology covers the Immediate-binding intersection of
+// StorageClass.AllowedTopologies with a snapshot's NodeAffinity (KEP-5943).
+// The result is a flattened []v1.TopologySelectorTerm (one single-value
+// expression per key) suitable to pass to GenerateAccessibilityRequirements.
+func TestIntersectSnapshotTopology(t *testing.T) {
+	testcases := map[string]struct {
+		scTopology   []v1.TopologySelectorTerm
+		snapTopology []v1.TopologySelectorTerm
+		expected     []v1.TopologySelectorTerm
+	}{
+		"no snapshot topology falls back to StorageClass terms": {
+			scTopology:   []v1.TopologySelectorTerm{zoneTerm("us-west-2a", "us-west-2b")},
+			snapTopology: nil,
+			expected: []v1.TopologySelectorTerm{
+				singleZoneTerm("us-west-2a"),
+				singleZoneTerm("us-west-2b"),
+			},
+		},
+		"no StorageClass topology falls back to snapshot terms": {
+			scTopology:   nil,
+			snapTopology: []v1.TopologySelectorTerm{zoneTerm("us-west-2c")},
+			expected: []v1.TopologySelectorTerm{
+				singleZoneTerm("us-west-2c"),
+			},
+		},
+		"overlapping zones intersect to the common subset": {
+			scTopology:   []v1.TopologySelectorTerm{zoneTerm("us-west-2a", "us-west-2b")},
+			snapTopology: []v1.TopologySelectorTerm{zoneTerm("us-west-2b", "us-west-2c")},
+			expected: []v1.TopologySelectorTerm{
+				singleZoneTerm("us-west-2b"),
+			},
+		},
+		"identical single zone": {
+			scTopology:   []v1.TopologySelectorTerm{zoneTerm("us-west-2a")},
+			snapTopology: []v1.TopologySelectorTerm{zoneTerm("us-west-2a")},
+			expected: []v1.TopologySelectorTerm{
+				singleZoneTerm("us-west-2a"),
+			},
+		},
+		"disjoint zones yield empty intersection": {
+			scTopology:   []v1.TopologySelectorTerm{zoneTerm("us-west-2d")},
+			snapTopology: []v1.TopologySelectorTerm{zoneTerm("us-west-2a", "us-west-2b", "us-west-2c")},
+			expected:     nil,
+		},
+		"snapshot zone within StorageClass region keeps the more specific snapshot term": {
+			scTopology: []v1.TopologySelectorTerm{{
+				MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+					{Key: snapRegionKey, Values: []string{"us-west-2"}},
+				},
+			}},
+			snapTopology: []v1.TopologySelectorTerm{{
+				MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+					{Key: snapRegionKey, Values: []string{"us-west-2"}},
+					{Key: snapZoneKey, Values: []string{"us-west-2a"}},
+				},
+			}},
+			// Segments are sorted by key within a flattened term: region, then zone.
+			expected: []v1.TopologySelectorTerm{{
+				MatchLabelExpressions: []v1.TopologySelectorLabelRequirement{
+					{Key: snapRegionKey, Values: []string{"us-west-2"}},
+					{Key: snapZoneKey, Values: []string{"us-west-2a"}},
+				},
+			}},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			got := intersectSnapshotTopology(tc.scTopology, tc.snapTopology)
+			if !cmp.Equal(got, tc.expected) {
+				t.Errorf("intersectSnapshotTopology() mismatch (-got +want):\n%s",
+					cmp.Diff(got, tc.expected))
+			}
+		})
+	}
+}
+
+// TestIntersectSnapshotTopologyEmptyIsFatalSignal documents that an empty (but
+// non-nil) result is the signal callers use to fail provisioning fast when the
+// snapshot and StorageClass topologies are incompatible.
+func TestIntersectSnapshotTopologyEmptyIsFatalSignal(t *testing.T) {
+	got := intersectSnapshotTopology(
+		[]v1.TopologySelectorTerm{zoneTerm("us-west-2d")},
+		[]v1.TopologySelectorTerm{zoneTerm("us-west-2a")},
+	)
+	if len(got) != 0 {
+		t.Fatalf("expected empty intersection for disjoint topologies, got %v", got)
+	}
+}

--- a/pkg/controller/topology.go
+++ b/pkg/controller/topology.go
@@ -692,6 +692,61 @@ func toCSITopology(terms []topologyTerm) []*csi.Topology {
 	return out
 }
 
+// intersectSnapshotTopology computes the intersection of the StorageClass's
+// AllowedTopologies and a snapshot's NodeAffinity (both expressed as
+// []v1.TopologySelectorTerm), returning the result as CSI Topology terms
+// suitable for CreateVolumeRequest.AccessibilityRequirements.Preferred /
+// Requisite.
+//
+// Used for Immediate volume binding where there is no
+// scheduler step to reconcile the snapshot's topology with
+// the StorageClass.
+//
+// Semantics:
+//   - Each input is an OR of terms; within a term, label expressions are ANDed
+//     and a label expression's values are ORed. We flatten both inputs to the
+//     same disjunctive-normal-form (a list of fully-specified topologyTerms),
+//     then keep the flattened StorageClass terms that are a superset of (i.e.
+//     satisfy) at least one flattened snapshot term.
+//   - If the snapshot has no NodeAffinity, the StorageClass terms are returned
+//     unchanged (no additional constraint from the snapshot).
+//   - If the StorageClass has no AllowedTopologies, the snapshot terms are
+//     returned (the snapshot is the only constraint).
+//   - A nil, empty result means the two constraints are incompatible; callers
+//     should treat this as a fatal provisioning error.
+func intersectSnapshotTopology(scTopology, snapTopology []v1.TopologySelectorTerm) []*csi.Topology {
+	scTerms := flatten(scTopology)
+	snapTerms := flatten(snapTopology)
+
+	if len(snapTerms) == 0 {
+		return toCSITopology(scTerms)
+	}
+	if len(scTerms) == 0 {
+		return toCSITopology(snapTerms)
+	}
+
+	var intersected []topologyTerm
+	for _, snapTerm := range snapTerms {
+		for _, scTerm := range scTerms {
+			// snapTerm.subset(scTerm) is true when every segment in the
+			// snapshot term is present in the StorageClass term, i.e. the
+			// StorageClass term provisions into a topology the snapshot is
+			// accessible from. Keep the more-specific StorageClass term.
+			if snapTerm.subset(scTerm) {
+				intersected = append(intersected, scTerm)
+			} else if scTerm.subset(snapTerm) {
+				// The snapshot term is more specific (e.g. SC allows a whole
+				// region, snapshot pins a zone within it). Keep the snapshot term.
+				intersected = append(intersected, snapTerm)
+			}
+		}
+	}
+
+	slices.SortFunc(intersected, topologyTerm.compare)
+	intersected = slices.CompactFunc(intersected, slices.Equal)
+	return toCSITopology(intersected)
+}
+
 // identical to logic in getPVCNameHashAndIndexOffset in pkg/volume/util/util.go in-tree
 // [https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/util/util.go]
 func getPVCNameHashAndIndexOffset(pvcName string) (hash uint32, index uint32) {

--- a/pkg/controller/topology.go
+++ b/pkg/controller/topology.go
@@ -692,6 +692,88 @@ func toCSITopology(terms []topologyTerm) []*csi.Topology {
 	return out
 }
 
+// intersectSnapshotTopology computes the intersection of the StorageClass's
+// AllowedTopologies and a snapshot's NodeAffinity (both expressed as
+// []v1.TopologySelectorTerm) and returns it as []v1.TopologySelectorTerm.
+//
+// The result is passed as the allowedTopologies argument to
+// GenerateAccessibilityRequirements for Immediate volume binding, so that the
+// snapshot's accessible topology is reconciled with the cluster the same way an
+// explicit StorageClass.AllowedTopologies would be (aggregation, preferred
+// ordering, etc.) rather than bypassing that logic.
+//
+// Semantics:
+//   - Each input is an OR of terms; within a term, label expressions are ANDed
+//     and a label expression's values are ORed. We flatten both inputs to the
+//     same disjunctive-normal-form (a list of fully-specified topologyTerms),
+//     then for each (StorageClass, snapshot) term pair where one is a subset of
+//     the other, keep the more-specific term: the StorageClass term when the
+//     snapshot term is a subset of it, or the snapshot term when it is a subset
+//     of the StorageClass term (e.g. the StorageClass allows a whole region and
+//     the snapshot pins a zone within it). Terms are compared by exact
+//     (key, value) segments; a pair where neither is a subset of the other
+//     (including disjoint topology keys) contributes nothing, matching how the
+//     regular volume path treats topology segments as opaque per-driver keys.
+//   - If the snapshot has no NodeAffinity, the StorageClass terms are returned
+//     unchanged (no additional constraint from the snapshot).
+//   - If the StorageClass has no AllowedTopologies, the snapshot terms are
+//     returned (the snapshot is the only constraint).
+//   - An empty result means the two constraints are incompatible; callers
+//     should treat this as a fatal provisioning error.
+func intersectSnapshotTopology(scTopology, snapTopology []v1.TopologySelectorTerm) []v1.TopologySelectorTerm {
+	scTerms := flatten(scTopology)
+	snapTerms := flatten(snapTopology)
+
+	if len(snapTerms) == 0 {
+		return topologyTermsToSelectorTerms(scTerms)
+	}
+	if len(scTerms) == 0 {
+		return topologyTermsToSelectorTerms(snapTerms)
+	}
+
+	var intersected []topologyTerm
+	for _, snapTerm := range snapTerms {
+		for _, scTerm := range scTerms {
+			// snapTerm.subset(scTerm) is true when every segment in the
+			// snapshot term is present in the StorageClass term, i.e. the
+			// StorageClass term provisions into a topology the snapshot is
+			// accessible from. Keep the more-specific StorageClass term.
+			if snapTerm.subset(scTerm) {
+				intersected = append(intersected, scTerm)
+			} else if scTerm.subset(snapTerm) {
+				// The snapshot term is more specific (e.g. SC allows a whole
+				// region, snapshot pins a zone within it). Keep the snapshot term.
+				intersected = append(intersected, snapTerm)
+			}
+		}
+	}
+
+	slices.SortFunc(intersected, topologyTerm.compare)
+	intersected = slices.CompactFunc(intersected, slices.Equal)
+	return topologyTermsToSelectorTerms(intersected)
+}
+
+// topologyTermsToSelectorTerms converts flattened topologyTerms back into
+// []v1.TopologySelectorTerm: each topologyTerm becomes one term with one
+// single-value MatchLabelExpression per segment.
+func topologyTermsToSelectorTerms(terms []topologyTerm) []v1.TopologySelectorTerm {
+	if len(terms) == 0 {
+		return nil
+	}
+	out := make([]v1.TopologySelectorTerm, 0, len(terms))
+	for _, t := range terms {
+		exprs := make([]v1.TopologySelectorLabelRequirement, 0, len(t))
+		for _, seg := range t {
+			exprs = append(exprs, v1.TopologySelectorLabelRequirement{
+				Key:    seg.Key,
+				Values: []string{seg.Value},
+			})
+		}
+		out = append(out, v1.TopologySelectorTerm{MatchLabelExpressions: exprs})
+	}
+	return out
+}
+
 // identical to logic in getPVCNameHashAndIndexOffset in pkg/volume/util/util.go in-tree
 // [https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/util/util.go]
 func getPVCNameHashAndIndexOffset(pvcName string) (hash uint32, index uint32) {

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -51,6 +51,16 @@ const (
 	//
 	// Releases leader election lease on sigterm / sigint.
 	ReleaseLeaderElectionOnExit featuregate.Feature = "ReleaseLeaderElectionOnExit"
+
+	// owner: @mdzraf
+	// alpha: v1.37
+	//
+	// For PVCs that reference a VolumeSnapshot data source with Immediate
+	// volume binding, intersects the snapshot's NodeAffinity (from
+	// VolumeSnapshotContent.Spec) with StorageClass.AllowedTopologies when
+	// building CreateVolume AccessibilityRequirements, so the volume is
+	// provisioned in a topology where the snapshot is accessible.
+	VolumeSnapshotTopology featuregate.Feature = "VolumeSnapshotTopology"
 )
 
 func init() {
@@ -64,6 +74,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	CrossNamespaceVolumeDataSource: {Default: false, PreRelease: featuregate.Alpha},
 	VolumeAttributesClass:          {Default: true, PreRelease: featuregate.GA},
 	ReleaseLeaderElectionOnExit:    {Default: false, PreRelease: featuregate.Alpha},
+	VolumeSnapshotTopology:         {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // IsVolumeAttributesClassV1Enabled checks if the VolumeAttributesClass v1 API is enabled.

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1/types.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1/types.go
@@ -232,6 +232,18 @@ type VolumeSnapshotClass struct {
 	// "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted.
 	// Required.
 	DeletionPolicy DeletionPolicy `json:"deletionPolicy" protobuf:"bytes,4,opt,name=deletionPolicy"`
+
+	// allowedTopologies restricts the node topologies where snapshots created
+	// using this class are usable from. A snapshot is usable from a location
+	// if volumes created from that snapshot are guaranteed to be accessible
+	// from that location. Each volume plugin defines its own supported
+	// topology specifications. An empty list means there is no topology
+	// restriction. This is passed to the CSI driver as
+	// AccessibilityRequirements in the CreateSnapshotRequest.
+	// This is an alpha field tied to the VolumeSnapshotTopology feature gate
+	// (KEP-5943).
+	// +optional
+	AllowedTopologies []core_v1.TopologySelectorTerm `json:"allowedTopologies,omitempty" protobuf:"bytes,5,rep,name=allowedTopologies"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -351,6 +363,22 @@ type VolumeSnapshotContentSpec struct {
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="sourceVolumeMode is immutable"
 	SourceVolumeMode *core_v1.PersistentVolumeMode `json:"sourceVolumeMode" protobuf:"bytes,6,opt,name=sourceVolumeMode"`
+
+	// nodeAffinity defines the node topologies from which a volume can
+	// be provisioned using this snapshot as a source. This is derived from the
+	// CSI driver's CreateSnapshotResponse. For WaitForFirstConsumer volume
+	// binding, the scheduler plugin compares these terms against node labels to
+	// filter candidate nodes. For Immediate volume binding, the external-provisioner
+	// intersects these terms with StorageClass.AllowedTopologies to select a
+	// compatible provisioning topology.
+	// This field is mutable to support topology changes during the snapshot
+	// lifecycle (e.g., snapshot replication to additional regions, admin
+	// corrections for statically provisioned snapshots). Changes only affect
+	// future scheduling and provisioning.
+	// This is an alpha field tied to the VolumeSnapshotTopology feature gate
+	// (KEP-5943).
+	// +optional
+	NodeAffinity []core_v1.TopologySelectorTerm `json:"nodeAffinity,omitempty" protobuf:"bytes,7,rep,name=nodeAffinity"`
 }
 
 // VolumeSnapshotContentSource represents the CSI source of a snapshot.

--- a/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1/zz_generated.deepcopy.go
@@ -70,6 +70,13 @@ func (in *VolumeSnapshotClass) DeepCopyInto(out *VolumeSnapshotClass) {
 			(*out)[key] = val
 		}
 	}
+	if in.AllowedTopologies != nil {
+		in, out := &in.AllowedTopologies, &out.AllowedTopologies
+		*out = make([]corev1.TopologySelectorTerm, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 
@@ -229,6 +236,13 @@ func (in *VolumeSnapshotContentSpec) DeepCopyInto(out *VolumeSnapshotContentSpec
 		in, out := &in.SourceVolumeMode, &out.SourceVolumeMode
 		*out = new(corev1.PersistentVolumeMode)
 		**out = **in
+	}
+	if in.NodeAffinity != nil {
+		in, out := &in.NodeAffinity, &out.NodeAffinity
+		*out = make([]corev1.TopologySelectorTerm, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	return
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -223,7 +223,7 @@ github.com/kubernetes-csi/csi-lib-utils/standardflags
 ## explicit; go 1.25.0
 github.com/kubernetes-csi/csi-test/v5/driver
 github.com/kubernetes-csi/csi-test/v5/utils
-# github.com/kubernetes-csi/external-snapshotter/client/v8 v8.6.0
+# github.com/kubernetes-csi/external-snapshotter/client/v8 v8.6.0 => github.com/mdzraf/external-snapshotter/client/v8 v8.4.1-0.20260730192112-9610545fc807
 ## explicit; go 1.26.0
 github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1
 github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1
@@ -1660,3 +1660,4 @@ sigs.k8s.io/yaml
 # k8s.io/cri-streaming => k8s.io/cri-streaming v0.36.1
 # k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.36.1
 # k8s.io/streaming => k8s.io/streaming v0.36.1
+# github.com/kubernetes-csi/external-snapshotter/client/v8 => github.com/mdzraf/external-snapshotter/client/v8 v8.4.1-0.20260730192112-9610545fc807

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -221,7 +221,7 @@ github.com/kubernetes-csi/csi-lib-utils/standardflags
 ## explicit; go 1.25.0
 github.com/kubernetes-csi/csi-test/v5/driver
 github.com/kubernetes-csi/csi-test/v5/utils
-# github.com/kubernetes-csi/external-snapshotter/client/v8 v8.6.0
+# github.com/kubernetes-csi/external-snapshotter/client/v8 v8.6.0 => github.com/mdzraf/external-snapshotter/client/v8 v8.4.1-0.20260730192112-9610545fc807
 ## explicit; go 1.26.0
 github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1
 github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1
@@ -1659,3 +1659,4 @@ sigs.k8s.io/yaml
 # k8s.io/cri-streaming => k8s.io/cri-streaming v0.36.1
 # k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.36.1
 # k8s.io/streaming => k8s.io/streaming v0.36.1
+# github.com/kubernetes-csi/external-snapshotter/client/v8 => github.com/mdzraf/external-snapshotter/client/v8 v8.4.1-0.20260730192112-9610545fc807


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR introduces the changes necessary in the provisioner to be able to check for Volume Snapshot Topology and see if there is any intersection between the snapshot's `NodeAffinity` and `StorageClass.AllowedTopologies`.  This functionality is gated behind the `VolumeSnapshotTopology` feature gate.

This is part of the implementation for https://github.com/kubernetes/enhancements/issues/5943

**Special notes for your reviewer**:

/hold 

As noted in the TODO comment, the current implementation references a custom fork of the external snapshotter and will be switched to the released version of it once [the PR to introduce topology for volume snapshots is merged](https://github.com/kubernetes-csi/external-snapshotter/pull/1463).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduce VolumeSnapshotTopology Feature Gate Along with Functionality to Check for Topology Intersection
```
